### PR TITLE
(GH-628) Add semver based version pin for Language Server

### DIFF
--- a/package.json
+++ b/package.json
@@ -124,6 +124,10 @@
               ],
               "default": "off",
               "description": "Traces the communication between VS Code and the language server."
+            },
+            "required_version": {
+              "type": "string",
+              "description": "The required version of the Language Server described as a semantic version string, for example '^2.0.1' or '> 1.0'. Defaults to latest available version."
             }
           },
           "default": {

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
               "default": "off",
               "description": "Traces the communication between VS Code and the language server."
             },
-            "required_version": {
+            "requiredVersion": {
               "type": "string",
               "description": "The required version of the Language Server described as a semantic version string, for example '^2.0.1' or '> 1.0'. Defaults to latest available version."
             }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -39,8 +39,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 		}
 	}
 
-	if (config('terraform').has('languageServer.required_version')) {
-		const langServerVer = config('terraform').get('languageServer.required_version', defaultVersionString)
+	if (config('terraform').has('languageServer.requiredVersion')) {
+		const langServerVer = config('terraform').get('languageServer.requiredVersion', defaultVersionString)
 		if (!isValidVersionString(langServerVer)) {
 			vscode.window.showWarningMessage(`The Terraform Language Server Version string '${langServerVer}' is not a valid semantic version and will be ignored.`);
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -172,7 +172,7 @@ async function updateLanguageServer(clientHandler: ClientHandler, lsPath: Server
 		// skip install if a language server binary path is set
 		if (!lsPath.hasCustomBinPath()) {
 			const installer = new LanguageServerInstaller(lsPath, reporter);
-			const install = await installer.needsInstall(config('terraform').get('languageServer.version', defaultVersionString));
+			const install = await installer.needsInstall(config('terraform').get('languageServer.requiredVersion', defaultVersionString));
 			if (install) {
 				await clientHandler.stopClients();
 				try {

--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -9,6 +9,11 @@ import { ServerPath } from './serverPath';
 import { Release, getRelease } from '@hashicorp/js-releases';
 
 const extensionVersion = vscode.extensions.getExtension('hashicorp.terraform').packageJSON.version;
+export const defaultVersionString = "latest";
+
+export function isValidVersionString(value: string): boolean {
+	return semver.validRange(value,  { includePrerelease: true, loose: true }) !== null;
+}
 
 export class LanguageServerInstaller {
 	constructor(
@@ -19,10 +24,30 @@ export class LanguageServerInstaller {
 	private userAgent = `Terraform-VSCode/${extensionVersion} VSCode/${vscode.version}`;
 	private release: Release;
 
-	public async needsInstall(): Promise<boolean> {
+	private async getRequiredVersionRelease(versionString: string): Promise<Release> {
 		try {
-			this.release = await getRelease("terraform-ls", "latest", this.userAgent);
+			const release = await getRelease("terraform-ls", versionString, this.userAgent);
+			console.log(`Found Terraform language server version ${release.version} which satisfies range '${versionString}'`);
+			return release;
 		} catch (err) {
+			if (versionString == defaultVersionString) { throw err; }
+			console.log(`Error while finding Terraform language server release which satisfies range '${versionString}' and will reattempt with '${defaultVersionString}': ${err}`)
+		}
+
+		// Attempt to find the latest release
+		const release = await getRelease("terraform-ls", defaultVersionString, this.userAgent);
+		console.log(`Found Default Terraform language server version ${release.version} which satisfies range '${defaultVersionString}'`);
+		return release;
+	}
+
+	public async needsInstall(requiredVersion: string): Promise<boolean> {
+		// Silently default to latest if an invalid version string is passed.
+		// Actually telling the user about a bad string is left to the main extension code instead of here
+		const versionString = isValidVersionString(requiredVersion) ? requiredVersion : defaultVersionString;
+		try {
+			this.release = await this.getRequiredVersionRelease(versionString);
+		} catch (err) {
+			console.log(`Error while finding Terraform language server release which satisfies range '${versionString}': ${err}`)
 			// if the releases site is inaccessible, report it and skip the install
 			this.reporter.sendTelemetryException(err);
 			return false;
@@ -31,6 +56,7 @@ export class LanguageServerInstaller {
 		let installedVersion: string;
 		try {
 			installedVersion = await getLsVersion(this.lsPath);
+			console.log(`Currently installed Terraform language server is version '${installedVersion}`)
 		} catch (err) {
 			// Most of the time, getLsVersion will produce "ENOENT: no such file or directory"
 			// on a fresh installation (unlike upgrade). It’s also possible that the file or directory
@@ -43,12 +69,18 @@ export class LanguageServerInstaller {
 		}
 
 		this.reporter.sendTelemetryEvent('foundLsInstalled', { terraformLsVersion: installedVersion });
-		const upgrade = semver.gt(this.release.version, installedVersion, { includePrerelease: true });
-		if (upgrade) {
+
+		if (semver.eq(this.release.version, installedVersion, { includePrerelease: true })) {
+			// Already at the specified versoin
+			return false;
+		} else if (semver.gt(this.release.version, installedVersion, { includePrerelease: true })) {
+			// Upgrade
 			const selected = await vscode.window.showInformationMessage(`A new language server release is available: ${this.release.version}. Install now?`, 'Install', 'Cancel');
 			return (selected === "Install");
 		} else {
-			return false; // no upgrade available
+			// Downgrade
+			const selected = await vscode.window.showInformationMessage(`An older language server release is available: ${this.release.version}. Install now?`, 'Install', 'Cancel');
+			return (selected === "Install");
 		}
 	}
 

--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -32,6 +32,7 @@ export class LanguageServerInstaller {
 		} catch (err) {
 			if (versionString == defaultVersionString) { throw err; }
 			console.log(`Error while finding Terraform language server release which satisfies range '${versionString}' and will reattempt with '${defaultVersionString}': ${err}`)
+			vscode.window.showWarningMessage(`No version matching ${versionString} found, searching for ${defaultVersionString} instead`);
 		}
 
 		// Attempt to find the latest release

--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -71,7 +71,7 @@ export class LanguageServerInstaller {
 		this.reporter.sendTelemetryEvent('foundLsInstalled', { terraformLsVersion: installedVersion });
 
 		if (semver.eq(this.release.version, installedVersion, { includePrerelease: true })) {
-			// Already at the specified versoin
+			// Already at the specified version
 			return false;
 		} else if (semver.gt(this.release.version, installedVersion, { includePrerelease: true })) {
 			// Upgrade


### PR DESCRIPTION
Partially solves #628 

This PR does not address any UI for selecting a version pin.  It merely adds all of the plumbing to make the version pin actually work.  A later PR would then add the UI layer.

---

Previously the Language Server would always update to the latest version however
there are scenarios where using an older version is required.  This commit adds
a new `version` configuration setting which is a semver range (as per the
@hashicorp/js-releases module). This setting is then used to find an appropriate
release when calling the Hashi release API.

This commit also adds validation on the `version` setting to ensure it is a
valid string and warns the user of the potentially bad setting.

This commit then updates the Language Server installer to not only upgrade the
server, but also downgrade it.