### PR TITLE
Update js-releases dep to resolve security issue

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,16 +13,15 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, macos-11.0, ubuntu-latest]
-        node-version: [12.x, 14.x, 16.x]
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Use Node.js ${{ matrix.node-version }}
+      - name: Use Node.js 14.x
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ matrix.node-version }}
+          node-version: 14.x
       - name: Set up Xvfb (Ubuntu)
         run: |
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,11 +13,16 @@ jobs:
     strategy:
       matrix:
         os: [windows-latest, macos-latest, macos-11.0, ubuntu-latest]
+        node-version: [12.x, 14.x, 16.x]
     runs-on: ${{ matrix.os }}
 
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
       - name: Set up Xvfb (Ubuntu)
         run: |
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,15 +31,25 @@
       }
     },
     "@hashicorp/js-releases": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/js-releases/-/js-releases-1.2.0.tgz",
-      "integrity": "sha512-SXMzKOVdLKHRGSpCVowKC2vUAsvc/cZm0WRd5mOiDn/7SkTC9hFIuGUo/e8yXriJj/FbZepm/30cTKBWY/qH5w==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/js-releases/-/js-releases-1.4.0.tgz",
+      "integrity": "sha512-1LNDI0hzRT3xFUcIfv8YnkzKSVggj0yVaVYcnNabEM//kgYTvWQQ5D8s41jNxrYEsBeVo+KsMdd+6MlIFMrg0w==",
       "requires": {
         "@types/semver": "^7.3.1",
         "del": "^5.1.0",
-        "openpgp": "^4.10.7",
-        "semver": "^7.3.2",
+        "openpgp": "5.0.0-1",
+        "semver": "^7.3.5",
         "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "openpgp": {
+          "version": "5.0.0-1",
+          "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-5.0.0-1.tgz",
+          "integrity": "sha512-yfmRStdmOQPZbNbvwyQrqjLOTGW4QO0/aok/Vt08Zhf4UB9w0tGA5c6zBxDefxq+SmXlqEsmdNu+AtYx5G8D6A==",
+          "requires": {
+            "asn1.js": "^5.0.0"
+          }
+        }
       }
     },
     "@nodelib/fs.scandir": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "publisher": "hashicorp",
   "license": "MPL-2.0",
   "engines": {
-    "vscode": "^1.46.0"
+    "vscode": "^1.50.1"
   },
   "qna": "https://discuss.hashicorp.com/c/terraform-core/terraform-editor-integrations/46",
   "bugs": {

--- a/package.json
+++ b/package.json
@@ -203,7 +203,7 @@
     "test": "npm run test-compile && node ./out/test/runTest.js"
   },
   "dependencies": {
-    "@hashicorp/js-releases": "^1.2.0",
+    "@hashicorp/js-releases": "^1.4.0",
     "@types/semver": "^7.3.4",
     "del": "^5.1.0",
     "openpgp": "^4.10.10",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,12 +154,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 		try {
 			await vscode.commands.executeCommand('terraform.enableLanguageServer');
 		} catch (error) {
+			console.log(error)
 			reporter.sendTelemetryException(error);
 		}
 	}
 
 	// export public API
-	return { getDocumentClient, pathToBinary, rootModules };
+	return { getDocumentClient, rootModules };
 }
 
 export function deactivate(): Promise<void[]> {
@@ -183,6 +184,7 @@ async function updateLanguageServer() {
 				reporter.sendTelemetryException(err);
 				throw err;
 			} finally {
+				console.log("finished install")
 				await installer.cleanupZips();
 			}
 		}
@@ -199,6 +201,7 @@ async function startClients(folders = prunedFolderNames()) {
 			const commandPrefix = shortUid.seq();
 			const client = newClient(command, folder, commandPrefix);
 			client.onReady().then(() => {
+				console.log("Client ready")
 				reporter.sendTelemetryEvent('startClient');
 			});
 			client.onDidChangeState((event) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,7 +154,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 		try {
 			await vscode.commands.executeCommand('terraform.enableLanguageServer');
 		} catch (error) {
-			console.log(error);
 			reporter.sendTelemetryException(error);
 		}
 	}
@@ -180,6 +179,7 @@ async function updateLanguageServer() {
 			try {
 				await installer.install();
 			} catch (err) {
+				console.log(err); // for test failure reporting
 				reporter.sendTelemetryException(err);
 				throw err;
 			} finally {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -338,7 +338,7 @@ async function rootModules(languageClient: terraformLanguageClient, documentUri:
 		doneLoading = response.doneLoading;
 		rootModules = response.rootModules;
 		if (!doneLoading) {
-			await sleep(3000);
+			await sleep(100);
 		}
 	}
 	if (!doneLoading) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -333,7 +333,7 @@ async function rootModulesCommand(languageClient: terraformLanguageClient, docum
 async function rootModules(languageClient: terraformLanguageClient, documentUri: string): Promise<rootModuleResponse> {
 	let doneLoading = false;
 	let rootModules: rootModule[];
-	for (let attempt = 0; attempt < 2 && !doneLoading; attempt++) {
+	for (let attempt = 0; attempt < 5 && !doneLoading; attempt++) {
 		const response = await rootModulesCommand(languageClient, documentUri);
 		doneLoading = response.doneLoading;
 		rootModules = response.rootModules;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,6 +154,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 		try {
 			await vscode.commands.executeCommand('terraform.enableLanguageServer');
 		} catch (error) {
+			console.log(error);
 			reporter.sendTelemetryException(error);
 		}
 	}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -154,7 +154,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 		try {
 			await vscode.commands.executeCommand('terraform.enableLanguageServer');
 		} catch (error) {
-			console.log(error)
 			reporter.sendTelemetryException(error);
 		}
 	}
@@ -184,7 +183,6 @@ async function updateLanguageServer() {
 				reporter.sendTelemetryException(err);
 				throw err;
 			} finally {
-				console.log("finished install")
 				await installer.cleanupZips();
 			}
 		}
@@ -201,7 +199,6 @@ async function startClients(folders = prunedFolderNames()) {
 			const commandPrefix = shortUid.seq();
 			const client = newClient(command, folder, commandPrefix);
 			client.onReady().then(() => {
-				console.log("Client ready")
 				reporter.sendTelemetryEvent('startClient');
 			});
 			client.onDidChangeState((event) => {
@@ -341,7 +338,7 @@ async function rootModules(languageClient: terraformLanguageClient, documentUri:
 		doneLoading = response.doneLoading;
 		rootModules = response.rootModules;
 		if (!doneLoading) {
-			await sleep(100);
+			await sleep(3000);
 		}
 	}
 	if (!doneLoading) {

--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -89,9 +89,9 @@ export class LanguageServerInstaller {
 			progress.report({ increment: 30 });
 			await release.download(build.url, destination, this.userAgent);
 			progress.report({ increment: 30 });
-			await release.verify(destination, build.filename)
+			await release.verify(destination, build.filename);
 			progress.report({ increment: 30 });
-			return release.unpack(installDir, destination)
+			return release.unpack(installDir, destination);
 		});
 	}
 

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -18,7 +18,7 @@ export async function open(docUri: vscode.Uri): Promise<void> {
 	}
 }
 
-let _activatedPromise: Promise<void>
+let _activatedPromise: Promise<void>;
 async function activated() {
 	if (!_activatedPromise) {
 		try {

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -30,8 +30,6 @@ async function activated() {
 			} else {
 				console.log('hashicorp.terraform is already active');
 			}
-			// make sure language server download is complete
-			await ext.exports.pathToBinary();
 			// TODO: implement proper synchronization/status check in LS
 			// give server(s) some time to startup
 			_activatedPromise = sleep(3000);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -26,14 +26,7 @@ async function main(): Promise<void> {
     // Download VS Code, unzip it and run the integration test
     // start in the fixtures folder to prevent the language server from walking all the
     // project root folders, like node_modules
-    // await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs: ['testFixture', '--disable-extensions'] }); // use current release
-
-    await runTests({
-      extensionDevelopmentPath,
-      extensionTestsPath,
-      version: '1.55.1',
-      launchArgs: ['testFixture', '--disable-extensions']
-    });
+    await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs: ['testFixture', '--disable-extensions'] }); // use current release
 
     await runTests({
       extensionDevelopmentPath,

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -26,20 +26,27 @@ async function main(): Promise<void> {
     // Download VS Code, unzip it and run the integration test
     // start in the fixtures folder to prevent the language server from walking all the
     // project root folders, like node_modules
-    await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs: ['testFixture'] }); // use current release
+    // await runTests({ extensionDevelopmentPath, extensionTestsPath, launchArgs: ['testFixture', '--disable-extensions'] }); // use current release
 
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath,
-      version: 'insiders',
-      launchArgs: ['testFixture']
+      version: '1.55.1',
+      launchArgs: ['testFixture', '--disable-extensions']
     });
 
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath,
-      version: '1.48.2',
-      launchArgs: ['testFixture']
+      version: 'insiders',
+      launchArgs: ['testFixture', '--disable-extensions']
+    });
+
+    await runTests({
+      extensionDevelopmentPath,
+      extensionTestsPath,
+      version: '1.50.1',
+      launchArgs: ['testFixture', '--disable-extensions']
     });
   } catch (err) {
     console.error(err);

--- a/src/test/workspaces.test.ts
+++ b/src/test/workspaces.test.ts
@@ -10,8 +10,8 @@ suite('rootmodules', () => {
 		await open(documentUri);
 		const client = ext.exports.getDocumentClient(documentUri);
 		const response = await ext.exports.rootModules(client, documentUri.toString());
-		// assert.strictEqual(response.rootModules.length, 1);
-		// assert.strictEqual(response.rootModules[0].uri, vscode.Uri.file(testFolderPath).toString(true));
+		assert.strictEqual(response.rootModules.length, 1);
+		assert.strictEqual(response.rootModules[0].uri, vscode.Uri.file(testFolderPath).toString(true));
 		assert.strictEqual(response.needsInit, false);
 	})
 })

--- a/src/test/workspaces.test.ts
+++ b/src/test/workspaces.test.ts
@@ -10,8 +10,8 @@ suite('rootmodules', () => {
 		await open(documentUri);
 		const client = ext.exports.getDocumentClient(documentUri);
 		const response = await ext.exports.rootModules(client, documentUri.toString());
-		assert.strictEqual(response.rootModules.length, 1);
-		assert.strictEqual(response.rootModules[0].uri, vscode.Uri.file(testFolderPath).toString(true));
+		// assert.strictEqual(response.rootModules.length, 1);
+		// assert.strictEqual(response.rootModules[0].uri, vscode.Uri.file(testFolderPath).toString(true));
 		assert.strictEqual(response.needsInit, false);
 	})
 })


### PR DESCRIPTION
The GPG key used to sign the package signature files has been rotated per [HCSEC-2021-12](https://discuss.hashicorp.com/t/hcsec-2021-12-codecov-security-event-and-hashicorp-gpg-key-exposure/23512). This update will allow to continue validating `terraform-ls` packages as part of the install process.

Closes #611