### PR TITLE
Update incorrect dates to CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,14 @@
-# 2.10.0 (2020-04-13)
+# 2.10.0 (2021-04-13)
 
 * Update syntax highlighting for Terraform 0.15 (#604)
 
-# 2.9.1 (2020-03-24)
+# 2.9.1 (2021-03-24)
 
 Bugs:
 
 * Fix contents of vsix package
 
-# 2.9.0 (2020-03-24)
+# 2.9.0 (2021-03-24)
 
 * Check for language server updates every 24 hours (#595)
 


### PR DESCRIPTION
Changed the incorrect years from `2020` to `2021` for the last 3 versions.