### PR TITLE
fix language server update logic

### DIFF
--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -52,7 +52,7 @@ export class ClientHandler {
 		const disposables: vscode.Disposable[] = [];
 
 		if (this.supportsMultiFolders) {
-			if (this.getClient()?.client.needsStart()) {
+			if (clients.has(MULTI_FOLDER_CLIENT)) {
 				console.log(`No need to start another client for ${folders}`)
 				return disposables;
 			}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,8 +164,10 @@ export function deactivate(): Promise<void[]> {
 }
 
 async function updateLanguageServer(clientHandler: ClientHandler, installPath: string) {
-	const delay = 1000 * 60 * 60 * 24;
-	languageServerUpdater.timeout(updateLanguageServer, delay); // check for new updates every 24hrs
+	const hour = 1000 * 60 * 60;
+	languageServerUpdater.timeout(function() {
+		updateLanguageServer(clientHandler, installPath);
+	}, 24 * hour);
 
 	// skip install if a language server binary path is set
 	if (!config('terraform').get('languageServer.pathToBinary')) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -164,6 +164,7 @@ export function deactivate(): Promise<void[]> {
 }
 
 async function updateLanguageServer(clientHandler: ClientHandler, installPath: string) {
+	console.log('Checking for language server updates...')
 	const hour = 1000 * 60 * 60;
 	languageServerUpdater.timeout(function() {
 		updateLanguageServer(clientHandler, installPath);


### PR DESCRIPTION
This PR includes two fixes:

## Broken LS updates

As part of the refactoring and fixing a different bug in #688 I didn't notice that the `updateLanguageServer` was previously argument-less function and it is still passed as such into the update time ticker, despite needing two arguments.

This leads to the following error popup every time an update is attempted (every 24 hours):

![Screenshot 2021-07-16 at 17 02 30](https://user-images.githubusercontent.com/287584/125976324-6085ce22-8e77-44cb-b5a2-39243c3552ad.png)

## Duplicate LS instances on update

This was only uncovered once LS updates were actually fixed - i.e. users are technically not affected by this as updating isn't hitting the codepath anyway.

Previously `this.getClient()?.client.needsStart()` was used to obtain the client and check if it _needs start_ (meaning if it's not started _yet_) which is actually the opposite of what we need. 🤦🏻 

I instead simplified that to `has()` - which is already used for the individual clients. It does mean we're not checking the real state of the client, but we never did and we wouldn't push a new client into the set unless it was started anyway.