### PR TITLE
build: Introduce dependabot for updating deps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,8 @@
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    versioning-strategy: lockfile-only
+    directory: "/"
+    schedule:
+      interval: "daily"
+    labels: ["dependencies"]


### PR DESCRIPTION
This should help us keep our dependencies up to date.

Initially this would use more "cautious" strategy and only perform updates that can be done in lockfile only, i.e. leaving requirements in the manifest untouched. Later though we can consider relaxing these.