### PR TITLE
Fix branch links for terraform-ls and vscode-terraform in readme and changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -147,7 +147,7 @@ Other updates:
 * Added shortcuts (snippets) for variable and for_each syntax -- `fore`, `vare`, `varm`
 * For contributors, the TypeScript testing and linting frameworks have been brought current with the recommended packages
 * Logos now match the current brand guidelines (pretty snazzy!)
-* Auto-completion, hover, and definition features are now managed by the language server, so see their [changelog](https://github.com/hashicorp/terraform-ls/blob/master/CHANGELOG.md) for the most recent updates
+* Auto-completion, hover, and definition features are now managed by the language server, so see their [changelog](https://github.com/hashicorp/terraform-ls/blob/main/CHANGELOG.md) for the most recent updates
 * External commands such as `terraform validate` and `tflint` are removed from the extension, but we plan to add hooks for these and/or additional integrations via the language server.
 * The outline view and model overview have been removed for now in order to focus on core features
 

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This will create diagnostics for any elements that fail validation. `terraform v
 
 **v2.0.0**  is the first official release from HashiCorp, prior releases were by [Mikael Olenfalk](https://github.com/mauve).
 
-The 2.0.0 release integrates a new [Language Server package from HashiCorp](https://github.com/hashicorp/terraform-ls). The extension will install and upgrade terraform-ls to continue to add new functionality around code completion and formatting. See the [terraform-ls CHANGELOG](https://github.com/hashicorp/terraform-ls/blob/master/CHANGELOG.md) for details.
+The 2.0.0 release integrates a new [Language Server package from HashiCorp](https://github.com/hashicorp/terraform-ls). The extension will install and upgrade terraform-ls to continue to add new functionality around code completion and formatting. See the [terraform-ls CHANGELOG](https://github.com/hashicorp/terraform-ls/blob/main/CHANGELOG.md) for details.
 
 In addition, this new version brings the syntax highlighting up to date with all HCL2 features, as needed for Terraform 0.12 and above.
 
@@ -94,7 +94,7 @@ In addition, this new version brings the syntax highlighting up to date with all
 }
 ```
 
-See the [CHANGELOG](https://github.com/hashicorp/vscode-terraform/blob/master/CHANGELOG.md) for more information.
+See the [CHANGELOG](https://github.com/hashicorp/vscode-terraform/blob/main/CHANGELOG.md) for more information.
 
 ## Terraform 0.11
 


### PR DESCRIPTION
Terraform-LS repo has deleted master, so redirects to the default of main. 
Vscode-terraform still has the master branch, so the links from VSCode readme take you to the old changelog, not the updated one on the main branch. 