### PR TITLE
Only trigger auto-update once in a VSCode session

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -34,3 +34,22 @@ export function httpsRequest(url: string, options: https.RequestOptions = {}, en
 export async function sleep(ms: number): Promise<void> {
 	return new Promise(resolve => setTimeout(resolve, ms));
 }
+
+// A small wrapper around setTimeout which ensures that only a single timeout
+// timer can be running at a time. Attempts to add a new timeout silently fail.
+export class SingleInstanceTimeout {
+	private timerLock = false;
+	private timerId: NodeJS.Timeout;
+
+	public timeout(fn, delay, ...args) {
+		if (!this.timerLock) {
+			this.timerLock = true;
+			this.timerId = setTimeout(function () { this.timerLock = false; fn() }, delay, args)
+		}
+	}
+
+	public clear() {
+		if (this.timerId) { clearTimeout(this.timerId) }
+		this.timerLock = false;
+	}
+}


### PR DESCRIPTION
Relates to #618 

Previously the extension would trigger a new auto-update whenever it was
activated. However this can causes issues when a user deactivates-activates the
language server quickly multiple times, as it cause multiple timeouts to be
created. Additionally, when disabled, it would not clear any active timeouts.

This commit adds a small wrapper around the setTimeout function to track usage.
In particular, it will silently ignore calls to add a timeout if a timeout is
already active.  This commit also clears any timeouts when the language server
is disabled.
