### PR TITLE
Create command contribution for terraform apply

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,6 +194,10 @@
         "title": "Terraform: validate"
       },
       {
+        "command": "terraform.apply",
+        "title": "Terraform: Apply"
+      },
+      {
         "command": "terraform.plan",
         "title": "Terraform: plan"
       }


### PR DESCRIPTION
Closes #648.
---
Command `terraform.apply` is already registered so this PR only adds it to extension manifest.
https://github.com/hashicorp/vscode-terraform/blob/b5c8b6c7855c98918b6fe4d2fea0f11d1c438599/src/extension.ts#L66-L68
![image](https://user-images.githubusercontent.com/22010517/126700170-aa7c8d77-c27d-412a-bfd5-f1b4c71beaf2.png)
