### PR TITLE
Readme: Correct supported list of extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ The HashiCorp Terraform Visual Studio Code (VS Code) extension adds syntax highl
 
 - Manages installation and updates of the [Terraform Language Server (terraform-ls)](https://github.com/hashicorp/terraform-ls), exposing its features:
   - Initialized provider completion (resource names, data source names, attribute names)
-- Includes syntax highlighting for `.tf` and `.tfvars` files (and `.hcl`) -- including all syntax changes new to Terraform 0.12
+- Includes syntax highlighting for `.tf` and `.tfvars` files -- including all syntax changes new to Terraform 0.12
 - Closes braces and quotes
 - Includes `for_each` and `variable` syntax shortcuts (`fore`, `vare`, `varm`)
 


### PR DESCRIPTION
Looks like this was just a relic from the older version of the extension. Generally `hcl` represents generic HCL configuration, not something Terraform would ever load.

That said it's something we may consider supporting in the future either directly or via a separate extension and/or separate language server.

For now _not_ supporting HCL in a _Terraform_ extension is intentional.

Relatedly if any other Terraform extension supports HCL and treats it the same way as Terraform's HCL, it's _probably_ inaccurate. Many extensions aren't currently aware of this distinction and that's something we also need to communicate going forward, as per https://github.com/hashicorp/terraform-ls/issues/50#issuecomment-630053301