### PR TITLE
Updated tflint support for new JSON format.

### DIFF
--- a/src/commands/lint.ts
+++ b/src/commands/lint.ts
@@ -49,29 +49,70 @@ export class LintCommand extends Command {
     issues
       .forEach((issue) => {
         let diagnostic = toDiagnostic(issue);
-        if (issuesByFile.has(issue.file))
-          issuesByFile.get(issue.file).push(diagnostic);
+        if (issuesByFile.has(issue.range.filename))
+          issuesByFile.get(issue.range.filename).push(diagnostic);
         else
-          issuesByFile.set(issue.file, [diagnostic]);
+          issuesByFile.set(issue.range.filename, [diagnostic]);
       });
     return issuesByFile;
   }
 }
 
+/*
+Issue structure as of tflint > 0.10.1
+{
+    "callers": [
+    ],
+    "message": "`kubernetes-thing` resource name has a dash",
+    "range": {
+        "end": {
+            "column": 53,
+            "line": 7
+        },
+        "filename": "main.tf",
+        "start": {
+            "column": 1,
+            "line": 7
+        }
+    },
+    "rule": {
+        "link": "https://github.com/terraform-linters/tflint/blob/v0.13.4/docs/rules/terraform_dash_in_resource_name.md",
+        "name": "terraform_dash_in_resource_name",
+        "severity": "info"
+    }
+}
+*/
+
 type Issue = {
-  type: string;
   message: string;
+  range: IssueRange;
+  rule: IssueRule;
+};
+
+type IssueRange = {
+  filename: string;
+  start: IssuePosition;
+  end: IssuePosition;
+};
+
+type IssuePosition = {
+  column: number;
   line: number;
-  file: string;
+};
+
+type IssueRule = {
+  link: string;
+  name: string;
+  severity: string;
 };
 
 function typeToSeverity(type: string): vscode.DiagnosticSeverity {
   switch (type) {
-    case "ERROR":
+    case "error":
       return vscode.DiagnosticSeverity.Error;
-    case "WARNING":
+    case "warning":
       return vscode.DiagnosticSeverity.Warning;
-    case "NOTICE":
+    case "notice":
       return vscode.DiagnosticSeverity.Information;
   }
 
@@ -79,8 +120,10 @@ function typeToSeverity(type: string): vscode.DiagnosticSeverity {
 }
 
 function toDiagnostic(issue: Issue): vscode.Diagnostic {
-  return new vscode.Diagnostic(new vscode.Range(issue.line - 1, 0, issue.line - 1, 100),
-    issue.message, typeToSeverity(issue.type));
+  return new vscode.Diagnostic(
+    new vscode.Range(issue.range.start.line - 1, issue.range.start.column - 1, issue.range.end.line - 1, issue.range.end.column - 1),
+    issue.message,
+    typeToSeverity(issue.rule.severity));
 }
 
 export let LintDiagnosticsCollection = vscode.languages.createDiagnosticCollection("terraform-lint");
@@ -97,12 +140,24 @@ function lint(execPath: string, lintConfig: string, workspaceDir: string): Promi
       encoding: 'utf8',
       maxBuffer: 1024 * 1024
     }, (error, stdout, stderr) => {
-      if (error) {
+      if (error["code"] < 2 || error["code"] > 3) {
+        // 0: No issues found - won't enter this block
+        // 2: Errors occurred (can be parsed below)
+        // 3: No errors occurred, but issues found (can be parsed below)
+        // https://github.com/terraform-linters/tflint/blob/000c2eb1a92bb43b1107372ea409bd7f2008caac/cmd/cli.go#L26
         reject(error);
       } else {
         try {
+          // tflint > 0.10.1 returns errors in two arrays:
+          // {"issues":[],"errors":[]}
+          // https://github.com/terraform-linters/tflint/blob/000c2eb1a92bb43b1107372ea409bd7f2008caac/formatter/json.go
+          // Errors only contain messages from terraform, not lint issues.
           let result = JSON.parse(stdout);
-          resolve(result);
+          if (result["errors"].length > 0) {
+            // Just pick the first error. This is pretty rare.
+            reject(result["errors"][0]);
+          }
+          resolve(result["issues"]);
         } catch (parseError) {
           reject(parseError);
         }


### PR DESCRIPTION
Recent versions of tflint have changed the return values and output format. This PR updates the execution and parsing support for the new format.

- Exit codes for errors properly handled.
- Issues parsed for the new JSON format.

Tested against tflint 0.13.4 on MacOS.