### PR TITLE
[HOLD] Install arm64 instead of amd64 for darwin

### DIFF
--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -139,10 +139,6 @@ function goArch(): string {
 	if (arch === 'x64') {
 		return 'amd64';
 	}
-	if (arch === 'arm64' && process.platform.toString() === 'darwin') {
-		// On Apple Silicon, install the amd64 version and rely on Rosetta2
-		// until a native build is available.
-		return 'amd64';
-	}
+
 	return arch;
 }


### PR DESCRIPTION
This should not be merged until https://github.com/hashicorp/terraform-ls/pull/350 is merged and released, i.e. when there is an actual darwin/arm64 build of LS available.

That PR is currently also on hold due to https://github.com/syndbg/goenv/pull/164
