### PR TITLE
Add `hcl` as lanugage id in markdown

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,8 +136,15 @@
         "path": "./syntaxes/terraform.json"
       },
       {
-        "scopeName": "text.markdown.terraform.codeblock",
+        "scopeName": "text.markdown.terraform.codeblock-terraform",
         "path": "./syntaxes/terraform.codeblock.json",
+        "injectTo": [
+          "text.html.markdown"
+        ]
+      },
+      {
+        "scopeName": "text.markdown.terraform.codeblock-hcl",
+        "path": "./syntaxes/terraform.codeblock-hcl.json",
         "injectTo": [
           "text.html.markdown"
         ]

--- a/syntaxes/terraform.codeblock-hcl.json
+++ b/syntaxes/terraform.codeblock-hcl.json
@@ -1,22 +1,22 @@
 {
 	"$schema": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json",
-	"name": "sltest",
+	"name": "sltest-hcl",
 	"fileTypes": [],
 	"injectionSelector": "L:markup.fenced_code.block.markdown",
 	"patterns": [
 		{
-			"include": "#terraform-code-block-terraform"
+			"include": "#terraform-code-block-hcl"
 		}
 	],
 	"repository": {
-		"terraform-code-block-terraform": {
-			"begin": "(?<=[`~])terraform(\\s+[^`~]*)?$",
+		"terraform-code-block-hcl": {
+			"begin": "(?<=[`~])hcl(\\s+[^`~]*)?$",
 			"end": "(^|\\G)(?=\\s*[`~]{3,}\\s*$)",
 			"patterns": [
 				{
 					"begin": "(^|\\G)(\\s*)(.*)",  
 					"while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
-					"contentName": "meta.embedded.block.terraform",
+					"contentName": "meta.embedded.block.terraform-hcl",
 					"patterns": [
 						{
 							"include": "source.terraform"
@@ -26,5 +26,5 @@
 			]
 		}
 	},
-	"scopeName": "text.markdown.terraform.codeblock-terraform"
+	"scopeName": "text.markdown.terraform.codeblock-hcl"
 }


### PR DESCRIPTION
The Terraform provider docs use `hcl` as the language identifier for code blocks in markdown rather than `terraform`. This PR enables the embedded codeblock support for `hcl`

With this PR, both code blocks below get language support (not just the second one):

    ```hcl
        resource "test" "test {
        }
    ```
    ```terraform
        resource "test" "test {
        }
    ```