### PR TITLE
fix parenthesis inclusion

### DIFF
--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -650,7 +650,7 @@
 							"match": "\\*",
 							"comment": "Attribute-only splat",
 							"name": "keyword.operator.splat.terraform"
-						}	
+						}
 					]
 				}
 			}
@@ -793,7 +793,7 @@
 			},
 			"patterns": [
 				{
-					"include": "expressions"
+					"include": "#expressions"
 				},
 				{
 					"include": "#local_identifiers"


### PR DESCRIPTION
Signed-off-by: Anthony Sottile <asottile@umich.edu>

this was crashing my text editor with something like this:

```terraform
resource "a" "a" {
  b = ()
}
```

```console
$ babi t.tf
Traceback (most recent call last):
  File "/home/asottile/bin/babi", line 8, in <module>
    sys.exit(main())
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/main.py", line 152, in main
    return c_main(stdscr, filenames, positions, stdin, perf)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/main.py", line 57, in c_main
    res = _edit(screen, stdin)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/main.py", line 29, in _edit
    screen.draw()
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/screen.py", line 258, in draw
    self.file.draw(self.stdscr, self.margin)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/file.py", line 789, in draw
    file_hl.highlight_until(self.buf, self.buf.file_y + to_display)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/hl/syntax.py", line 119, in highlight_until
    state, regions = self._hl(state, lines[i], i == 0)  # type: ignore
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/hl/syntax.py", line 63, in _hl_uncached
    new_state, regions = highlight_line(
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/highlight.py", line 782, in highlight_line
    search_res = state.cur.rule.search(
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/highlight.py", line 485, in search
    return _do_regset(idx, match, self, compiler, state, pos)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/highlight.py", line 363, in _do_regset
    target_rule = compiler.compile_rule(rule.u_rules[idx])
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/highlight.py", line 663, in compile_rule
    ret = self._c_rules[rule] = self._compile_rule(grammar, rule)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/highlight.py", line 631, in _compile_rule
    regs, rules = self._patterns(grammar, rule.patterns)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/highlight.py", line 595, in _patterns
    tmp_regs, tmp_rules = self._include(
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/highlight.py", line 578, in _include
    grammar = self._grammars.grammar_for_scope(s)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/highlight.py", line 708, in grammar_for_scope
    raw = self._raw_for_scope(scope)
  File "/home/asottile/opt/venv/lib/python3.8/site-packages/babi/highlight.py", line 690, in _raw_for_scope
    grammar_path = self._scope_to_files.pop(scope)
KeyError: 'expressions'
```