### PR TITLE
Bump npm requirement to 7.17.0 (latest major)

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "publisher": "hashicorp",
   "license": "MPL-2.0",
   "engines": {
-    "npm": "^7.15.1",
+    "npm": "^7.17.0",
     "vscode": "^1.50.1"
   },
   "qna": "https://discuss.hashicorp.com/c/terraform-core/terraform-editor-integrations/46",


### PR DESCRIPTION
No particular reason, just "cleaning up" before the release.