### PR TITLE
Update changelog URL

### DIFF
--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -107,7 +107,7 @@ export class LanguageServerInstaller {
 		vscode.window.showInformationMessage(`Installed terraform-ls ${version}.`, "View Changelog")
 			.then(selected => {
 				if (selected === "View Changelog") {
-					vscode.env.openExternal(vscode.Uri.parse(`https://github.com/hashicorp/terraform-ls/releases/tag/v${version}`));
+					vscode.env.openExternal(vscode.Uri.parse('https://github.com/hashicorp/terraform-ls/blob/main/CHANGELOG.md'));
 				}
 			});
 		return;


### PR DESCRIPTION
Link to the latest copy of the changelog document, rather than release page.

There are no changelog notes for terraform-ls GitHub releases, so link directly to the changelog file instead.

Since this plugin is only used to install the latest terraform-ls version, link to the main branch `CHANGELOG.md`, rather than the version as of the appropriate tag. Sometimes the changelog is modified after the tag with forgotten information, and we don't want to hide that from users.