### PR TITLE
Correct delay for language server version check

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -167,7 +167,7 @@ export function deactivate(): Promise<void[]> {
 }
 
 async function updateLanguageServer() {
-	const delay = 1000 * 60 * 24;
+	const delay = 1000 * 60 * 60 * 24;
 	setTimeout(updateLanguageServer, delay); // check for new updates every 24hrs
 
 	// skip install if a language server binary path is set


### PR DESCRIPTION
Partially fixes #618 

Previously PR 595 added in a periodic check for the language server version
however the period chosen was incorrect. Currently it checks evey 24mins,
not 24 hours.

This commit changes the period to the expected 24hr period.