### PR TITLE
Fix, concatenate tflint issues and errors prior to processing

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -26,7 +26,9 @@ export class LintCommand extends Command {
 
       const workspaceDir = workspaceFolder.uri.fsPath;
       try {
-        const issues = await lint(configuration["lintPath"], configuration["lintConfig"], workspaceDir);
+        const allFindings = await lint(configuration["lintPath"], configuration["lintConfig"], workspaceDir);
+        const issues = allFindings["issues"].concat(allFindings["errors"]);
+
         this.logger.info(`${issues.length} issues`);
 
         this.groupIssues(issues).forEach((diagnostics, file) => {


### PR DESCRIPTION
In tflint 0.11.2, the value returned from a JSON formatted check is
{"issues":[],"errors":[]}

The typescript code here assumed it was returning a singular array
instead a map of arrays.

This commit concatenates the two arrays together for further
processing.