### PR TITLE
Include oci provider to the language server

### DIFF
--- a/src/languageclient.ts
+++ b/src/languageclient.ts
@@ -209,6 +209,7 @@ provider "aws" {}
 provider "azurerm" {}
 provider "google" {}
 provider "alicloud" {}
+provider "oci" {}
 provider "helm" {}
 provider "kubernetes" {}
 provider "random" {}


### PR DESCRIPTION
oci provider is already configured for the autocompletion, but was missing on the language server as default providers.