### PR TITLE
Fix: "Cannot set property 'excludePaths' of undefined" in index-adapter

### DIFF
--- a/src/index/index-adapter.ts
+++ b/src/index/index-adapter.ts
@@ -34,11 +34,11 @@ export class IndexAdapter extends vscode.Disposable {
     this.disposables.map(d => d.dispose());
   }
 
-  private onDidChangeWorkspaceFolders(e: vscode.WorkspaceFoldersChangeEvent) {
+  private onDidChangeWorkspaceFolders = (e: vscode.WorkspaceFoldersChangeEvent) => {
     // TODO: remove all groups which are part e.removed[]
   }
 
-  private onDidChangeConfiguration(e: vscode.ConfigurationChangeEvent) {
+  private onDidChangeConfiguration = (e: vscode.ConfigurationChangeEvent) => {
     if (!e.affectsConfiguration("terraform.indexing"))
       return;
     this.excludePaths = getConfiguration().indexing.exclude || [];


### PR DESCRIPTION
Package version: 1.4.0
VSCode version: 1.41.0

**Error**
TypeError: Cannot set property 'excludePaths' of undefined
	at onDidChangeConfiguration (...index-adapter.js)

**Issue**
onDidChangeConfiguration (IndexAdapter) is passed as a callback to vscode.workspace.onDidChangeConfiguration, but the callback is not bound to the source object and cannot access "this" when called.

**Solution**
Change onDidChangeWorkspaceFolders and onDidChangeConfiguration to anonymous functions