### PR TITLE
github: Reduce timeouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ on:
 jobs:
   lint:
     runs-on: ubuntu-latest
-
+    timeout-minutes: 3
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
@@ -29,6 +29,7 @@ jobs:
       matrix:
         os: [windows-latest, macos-latest, macos-11.0, ubuntu-latest]
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 10
 
     steps:
       - name: Checkout Repo


### PR DESCRIPTION
Default timeouts are actually 6 hours and our jobs should typically finish within minutes, so there's no point in waiting any longer.