### PR TITLE
use the amd64 binary on Apple Silicon Macs for now

### DIFF
--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -64,6 +64,13 @@ export class LanguageServerInstaller {
 			case 'ia32':
 				arch = '386'
 				break;
+			case 'arm64':
+				if (platform === 'darwin') {
+					// On Apple Silicon, install the amd64 version and rely on Rosetta2
+					// until a native build is available.
+					arch = 'amd64'
+				}
+				break;
 		}
 		const build = release.getBuild(platform, arch);
 		if (!build) {


### PR DESCRIPTION
This fixes #521

I'm guessing there won't be a native build of terraform-ls until at least February 2021 when Golang 1.16 is released with `GOARCH=arm64` support. So it seems worth doing this for now, the amd64 terraform-ls binary works great.