### PR TITLE
feat: use arm64 ls builds on darwin

### DIFF
--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -153,11 +153,6 @@ function goArch(): string {
 	if (arch === 'x64') {
 		return 'amd64';
 	}
-	if (arch === 'arm64' && process.platform.toString() === 'darwin') {
-		// On Apple Silicon, install the amd64 version and rely on Rosetta2
-		// until a native build is available.
-		return 'amd64';
-	}
 	return arch;
 }
 


### PR DESCRIPTION
Native arm64 builds are now available https://github.com/hashicorp/terraform-ls/releases/tag/v0.16.3