### PR TITLE
Automatically publish extension to OpenVSX (GitHub workflow)

### DIFF
--- a/.github/workflows/publish-extension.yml
+++ b/.github/workflows/publish-extension.yml
@@ -1,0 +1,20 @@
+name: Publish Terraform VS Code Extension
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  publish_to_openvsx:
+    name: publish to open-vsx.org
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v1
+      with:
+        node-version: '12'
+    - run: npm install
+    - run: npx ovsx publish
+      env:
+        OVSX_PAT: ${{ secrets.OVSX_PAT }}


### PR DESCRIPTION
Hello! 👋 Many thanks for the cool Terraform extension!

Fixes https://github.com/hashicorp/vscode-terraform/issues/379. This proof-of-concept GitHub workflow would:
- Run on every push to `master`
- Publish the Terraform VS Code Extension to https://open-vsx.org (using the `ovsx` CLI)

It requires:
- [ ] Setting up an `OVSX_PAT` GitHub secret with value from https://open-vsx.org/user-settings/tokens

Notes:
- ~~⚠️ Untested~~
- This workflow can probably be extended with a similar job to automate the publishing to VS Code Marketplace