### PR TITLE
Leave .hcl files unclaimed as Terraform files

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,8 +71,7 @@
         ],
         "extensions": [
           ".tf",
-          ".tfvars",
-          ".hcl"
+          ".tfvars"
         ],
         "configuration": "./language-configuration.json"
       },


### PR DESCRIPTION
Thanks for building this extension!

Terraform itself does not use the `.hcl` suffix, and claiming it here can cause a poor experience for folks editing other HCL-based languages used by other applications, which are likely to have a different idea about which block types and arguments are considered valid and thus are incorrectly marked as invalid by this extension today.

Since HCL is just a syntax, in similar vein to XML, it doesn't really make sense to do more than just syntax highlighting and possibly bracket completion for generic `.hcl` files: any further features such as autocomplete and go to definition will always rely on knowledge of a particular application's own schema.
