### PR TITLE
Extract logic for determining LS paths

### DIFF
--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -17,16 +17,11 @@ import {
 	sortedWorkspaceFolders
 } from './vscodeUtils';
 import TelemetryReporter from 'vscode-extension-telemetry';
+import { ServerPath } from './serverPath';
 
 export interface TerraformLanguageClient {
 	commandPrefix: string,
 	client: LanguageClient
-}
-
-interface pathGetter {
-	binPath(): string
-	binName(): string
-	hasCustomBinPath(): boolean
 }
 
 const MULTI_FOLDER_CLIENT = "";
@@ -41,7 +36,7 @@ export class ClientHandler {
 	private shortUid: ShortUniqueId;
 	private supportsMultiFolders = true;
 
-	constructor(private lsPath: pathGetter, private reporter: TelemetryReporter ) {
+	constructor(private lsPath: ServerPath, private reporter: TelemetryReporter ) {
 		this.shortUid = new ShortUniqueId();
 		if (lsPath.hasCustomBinPath()) {
 			this.reporter.sendTelemetryEvent('usePathToBinary');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,22 +3,14 @@ import {
 	ExecuteCommandParams,
 	ExecuteCommandRequest
 } from 'vscode-languageclient';
-import {
-	LanguageClient
-} from 'vscode-languageclient/node';
+import { LanguageClient } from 'vscode-languageclient/node';
 import { Utils } from 'vscode-uri'
 import TelemetryReporter from 'vscode-extension-telemetry';
-
 import { LanguageServerInstaller } from './languageServerInstaller';
 import { ClientHandler, TerraformLanguageClient } from './clientHandler';
-import {
-	config,
-	prunedFolderNames,
-	ServerPath
-} from './vscodeUtils';
-import {
-	SingleInstanceTimeout,
-} from './utils';
+import { config, prunedFolderNames } from './vscodeUtils';
+import { SingleInstanceTimeout } from './utils';
+import { ServerPath } from './serverPath';
 
 const terraformStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,6 @@ import {
 	LanguageClient
 } from 'vscode-languageclient/node';
 import { Utils } from 'vscode-uri'
-import * as path from 'path';
 import TelemetryReporter from 'vscode-extension-telemetry';
 
 import { LanguageServerInstaller } from './languageServerInstaller';
@@ -15,6 +14,7 @@ import { ClientHandler, TerraformLanguageClient } from './clientHandler';
 import {
 	config,
 	prunedFolderNames,
+	ServerPath
 } from './vscodeUtils';
 import {
 	SingleInstanceTimeout,
@@ -35,9 +35,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 	reporter = new TelemetryReporter(extensionId, extensionVersion, appInsightsKey);
 	context.subscriptions.push(reporter);
 
-	clientHandler = new ClientHandler(context, reporter);
-
-	const installPath = path.join(context.extensionPath, 'lsp');
+	const lsPath = new ServerPath(context);
+	clientHandler = new ClientHandler(lsPath, reporter);
 
 	// get rid of pre-2.0.0 settings
 	if (config('terraform').has('languageServer.enabled')) {
@@ -55,7 +54,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 				const current = config('terraform').get('languageServer');
 				await config('terraform').update('languageServer', Object.assign(current, { external: true }), vscode.ConfigurationTarget.Global);
 			}
-			return updateLanguageServer(clientHandler, installPath);
+			return updateLanguageServer(clientHandler, lsPath);
 		}),
 		vscode.commands.registerCommand('terraform.disableLanguageServer', async () => {
 			if (enabled()) {
@@ -118,7 +117,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 				// Make sure there's an open document in a folder
 				// Also check whether they're running a different language server
 				// TODO: Check initializationOptions for command presence instead of pathToBinary
-				if (event && vscode.workspace.workspaceFolders[0] && !config('terraform').get('languageServer.pathToBinary')) {
+				if (event && vscode.workspace.workspaceFolders[0] && !lsPath.hasCustomBinPath()) {
 					const documentUri = event.document.uri;
 					const client = clientHandler.getClient(documentUri);
 					const moduleUri = Utils.dirname(documentUri);
@@ -163,16 +162,16 @@ export function deactivate(): Promise<void[]> {
 	return clientHandler.stopClients();
 }
 
-async function updateLanguageServer(clientHandler: ClientHandler, installPath: string) {
+async function updateLanguageServer(clientHandler: ClientHandler, lsPath: ServerPath) {
 	console.log('Checking for language server updates...')
 	const hour = 1000 * 60 * 60;
 	languageServerUpdater.timeout(function() {
-		updateLanguageServer(clientHandler, installPath);
+		updateLanguageServer(clientHandler, lsPath);
 	}, 24 * hour);
 
 	// skip install if a language server binary path is set
-	if (!config('terraform').get('languageServer.pathToBinary')) {
-		const installer = new LanguageServerInstaller(installPath, reporter);
+	if (!lsPath.hasCustomBinPath()) {
+		const installer = new LanguageServerInstaller(lsPath, reporter);
 		const install = await installer.needsInstall();
 		if (install) {
 			await clientHandler.stopClients();

--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -4,20 +4,15 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as semver from 'semver';
 import TelemetryReporter from 'vscode-extension-telemetry';
-
 import { exec } from './utils';
+import { ServerPath } from './serverPath';
 import { Release, getRelease } from '@hashicorp/js-releases';
 
 const extensionVersion = vscode.extensions.getExtension('hashicorp.terraform').packageJSON.version;
 
-interface pathGetter {
-	installPath(): string;
-	binPath(): string
-}
-
 export class LanguageServerInstaller {
 	constructor(
-		private lsPath: pathGetter,
+		private lsPath: ServerPath,
 		private reporter: TelemetryReporter
 	) { }
 
@@ -120,7 +115,7 @@ export class LanguageServerInstaller {
 	}
 }
 
-async function getLsVersion(lsPath: pathGetter): Promise<string> {
+async function getLsVersion(lsPath: ServerPath): Promise<string> {
 	const binPath = lsPath.binPath();
 	fs.accessSync(binPath, fs.constants.X_OK);
 

--- a/src/serverPath.ts
+++ b/src/serverPath.ts
@@ -1,0 +1,40 @@
+import * as vscode from 'vscode';
+import * as path from 'path';
+
+const INSTALL_FOLDER_NAME = 'lsp';
+const CUSTOM_BIN_PATH_OPTION_NAME = 'languageServer.pathToBinary';
+
+export class ServerPath {
+	private customBinPath: string;
+
+	constructor(private context: vscode.ExtensionContext ) {
+		this.customBinPath = vscode.workspace.getConfiguration('terraform').get(CUSTOM_BIN_PATH_OPTION_NAME);
+	}
+
+	public installPath(): string {
+		return this.context.asAbsolutePath(INSTALL_FOLDER_NAME);
+	}
+
+	public hasCustomBinPath(): boolean {
+		return !!this.customBinPath;
+	}
+
+	public binPath(): string {
+		if (this.hasCustomBinPath()) {
+			return this.customBinPath;
+		}
+
+		return path.resolve(this.installPath(), this.binName());
+	}
+
+	public binName(): string {
+		if (this.hasCustomBinPath()) {
+			return path.basename(this.customBinPath);
+		}
+
+		if (process.platform === 'win32') {
+			return 'terraform-ls.exe'
+		}
+		return 'terraform-ls';
+	}
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,4 @@
 import * as cp from 'child_process';
-import * as https from 'https';
 
 export function exec(cmd: string, args: readonly string[]): Promise<{ stdout: string, stderr: string }> {
 	return new Promise((resolve, reject) => {
@@ -9,25 +8,6 @@ export function exec(cmd: string, args: readonly string[]): Promise<{ stdout: st
 			}
 			return resolve({ stdout, stderr });
 		});
-	});
-}
-
-export function httpsRequest(url: string, options: https.RequestOptions = {}, encoding = 'utf8'): Promise<string> {
-	return new Promise((resolve, reject) => {
-		https.request(url, options, res => {
-			if (res.statusCode === 301 || res.statusCode === 302) { // follow redirects
-				return resolve(httpsRequest(res.headers.location, options, encoding));
-			}
-			if (res.statusCode !== 200) {
-				return reject(res.statusMessage);
-			}
-			let body = '';
-			res.setEncoding(encoding)
-				.on('data', data => body += data)
-				.on('end', () => resolve(body));
-		})
-			.on('error', reject)
-			.end();
 	});
 }
 

--- a/src/vscodeUtils.ts
+++ b/src/vscodeUtils.ts
@@ -1,4 +1,42 @@
 import * as vscode from 'vscode';
+import * as path from 'path';
+
+export class ServerPath {
+	private folderName = 'lsp';
+	private customBinPath: string;
+	public customBinPathOptionName = 'languageServer.pathToBinary';
+
+	constructor(private context: vscode.ExtensionContext ) {
+		this.customBinPath = config('terraform').get(this.customBinPathOptionName);
+	}
+
+	public installPath(): string {
+		return this.context.asAbsolutePath(this.folderName);
+	}
+
+	public hasCustomBinPath(): boolean {
+		return !!this.customBinPath;
+	}
+
+	public binPath(): string {
+		if (this.hasCustomBinPath()) {
+			return this.customBinPath;
+		}
+
+		return path.resolve(this.installPath(), this.binName());
+	}
+
+	public binName(): string {
+		if (this.hasCustomBinPath()) {
+			return path.basename(this.customBinPath);
+		}
+
+		if (process.platform === 'win32') {
+			return 'terraform-ls.exe'
+		}
+		return 'terraform-ls';
+	}
+}
 
 export function config(section: string, scope?: vscode.ConfigurationScope): vscode.WorkspaceConfiguration {
 	return vscode.workspace.getConfiguration(section, scope);

--- a/src/vscodeUtils.ts
+++ b/src/vscodeUtils.ts
@@ -1,42 +1,4 @@
 import * as vscode from 'vscode';
-import * as path from 'path';
-
-export class ServerPath {
-	private folderName = 'lsp';
-	private customBinPath: string;
-	public customBinPathOptionName = 'languageServer.pathToBinary';
-
-	constructor(private context: vscode.ExtensionContext ) {
-		this.customBinPath = config('terraform').get(this.customBinPathOptionName);
-	}
-
-	public installPath(): string {
-		return this.context.asAbsolutePath(this.folderName);
-	}
-
-	public hasCustomBinPath(): boolean {
-		return !!this.customBinPath;
-	}
-
-	public binPath(): string {
-		if (this.hasCustomBinPath()) {
-			return this.customBinPath;
-		}
-
-		return path.resolve(this.installPath(), this.binName());
-	}
-
-	public binName(): string {
-		if (this.hasCustomBinPath()) {
-			return path.basename(this.customBinPath);
-		}
-
-		if (process.platform === 'win32') {
-			return 'terraform-ls.exe'
-		}
-		return 'terraform-ls';
-	}
-}
 
 export function config(section: string, scope?: vscode.ConfigurationScope): vscode.WorkspaceConfiguration {
 	return vscode.workspace.getConfiguration(section, scope);


### PR DESCRIPTION
Unblocks #691 

--- 

Path to either the LS binary or to the installation folder is needed in multiple places and sadly isn't as trivial. This extraction ensures that the same mistakes (such as forgetting to reflect Windows exe extensions or path separators) aren't repeated.

Windows would normally still find and execute a binary even without the "exe" extension so this bug shouldn't be affecting Windows users at this point, but some further checks (testing file existence/permissions) will be added in the above PR and that requires knowing the real binary name.
