### PR TITLE
Add local provider for terraform

### DIFF
--- a/src/languageclient.ts
+++ b/src/languageclient.ts
@@ -216,6 +216,7 @@ provider "null" {}
 provider "external" {}
 provider "template" {}
 provider "archive" {}
+provider "local" {}
                         `);
         }
         const defaultProvidersPluginsPath = Path.join(serverLocation, ".terraform", "plugins");


### PR DESCRIPTION
The local provider is fairly often used, and is not exotic enough to not include with defaults

This allows "local_file" resources with the lsp