### PR TITLE
github: further improve issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -4,26 +4,48 @@ about: Let us know about an unexpected error, a crash, or an incorrect behavior.
 labels: bug
 ---
 
-### VS Code Version
+## Versions
+
+This bug is reproducible in:
+ - [ ] the **latest** version of the extension (below)
+ - [ ] the **latest** version of the language server (below)
+
+### Extension
 <!--
-Copy this from VS Code (Help -> About -> Copy):
+Find this in the VS Code UI: Extensions Pane -> Installed -> HashiCorp Terraform
 -->
 ```
 
 ```
- 
-### Extension Version
+
+### Language Server
 <!--
-Copy this from the extension (Extensions Pane -> Terraform -> Manage / Settings -> Copy):
+Find this from the first few lines of relevant Output pane:
+View -> Output -> terraform-ls
 -->
 ```
 
 ```
 
-### Language Server Version
+### VS Code
 <!--
-Copy this from the *first* few lines of Output pane called "terraform-ls"
-(View -> Output -> terraform-ls)
+Copy this from VS Code
+ - Windows/Linux: Help -> About
+ - macOS: Code -> About Visual Studio Code
+-->
+```
+
+```
+
+### Operating System
+<!--
+Find version and build (32-bit or 64-bit) of your OS
+ - macOS: Apple logo -> About This Mac
+ - Windows: right-click on Windows logo -> Settings -> Device and Windows specifications
+ - Linux: `uname -a`
+   - Ubuntu: `cat /etc/issue`
+
+Also note whether you use WSL (Windows Subsystem for Linux) when on Windows.
 -->
 ```
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -4,16 +4,30 @@ about: Suggest a new feature or other enhancement.
 labels: enhancement
 ---
 
-### Current Version
+## Versions
+
+This feature does not yet exist in:
+ - [ ] the **latest** version of the extension (below)
+ - [ ] the **latest** version of the language server (below)
+
+### Extension
 <!--
-Run `terraform-ls --version` to show the version, and paste the result between the ``` marks below.
-If you are not running the latest version, please try upgrading because your issue may have already been fixed.
+Find this in the VS Code UI: Extensions Pane -> Installed -> HashiCorp Terraform
 -->
 ```
 
 ```
 
-### Use-cases
+### Language Server
+<!--
+Find this from the first few lines of relevant Output pane:
+View -> Output -> terraform-ls
+-->
+```
+
+```
+
+## Problem Statement
 <!--
 In order to properly evaluate a feature request, it is necessary to understand the use-cases for it.
 
@@ -21,32 +35,38 @@ Please describe below the _end goal_ you are trying to achieve that has led you 
 
 Please keep this section focused on the problem and not on the suggested solution. We'll get to that in a moment, below!
 -->
-
-### Attempted Solutions
 <!--
-If you've already tried to solve the problem within server's existing features and found a limitation that prevented you from succeeding, please describe it below in as much detail as possible.
+If you've already tried to solve the problem with existing features and found a limitation that prevented you from succeeding, please describe it below in as much detail as possible.
 
 Ideally, this would include real configuration snippets that you tried, actions you performed (e.g. autocompletion in a particular position in that snippet), and what results you got in each case.
 
-Please remove any sensitive information such as passwords before sharing configuration snippets and command lines.
+Please remove any sensitive information such as passwords before sharing configuration snippets.
 --->
 
-### Proposal
+(User can today does ... but ...)
+
+When user does ... they ...
+It would be helpful if ...
+
+
+## Expected User Experience
+<!--
+If you already have an idea of what this feature might look like in the editor
+and can produce screenshots, drawings or ASCII art - please attach it here.
+-->
+
+User would be able to see ... when ...
+
+## Proposal
 <!--
 If you have an idea for a way to address the problem via a change to existing features, please describe it below.
 
-In this section, it's helpful to include specific examples of how what you are suggesting might look in configuration files, or on the command line, since that allows us to understand the full picture of what you are proposing.
+In this section, it's helpful to include specific examples of how what you are suggesting might look in configuration files, or in the UI, since that allows us to understand the full picture of what you are proposing.
 
-If you're not sure of some details, don't worry! When we evaluate the feature request we may suggest modifications as necessary to work within the design constraints of Language Server.
+If you're not sure of some details, don't worry! When we evaluate the feature request we may suggest modifications as necessary to work within the design constraints of Language Server and VS Code.
 -->
 
-#### Expected User Experience
-<!--
-If you already have an idea of what this feature might look like in the editor
-and can produce drawings or ASCII art - please attach it here.
--->
-
-### References
+## References
 <!--
 Are there any other GitHub issues, whether open or closed, that are related to the problem you've described above or to the suggested solution? If so, please create a list below that mentions each of them. For example:
 


### PR DESCRIPTION
I re-ordered some sections to make it easier to follow/read from top to bottom, added more OS-specific details for how to find versions of things and added a "template" to help understand what's expected under each section.