### PR TITLE
Fix DocumentSelector for multi-folder workspace

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,6 +9,21 @@ on:
       - main
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - name: Use Node.js 14.x
+        uses: actions/setup-node@v1
+        with:
+          node-version: 14.x
+      - name: npm install
+        run: npm install
+      - name: lint
+        run: npm run lint
+
   test:
     strategy:
       matrix:

--- a/package.json
+++ b/package.json
@@ -200,6 +200,7 @@
     "package": "vsce package",
     "compile": "tsc -b",
     "watch": "tsc -b -w",
+    "lint": "eslint .",
     "test-compile": "tsc -p ./",
     "test": "npm run test-compile && node ./out/test/runTest.js"
   },

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -23,7 +23,7 @@ export interface TerraformLanguageClient {
 	client: LanguageClient
 }
 
-let clients: Map<string, TerraformLanguageClient> = new Map();
+const clients: Map<string, TerraformLanguageClient> = new Map();
 
 /**
  * ClientHandler maintains lifecycles of language clients
@@ -33,7 +33,7 @@ let clients: Map<string, TerraformLanguageClient> = new Map();
 export class ClientHandler {
 	private shortUid: ShortUniqueId;
 	private pathToBinary: string;
-	private supportsMultiFolders: boolean = true;
+	private supportsMultiFolders = true;
 
 	constructor(private context: vscode.ExtensionContext, private reporter: TelemetryReporter ) {
 		this.shortUid = new ShortUniqueId();
@@ -41,13 +41,13 @@ export class ClientHandler {
 		if (this.pathToBinary) {
 			this.reporter.sendTelemetryEvent('usePathToBinary');
 		} else {
-			let installPath = path.join(context.extensionPath, 'lsp');
+			const installPath = path.join(context.extensionPath, 'lsp');
 			this.pathToBinary = path.join(installPath, 'terraform-ls');
 		}
-	};
+	}
 
 	public StartClients(folders?: string[]): vscode.Disposable[] {
-		let disposables: vscode.Disposable[] = [];
+		const disposables: vscode.Disposable[] = [];
 
 		if (this.supportsMultiFolders) {
 			if (this.GetClient()?.client.needsStart()) {
@@ -57,7 +57,7 @@ export class ClientHandler {
 
 			console.log('Starting client');
 
-			let tfClient = this.newTerraformClient();
+			const tfClient = this.newTerraformClient();
 			tfClient.client.onReady().then(async () => {
 				this.reporter.sendTelemetryEvent('startClient');
 				const multiFoldersSupported = tfClient.client.initializeResult.capabilities.workspace?.workspaceFolders?.supported;
@@ -82,7 +82,7 @@ export class ClientHandler {
 			for (const folder of folders) {
 				if (!clients.has(folder)) {
 					console.log(`Starting client for ${folder}`);
-					let folderClient = this.newTerraformClient(folder);
+					const folderClient = this.newTerraformClient(folder);
 					folderClient.client.onReady().then(() => {
 						this.reporter.sendTelemetryEvent('startClient');
 					});
@@ -95,7 +95,7 @@ export class ClientHandler {
 			}
 		}
 		return disposables;
-	};
+	}
 
 	private newTerraformClient(location?: string): TerraformLanguageClient {
 		const cmd = this.pathToBinary;
@@ -170,7 +170,7 @@ export class ClientHandler {
 			revealOutputChannelOn: 4 // hide always
 		};
 
-		let client = new LanguageClient(
+		const client = new LanguageClient(
 			id,
 			name,
 			serverOptions,
@@ -185,10 +185,10 @@ export class ClientHandler {
 		});
 
 		return {commandPrefix, client}
-	};
+	}
 
 	public async StopClients(folders?: string[]): Promise<void[]> {
-		let promises: Promise<void>[] = [];
+		const promises: Promise<void>[] = [];
 
 		if (this.supportsMultiFolders) {
 			promises.push(this.stopClient(""));
@@ -206,7 +206,7 @@ export class ClientHandler {
 			promises.push(this.stopClient(folder));
 		}
 		return Promise.all(promises);
-	};
+	}
 
 	private async stopClient(folder: string): Promise<void> {
 		if (!clients.has(folder)) {
@@ -221,7 +221,7 @@ export class ClientHandler {
 			}
 			console.log(`Client stopped for ${folder}`);
 		}).then(() => {
-			let ok = clients.delete(folder);
+			const ok = clients.delete(folder);
 			if (ok) {
 				if (folder === "") {
 					console.log('Client deleted');
@@ -238,7 +238,7 @@ export class ClientHandler {
 		}
 
 		return clients.get(this.clientName(document.toString()));
-	};
+	}
 
 	private clientName(folderName: string, workspaceFolders: readonly string[] = sortedWorkspaceFolders()): string {
 		folderName = normalizeFolderName(folderName);
@@ -248,5 +248,5 @@ export class ClientHandler {
 			folderName = getFolderName(getWorkspaceFolder(outerFolder));
 		}
 		return folderName;
-	};
+	}
 }

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -1,0 +1,252 @@
+import * as vscode from 'vscode';
+import ShortUniqueId from 'short-unique-id';
+import {
+	Executable,
+	LanguageClient,
+	LanguageClientOptions,
+	ServerOptions,
+	State,
+	DocumentSelector
+} from 'vscode-languageclient/node';
+import {
+	config,
+	getFolderName,
+	getWorkspaceFolder,
+	normalizeFolderName,
+	sortedWorkspaceFolders
+} from './vscodeUtils';
+import * as path from 'path';
+import TelemetryReporter from 'vscode-extension-telemetry';
+
+export interface TerraformLanguageClient {
+	commandPrefix: string,
+	client: LanguageClient
+}
+
+let clients: Map<string, TerraformLanguageClient> = new Map();
+
+/**
+ * ClientHandler maintains lifecycles of language clients
+ * based on the server's capabilities (whether multi-folder
+ * workspaces are supported).
+ */
+export class ClientHandler {
+	private shortUid: ShortUniqueId;
+	private pathToBinary: string;
+	private supportsMultiFolders: boolean = true;
+
+	constructor(private context: vscode.ExtensionContext, private reporter: TelemetryReporter ) {
+		this.shortUid = new ShortUniqueId();
+		this.pathToBinary = config('terraform').get('languageServer.pathToBinary');
+		if (this.pathToBinary) {
+			this.reporter.sendTelemetryEvent('usePathToBinary');
+		} else {
+			let installPath = path.join(context.extensionPath, 'lsp');
+			this.pathToBinary = path.join(installPath, 'terraform-ls');
+		}
+	};
+
+	public StartClients(folders?: string[]): vscode.Disposable[] {
+		let disposables: vscode.Disposable[] = [];
+
+		if (this.supportsMultiFolders) {
+			if (this.GetClient()?.client.needsStart()) {
+				console.log(`No need to start another client for ${folders}`)
+				return disposables;
+			}
+
+			console.log('Starting client');
+
+			let tfClient = this.newTerraformClient();
+			tfClient.client.onReady().then(async () => {
+				this.reporter.sendTelemetryEvent('startClient');
+				const multiFoldersSupported = tfClient.client.initializeResult.capabilities.workspace?.workspaceFolders?.supported;
+				console.log(`Multi-folder support: ${multiFoldersSupported}`);
+
+				if (!multiFoldersSupported) {
+					// restart is needed to launch folder-focused instances
+					console.log('Restarting clients as folder-focused');
+					await this.StopClients(folders);
+					this.supportsMultiFolders = false;
+					this.StartClients(folders);
+				}
+			});
+
+			disposables.push(tfClient.client.start());
+			clients.set("", tfClient);
+
+			return disposables;
+		}
+
+		if (folders && folders.length > 0) {
+			for (const folder of folders) {
+				if (!clients.has(folder)) {
+					console.log(`Starting client for ${folder}`);
+					let folderClient = this.newTerraformClient(folder);
+					folderClient.client.onReady().then(() => {
+						this.reporter.sendTelemetryEvent('startClient');
+					});
+
+					disposables.push(folderClient.client.start());
+					clients.set(folder, folderClient);
+				} else {
+					console.log(`Client for folder: ${folder} already started`);
+				}
+			}
+		}
+		return disposables;
+	};
+
+	private newTerraformClient(location?: string): TerraformLanguageClient {
+		const cmd = this.pathToBinary;
+		const binaryName = cmd.split('/').pop();
+
+		const serverArgs: string[] = config('terraform').get('languageServer.args');
+		const experimentalFeatures = config('terraform-ls').get('experimentalFeatures');
+
+		let channelName = `${binaryName}`;
+		let id = `languageServer`
+		let name = `Language Server`
+		let wsFolder: vscode.WorkspaceFolder;
+		let rootModulePaths: string[];
+		let excludeModulePaths: string[];
+		let documentSelector: DocumentSelector;
+		let outputChannel: vscode.OutputChannel;
+		if (location) {
+			channelName = `${binaryName}: ${location}`;
+			id = `languageServer/${location}`
+			name = `Language Server: ${location}`
+			wsFolder = getWorkspaceFolder(location);
+			documentSelector = [
+				{ scheme: 'file', language: 'terraform', pattern: `${wsFolder.uri.fsPath}/**/*` },
+				{ scheme: 'file', language: 'terraform-vars', pattern: `${wsFolder.uri.fsPath}/**/*` }
+			]
+			rootModulePaths = config('terraform-ls', wsFolder).get('rootModules');
+			excludeModulePaths = config('terraform-ls', wsFolder).get('excludeRootModules');
+			outputChannel = vscode.window.createOutputChannel(channelName);
+			outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')} for folder: ${location}`);
+		} else {
+			documentSelector = [
+				{ scheme: 'file', language: 'terraform' },
+				{ scheme: 'file', language: 'terraform-vars' }
+			]
+			rootModulePaths = config('terraform-ls').get('rootModules');
+			excludeModulePaths = config('terraform-ls').get('excludeRootModules');
+			outputChannel = vscode.window.createOutputChannel(channelName);
+			outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
+		}
+
+		if (rootModulePaths.length > 0 && excludeModulePaths.length > 0) {
+			throw new Error('Only one of rootModules and excludeRootModules can be set at the same time, please remove the conflicting config and reload');
+		}
+
+		const commandPrefix = this.shortUid.seq();
+		let initializationOptions = { commandPrefix, experimentalFeatures };
+		if (rootModulePaths.length > 0) {
+			initializationOptions = Object.assign(initializationOptions, { rootModulePaths });
+		}
+		if (excludeModulePaths.length > 0) {
+			initializationOptions = Object.assign(initializationOptions, { excludeModulePaths });
+		}
+
+		const executable: Executable = {
+			command: cmd,
+			args: serverArgs,
+			options: {}
+		};
+		const serverOptions: ServerOptions = {
+			run: executable,
+			debug: executable
+		};
+		const clientOptions: LanguageClientOptions = {
+			documentSelector: documentSelector,
+			workspaceFolder: wsFolder,
+			initializationOptions: initializationOptions,
+			initializationFailedHandler: (error) => {
+				this.reporter.sendTelemetryException(error);
+				return false;
+			},
+			outputChannel: outputChannel,
+			revealOutputChannelOn: 4 // hide always
+		};
+
+		let client = new LanguageClient(
+			id,
+			name,
+			serverOptions,
+			clientOptions
+		);
+
+		client.onDidChangeState((event) => {
+			if (event.newState === State.Stopped) {
+				clients.delete(location);
+				this.reporter.sendTelemetryEvent('stopClient');
+			}
+		});
+
+		return {commandPrefix, client}
+	};
+
+	public async StopClients(folders?: string[]): Promise<void[]> {
+		let promises: Promise<void>[] = [];
+
+		if (this.supportsMultiFolders) {
+			promises.push(this.stopClient(""));
+			return Promise.all(promises);
+		}
+
+		if (!folders) {
+			folders = [];
+			for (const key of clients.keys()) {
+				folders.push(key);
+			}
+		}
+
+		for (const folder of folders) {
+			promises.push(this.stopClient(folder));
+		}
+		return Promise.all(promises);
+	};
+
+	private async stopClient(folder: string): Promise<void> {
+		if (!clients.has(folder)) {
+			console.log(`Attempted to stop a client for folder: ${folder} but no client exists`);
+			return;
+		}
+		
+		return clients.get(folder).client.stop().then(() => {
+			if (folder === "") {
+				console.log('Client stopped');
+				return
+			}
+			console.log(`Client stopped for ${folder}`);
+		}).then(() => {
+			let ok = clients.delete(folder);
+			if (ok) {
+				if (folder === "") {
+					console.log('Client deleted');
+					return
+				}
+				console.log(`Client deleted for ${folder}`);
+			}
+		});
+	}
+
+	public GetClient(document?: vscode.Uri): TerraformLanguageClient {
+		if (this.supportsMultiFolders) {
+			return clients.get("");
+		}
+
+		return clients.get(this.clientName(document.toString()));
+	};
+
+	private clientName(folderName: string, workspaceFolders: readonly string[] = sortedWorkspaceFolders()): string {
+		folderName = normalizeFolderName(folderName);
+		const outerFolder = workspaceFolders.find(element => folderName.startsWith(element));
+		// If this folder isn't nested, the found item will be itself
+		if (outerFolder && (outerFolder !== folderName)) {
+			folderName = getFolderName(getWorkspaceFolder(outerFolder));
+		}
+		return folderName;
+	};
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -37,7 +37,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 
 	clientHandler = new ClientHandler(context, reporter);
 
-	let installPath = path.join(context.extensionPath, 'lsp');
+	const installPath = path.join(context.extensionPath, 'lsp');
 
 	// get rid of pre-2.0.0 settings
 	if (config('terraform').has('languageServer.enabled')) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,40 +1,25 @@
 import * as vscode from 'vscode';
 import {
-	LanguageClientOptions,
 	ExecuteCommandParams,
 	ExecuteCommandRequest
 } from 'vscode-languageclient';
 import {
-	LanguageClient,
-	ServerOptions,
-	Executable,
-	State as ClientState
+	LanguageClient
 } from 'vscode-languageclient/node';
 import { Utils } from 'vscode-uri'
 import * as path from 'path';
-import ShortUniqueId from 'short-unique-id';
 import TelemetryReporter from 'vscode-extension-telemetry';
 
 import { LanguageServerInstaller } from './languageServerInstaller';
+import { ClientHandler, TerraformLanguageClient } from './clientHandler';
 import {
 	config,
-	getFolderName,
-	getWorkspaceFolder,
-	normalizeFolderName,
 	prunedFolderNames,
-	sortedWorkspaceFolders
 } from './vscodeUtils';
 import {
 	SingleInstanceTimeout,
 } from './utils';
 
-interface terraformLanguageClient {
-	commandPrefix: string,
-	client: LanguageClient
-}
-
-const clients: Map<string, terraformLanguageClient> = new Map();
-const shortUid = new ShortUniqueId();
 const terraformStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
 
 // Telemetry config
@@ -42,14 +27,17 @@ const extensionId = 'hashicorp.terraform';
 const appInsightsKey = '885372d2-6f3c-499f-9d25-b8b219983a52';
 let reporter: TelemetryReporter;
 
-let installPath: string;
+let clientHandler: ClientHandler;
 const languageServerUpdater = new SingleInstanceTimeout();
 
 export async function activate(context: vscode.ExtensionContext): Promise<any> {
 	const extensionVersion = vscode.extensions.getExtension(extensionId).packageJSON.version;
 	reporter = new TelemetryReporter(extensionId, extensionVersion, appInsightsKey);
 	context.subscriptions.push(reporter);
-	installPath = path.join(context.extensionPath, 'lsp');
+
+	clientHandler = new ClientHandler(context, reporter);
+
+	let installPath = path.join(context.extensionPath, 'lsp');
 
 	// get rid of pre-2.0.0 settings
 	if (config('terraform').has('languageServer.enabled')) {
@@ -67,7 +55,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 				const current = config('terraform').get('languageServer');
 				await config('terraform').update('languageServer', Object.assign(current, { external: true }), vscode.ConfigurationTarget.Global);
 			}
-			return updateLanguageServer();
+			return updateLanguageServer(clientHandler, installPath);
 		}),
 		vscode.commands.registerCommand('terraform.disableLanguageServer', async () => {
 			if (enabled()) {
@@ -75,10 +63,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 				await config('terraform').update('languageServer', Object.assign(current, { external: false }), vscode.ConfigurationTarget.Global);
 			}
 			languageServerUpdater.clear();
-			return stopClients();
+			return clientHandler.StopClients();
 		}),
 		vscode.commands.registerCommand('terraform.apply', async () => {
-			await terraformCommand('apply', false);
+			await terraformCommand('apply', false, clientHandler);
 		}),
 		vscode.commands.registerCommand('terraform.init', async () => {
 			const selected = await vscode.window.showOpenDialog({
@@ -90,19 +78,19 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 			});
 			if (selected) {
 				const moduleUri = selected[0];
-				const client = getDocumentClient(moduleUri);
+				const client = clientHandler.GetClient(moduleUri);
 				const requestParams: ExecuteCommandParams = { command: `${client.commandPrefix}.terraform-ls.terraform.init`, arguments: [`uri=${moduleUri}`] };
 				await execWorkspaceCommand(client.client, requestParams);
 			}
 		}),
 		vscode.commands.registerCommand('terraform.initCurrent', async () => {
-			await terraformCommand('init');
+			await terraformCommand('init', true, clientHandler);
 		}),
 		vscode.commands.registerCommand('terraform.plan', async () => {
-			await terraformCommand('plan', false);
+			await terraformCommand('plan', false, clientHandler);
 		}),
 		vscode.commands.registerCommand('terraform.validate', async () => {
-			await terraformCommand('validate');
+			await terraformCommand('validate', true, clientHandler);
 		}),
 		vscode.workspace.onDidChangeConfiguration(
 			async (event: vscode.ConfigurationChangeEvent) => {
@@ -118,10 +106,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 		vscode.workspace.onDidChangeWorkspaceFolders(
 			async (event: vscode.WorkspaceFoldersChangeEvent) => {
 				if (event.removed.length > 0) {
-					await stopClients(prunedFolderNames(event.removed));
+					await clientHandler.StopClients(prunedFolderNames(event.removed));
 				}
 				if (event.added.length > 0) {
-					await startClients(prunedFolderNames(event.added));
+					clientHandler.StartClients(prunedFolderNames(event.added));
 				}
 			}
 		),
@@ -132,7 +120,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 				// TODO: Check initializationOptions for command presence instead of pathToBinary
 				if (event && vscode.workspace.workspaceFolders[0] && !config('terraform').get('languageServer.pathToBinary')) {
 					const documentUri = event.document.uri;
-					const client = getDocumentClient(documentUri);
+					const client = clientHandler.GetClient(documentUri);
 					const moduleUri = Utils.dirname(documentUri);
 
 					if (client) {
@@ -168,14 +156,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 	}
 
 	// export public API
-	return { getDocumentClient, moduleCallers };
+	return { clientHandler, moduleCallers };
 }
 
 export function deactivate(): Promise<void[]> {
-	return stopClients();
+	return clientHandler.StopClients();
 }
 
-async function updateLanguageServer() {
+async function updateLanguageServer(clientHandler: ClientHandler, installPath: string) {
 	const delay = 1000 * 60 * 60 * 24;
 	languageServerUpdater.timeout(updateLanguageServer, delay); // check for new updates every 24hrs
 
@@ -184,7 +172,7 @@ async function updateLanguageServer() {
 		const installer = new LanguageServerInstaller(installPath, reporter);
 		const install = await installer.needsInstall();
 		if (install) {
-			await stopClients();
+			await clientHandler.StopClients();
 			try {
 				await installer.install();
 			} catch (err) {
@@ -196,150 +184,7 @@ async function updateLanguageServer() {
 			}
 		}
 	}
-	return startClients(); // on repeat runs with no install, this will be a no-op
-}
-
-async function startClients(folders = prunedFolderNames()) {
-	console.log('Starting:', folders);
-	const command = await pathToBinary();
-	const disposables: vscode.Disposable[] = [];
-
-	const firstClient = configureClient(command, folders[0])
-	firstClient.client.onReady().then(() => {
-		reporter.sendTelemetryEvent('startClient');
-		const multiFoldersSupported = firstClient.client.initializeResult.capabilities.workspace?.workspaceFolders?.supported;
-
-		console.log("Multi-folder support: ", multiFoldersSupported);
-		const remainingFolders = folders.slice(1);
-		for (const folder of remainingFolders) {
-			if (multiFoldersSupported) {
-				// Reuse the same client if server supports multiple workspace folders
-				clients.set(folder, firstClient);
-				continue
-			}
-
-			if (!clients.has(folder)) {
-				const c = configureClient(command, folder);
-				disposables.push(c.client.start());
-				clients.set(folder, c);
-			} else {
-				console.log(`Client for folder: ${folder} already started`);
-			}
-		}
-	});
-
-	disposables.push(firstClient.client.start());
-	clients.set(folders[0], firstClient);
-	
-	return disposables;
-}
-
-function configureClient(binPath:string, folder: string) {
-	const commandPrefix = shortUid.seq();
-	const client = newClient(binPath, folder, commandPrefix);
-
-	client.onDidChangeState((event) => {
-		if (event.newState === ClientState.Stopped) {
-			clients.delete(folder);
-			reporter.sendTelemetryEvent('stopClient');
-		}
-	});
-	return { commandPrefix, client }
-}
-
-function newClient(cmd: string, location: string, commandPrefix: string) {
-	const binaryName = cmd.split('/').pop();
-	const channelName = `${binaryName}: ${location}`;
-	const f: vscode.WorkspaceFolder = getWorkspaceFolder(location);
-	const serverArgs: string[] = config('terraform').get('languageServer.args');
-	const rootModulePaths: string[] = config('terraform-ls', f).get('rootModules');
-	const excludeModulePaths: string[] = config('terraform-ls', f).get('excludeRootModules');
-	const experimentalFeatures = config('terraform-ls').get('experimentalFeatures');
-
-	if (rootModulePaths.length > 0 && excludeModulePaths.length > 0) {
-		throw new Error('Only one of rootModules and excludeRootModules can be set at the same time, please remove the conflicting config and reload');
-	}
-
-	let initializationOptions = { commandPrefix, experimentalFeatures };
-	if (rootModulePaths.length > 0) {
-		initializationOptions = Object.assign(initializationOptions, { rootModulePaths });
-	}
-	if (excludeModulePaths.length > 0) {
-		initializationOptions = Object.assign(initializationOptions, { excludeModulePaths });
-	}
-
-	const setup = vscode.window.createOutputChannel(channelName);
-	setup.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')} for folder: ${location}`);
-
-	const executable: Executable = {
-		command: cmd,
-		args: serverArgs,
-		options: {}
-	};
-	const serverOptions: ServerOptions = {
-		run: executable,
-		debug: executable
-	};
-	const clientOptions: LanguageClientOptions = {
-		documentSelector: [{ scheme: 'file', language: 'terraform', pattern: `${f.uri.fsPath}/**/*` },
-		{ scheme: 'file', language: 'terraform-vars', pattern: `${f.uri.fsPath}/**/*` }],
-		workspaceFolder: f,
-		initializationOptions: initializationOptions,
-		initializationFailedHandler: (error) => {
-			reporter.sendTelemetryException(error);
-			return false;
-		},
-		outputChannel: setup,
-		revealOutputChannelOn: 4 // hide always
-	};
-
-	return new LanguageClient(
-		`languageServer/${location}`,
-		`Language Server: ${location}`,
-		serverOptions,
-		clientOptions
-	);
-}
-
-async function stopClients(folders = prunedFolderNames()) {
-	console.log('Stopping:', folders);
-	const promises: Thenable<void>[] = [];
-	for (const folder of folders) {
-		if (clients.has(folder)) {
-			promises.push(clients.get(folder).client.stop());
-		} else {
-			console.log(`Attempted to stop a client for folder: ${folder} but no client exists`);
-		}
-	}
-	return Promise.all(promises);
-}
-
-let _pathToBinaryPromise: Promise<string>;
-async function pathToBinary(): Promise<string> {
-	if (!_pathToBinaryPromise) {
-		let command: string = config('terraform').get('languageServer.pathToBinary');
-		if (command) { // Skip install/upgrade if user has set custom binary path
-			reporter.sendTelemetryEvent('usePathToBinary');
-		} else {
-			command = path.join(installPath, 'terraform-ls');
-		}
-		_pathToBinaryPromise = Promise.resolve(command);
-	}
-	return _pathToBinaryPromise;
-}
-
-function clientName(folderName: string, workspaceFolders: readonly string[] = sortedWorkspaceFolders()): string {
-	folderName = normalizeFolderName(folderName);
-	const outerFolder = workspaceFolders.find(element => folderName.startsWith(element));
-	// If this folder isn't nested, the found item will be itself
-	if (outerFolder && (outerFolder !== folderName)) {
-		folderName = getFolderName(getWorkspaceFolder(outerFolder));
-	}
-	return folderName;
-}
-
-function getDocumentClient(document: vscode.Uri): terraformLanguageClient {
-	return clients.get(clientName(document.toString()));
+	return clientHandler.StartClients(prunedFolderNames()); // on repeat runs with no install, this will be a no-op
 }
 
 function execWorkspaceCommand(client: LanguageClient, params: ExecuteCommandParams): Promise<any> {
@@ -356,22 +201,22 @@ interface moduleCallersResponse {
 	moduleCallers: moduleCaller[]
 }
 
-async function modulesCallersCommand(languageClient: terraformLanguageClient, moduleUri: string): Promise<any> {
+async function modulesCallersCommand(languageClient: TerraformLanguageClient, moduleUri: string): Promise<any> {
 	const requestParams: ExecuteCommandParams = { command: `${languageClient.commandPrefix}.terraform-ls.module.callers`, arguments: [`uri=${moduleUri}`] };
 	return execWorkspaceCommand(languageClient.client, requestParams);
 }
 
-async function moduleCallers(languageClient: terraformLanguageClient, moduleUri: string): Promise<moduleCallersResponse> {
+async function moduleCallers(languageClient: TerraformLanguageClient, moduleUri: string): Promise<moduleCallersResponse> {
 	const response = await modulesCallersCommand(languageClient, moduleUri);
 	const moduleCallers: moduleCaller[] = response.callers;
 
 	return { version: response.v, moduleCallers };
 }
 
-async function terraformCommand(command: string, languageServerExec = true): Promise<any> {
+async function terraformCommand(command: string, languageServerExec = true, clientHandler: ClientHandler): Promise<any> {
 	if (vscode.window.activeTextEditor) {
 		const documentUri = vscode.window.activeTextEditor.document.uri;
-		const languageClient = getDocumentClient(documentUri);
+		const languageClient = clientHandler.GetClient(documentUri);
 
 		const moduleUri = Utils.dirname(documentUri)
 		const response = await moduleCallers(languageClient, moduleUri.toString());

--- a/src/test/workspaces.test.ts
+++ b/src/test/workspaces.test.ts
@@ -2,13 +2,14 @@ import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { Utils } from 'vscode-uri';
 import { getDocUri, open, testFolderPath } from './helper';
+
 const ext = vscode.extensions.getExtension('hashicorp.terraform');
 
 suite('moduleCallers', () => {
 	test('should execute language server command', async () => {
 		const documentUri = getDocUri('modules/sample.tf');
 		await open(documentUri);
-		const client = ext.exports.clientHandler.GetClient(documentUri);
+		const client = ext.exports.clientHandler.getClient(documentUri);
 		const moduleUri = Utils.dirname(documentUri).toString();
 		const response = await ext.exports.moduleCallers(client, moduleUri);
 		assert.strictEqual(response.moduleCallers.length, 1);

--- a/src/test/workspaces.test.ts
+++ b/src/test/workspaces.test.ts
@@ -8,7 +8,7 @@ suite('moduleCallers', () => {
 	test('should execute language server command', async () => {
 		const documentUri = getDocUri('modules/sample.tf');
 		await open(documentUri);
-		const client = ext.exports.getDocumentClient(documentUri);
+		const client = ext.exports.clientHandler.GetClient(documentUri);
 		const moduleUri = Utils.dirname(documentUri).toString();
 		const response = await ext.exports.moduleCallers(client, moduleUri);
 		assert.strictEqual(response.moduleCallers.length, 1);


### PR DESCRIPTION
Fixes #685 

### Does it affect me?

This bug was introduced in 2.12.0 and affects any folders within workspaces of multiple folders which are not descendants of the 1st folder in the workspace.

For example, if workspace has two folders, and
 - 1st one `/my-repo` and 2nd `/my-repo/subfolder` then that workspace is **not** affected by the bug
 - 1st one `/my-repo` and 2nd `/another-repo` then that workspace **is** affected by the bug

The bug affects only users on language server `0.19+` (which is the first version that supports multiple folders natively).

### How did this happen?

Prior to this patch we would always launch the first instance of a client/server, to obtain the server capabilities and see if the server supports multiple folders. We would then continue launching more instances for any more folders if it doesn't, or reuse the same instance if it does.

The problem with reusing the same instance is that the instance is launched with a very specific document selector:

https://github.com/hashicorp/vscode-terraform/blob/583bdf59a19d46a0f5e2325f0d7a11379e0bd337/src/extension.ts#L284-L285

This prevents the client from receiving/processing documents outside of that first folder.

We cannot just remove the `pattern` part because that would make potentially multiple instances of the server (which don't support multi-folder natively) to **each** receive documents for the **whole workspace** (all folders) - resulting in duplicate requests and e.g. duplicate completion items.

Language clients are also immutable after launch, which includes the `documentSelector`.

### How is it being fixed?

Instead of _universally_ reusing the same client, we "optimistically" launch first one which has the "greedy" document selector - so that if the server does support multi-folder, no further action is needed.

If server does _not_ support multiple folders though we will shut down that instance and launch new ones with more narrowly scoped `documentSelector` - each targeting its own folder only.

--- 

While testing this I noticed the following error:

```
rejected promise not handled within 1 second: Error [ERR_STREAM_WRITE_AFTER_END]: write after end
stack trace: Error [ERR_STREAM_WRITE_AFTER_END]: write after end
	at Socket.write (internal/streams/writable.js:292:11)
```

The root cause is basically the upstream LSP library not waiting for `exit` request to be received before closing the channel.
This was fixed in https://github.com/microsoft/vscode-languageserver-node/pull/776 but to my knowledge that error isn't surfaced to the user and doesn't actually affect the user in any way. The server is already able to shut itself down when it receives `EOF` anyway - it just logs that as "dirty" shutdown.