### PR TITLE
fix: launch LS even if path contains escapable characters

### DIFF
--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -119,13 +119,13 @@ async function getLsVersion(dirPath: string): Promise<string> {
 	fs.accessSync(binPath, fs.constants.X_OK);
 
 	try {
-		const jsonCmd: { stdout: string } = await exec(`${binPath} version -json`);
+		const jsonCmd: { stdout: string } = await exec(binPath, ['version', '-json']);
 		const jsonOutput = JSON.parse(jsonCmd.stdout);
 		return jsonOutput.version
 	} catch (err) {
 		// assume older version of LS which didn't have json flag
 		if (err.status != 0) {
-			const plainCmd: { stdout: string, stderr: string } = await exec(`${binPath} -version`);
+			const plainCmd: { stdout: string, stderr: string } = await exec(binPath, ['-version']);
 			return plainCmd.stdout || plainCmd.stderr;
 		} else {
 			throw err

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -5,7 +5,7 @@ import { exec } from '../utils';
 async function terraformInit() {
   const cwd = process.cwd();
   process.chdir('testFixture');
-  const { stdout } = await exec('terraform init -no-color');
+  const { stdout } = await exec('terraform', ['init', '-no-color']);
   console.log(stdout);
   process.chdir(cwd);
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,9 +1,9 @@
 import * as cp from 'child_process';
 import * as https from 'https';
 
-export function exec(cmd: string): Promise<{ stdout: string, stderr: string }> {
+export function exec(cmd: string, args: readonly string[]): Promise<{ stdout: string, stderr: string }> {
 	return new Promise((resolve, reject) => {
-		cp.exec(cmd, (err, stdout, stderr) => {
+		cp.execFile(cmd, args, (err, stdout, stderr) => {
 			if (err) {
 				return reject(err);
 			}


### PR DESCRIPTION
Unblocks #691 

--- 

This fixes a long undiscovered bug which would cause the LS to never launch
in situation where there is an escapable character (such as whitespace)
in the *default* path leading to the LS binary.

The root cause is string concatenation of full commands (and
`child_process.exec` API expecteding already escaped string)
when checking LS version, instead of passing arguments individually.

This problem would also never be surfaced to the user due to some other
issues with error reporting (that can be addressed in a separate PR).

### Users Affected

This affects all v2 versions from what I can tell (based on the codepath).

### Reproduction

First time launch after fresh installation (or upgrade) on Windows with account called `Radek Simko` (with whitespace) + empty settings:

![Screenshot 2021-07-19 at 16 10 34](https://user-images.githubusercontent.com/287584/126183174-bf3cac72-08d8-40b0-9fb9-9988aeb4f673.png)

After restarting VS Code:
![Screenshot 2021-07-19 at 16 12 12](https://user-images.githubusercontent.com/287584/126183474-50e16324-2ff2-4a66-bf6d-cd7bba310f94.png)
