### PR TITLE
feat: add terraform destroy command

### DIFF
--- a/package.json
+++ b/package.json
@@ -192,6 +192,10 @@
       {
         "command": "terraform.plan",
         "title": "Terraform: plan"
+      },
+      {
+        "command": "terraform.destroy",
+        "title": "Terraform: destroy"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -105,7 +105,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 			await terraformCommand('validate');
 		}),
 		vscode.commands.registerCommand('terraform.destroy', async () => {
-			await terraformCommand('destroy', false);
+			const result = await vscode.window.showWarningMessage('Do you really want to destroy all resources?', { modal: true}, 'Yes');
+
+			if (result) {
+				await terraformCommand('destroy', false);
+			}
 		}),
 		vscode.workspace.onDidChangeConfiguration(
 			async (event: vscode.ConfigurationChangeEvent) => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -104,6 +104,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 		vscode.commands.registerCommand('terraform.validate', async () => {
 			await terraformCommand('validate');
 		}),
+		vscode.commands.registerCommand('terraform.destroy', async () => {
+			await terraformCommand('destroy', false);
+		}),
 		vscode.workspace.onDidChangeConfiguration(
 			async (event: vscode.ConfigurationChangeEvent) => {
 				if (event.affectsConfiguration('terraform') || event.affectsConfiguration('terraform-ls')) {


### PR DESCRIPTION
Hi all!

This PR adds the `Terraform: destroy` command and resolves #646.

When using the existing `terraformCommand` function to run the command, the user will see this prompt before the command is executed inside the terminal.

<img width="652" alt="CleanShot 2021-06-20 at 17 14 27@2x" src="https://user-images.githubusercontent.com/45985/122680351-f6532d80-d1ee-11eb-8696-8c8ef5192e17.png">

I think this prompt doesn't convey the potential danger of running destroy.

## Additional prompts

There are (at least) two more options for adding a prominent prompt before running the command.

**Option A**
This will open a modal at the position of the command palette of VSCode and ask for user confirmation.

I like this option because it keeps the user focus at the same position and locks the editor until a decision is made. 

<img width="457" alt="CleanShot 2021-06-20 at 17 22 23@2x" src="https://user-images.githubusercontent.com/45985/122680355-f7845a80-d1ee-11eb-8ba5-60f9686f8569.png">

**Option B**
This will open a warning message in the bottom right corner where most notifications appear and ask for user confirmation.

Opening the message at this position could go unnoticed, and it could seem that the command didn't do anything at all.

<img width="473" alt="CleanShot 2021-06-20 at 17 23 09@2x" src="https://user-images.githubusercontent.com/45985/122680360-f94e1e00-d1ee-11eb-925c-1dc04d952ac8.png">

## Solution

Which option do you prefer? This PR currently implements option A.

I couldn't find any tests for the other registered commands, so I added none for this new command. But I would suggest adding some kind of tests for commands, too.
