### PR TITLE
Module View Provider

### DIFF
--- a/assets/icons/terraform.svg
+++ b/assets/icons/terraform.svg
@@ -1,0 +1,4 @@
+<svg width="64" height="64" viewBox="0 0 64 64" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path fill-rule="evenodd" clip-rule="evenodd" d="M41.0445 23.2489V40.0562L55.7608 31.6531V14.8435L41.0445 23.2489Z" fill="#4040B2"/>
+<path fill-rule="evenodd" clip-rule="evenodd" d="M24.7175 50.3023L39.432 58.7083V41.8986L24.7175 33.4944V50.3023ZM8.39026 22.2694L23.1047 30.6748V13.867L8.39026 5.46338V22.2694ZM24.7175 14.8435V31.6532L39.4326 40.0568V23.2484L24.7175 14.8435Z" fill="#5F43E9"/>
+</svg>

--- a/package.json
+++ b/package.json
@@ -213,6 +213,58 @@
       {
         "command": "terraform.plan",
         "title": "Terraform: plan"
+      },
+      {
+        "command": "terraform.modules.refreshList",
+        "title": "Refresh",
+        "icon": "$(refresh)"
+      },
+      {
+        "command": "terraform.modules.openDocumentation",
+        "title": "Open Documentation",
+        "icon": "$(book)"
+      }
+    ],
+    "menus": {
+      "commandPalette": [
+        {
+          "command": "terraform.modules.refreshList",
+          "when": "false"
+        },
+        {
+          "command": "terraform.modules.openDocumentation",
+          "when": "false"
+        }
+      ],
+      "view/title": [
+        {
+          "command": "terraform.modules.refreshList",
+          "when": "view == terraform.modules",
+          "group": "navigation"
+        }
+      ],
+      "view/item/context": [
+        {
+          "command": "terraform.modules.openDocumentation",
+          "when": "view == terraform.modules"
+        }
+      ]
+    },
+    "views": {
+      "explorer": [
+        {
+          "id": "terraform.modules",
+          "name": "Terraform Module Calls",
+          "icon": "assets/icons/terraform.svg",
+          "visibility": "collapsed",
+          "when": "terraform.showModuleView"
+        }
+      ]
+    },
+    "viewsWelcome": [
+      {
+        "view": "terraform.modules",
+        "contents": "The active editor cannot provide information about installed modules. [Learn more about modules](https://www.terraform.io/docs/language/modules/develop/index.html) You may need to run 'terraform get'"
       }
     ]
   },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -5,6 +5,7 @@ import { LanguageClient } from 'vscode-languageclient/node';
 import { Utils } from 'vscode-uri';
 import { ClientHandler, TerraformLanguageClient } from './clientHandler';
 import { defaultVersionString, isValidVersionString, LanguageServerInstaller } from './languageServerInstaller';
+import { ModuleProvider } from './providers/moduleProvider';
 import { ServerPath } from './serverPath';
 import { SingleInstanceTimeout } from './utils';
 import { config, getActiveTextEditor, prunedFolderNames } from './vscodeUtils';
@@ -134,6 +135,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       reporter.sendTelemetryException(error);
     }
   }
+
+  vscode.commands.executeCommand('setContext', 'terraform.showModuleView', true);
+  context.subscriptions.push(
+    vscode.window.registerTreeDataProvider('terraform.modules', new ModuleProvider(context, clientHandler)),
+  );
 
   // export public API
   return { clientHandler, moduleCallers };

--- a/src/providers/moduleProvider.ts
+++ b/src/providers/moduleProvider.ts
@@ -1,0 +1,153 @@
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { ExecuteCommandParams, ExecuteCommandRequest } from 'vscode-languageclient';
+import { Utils } from 'vscode-uri';
+import { ClientHandler } from '../clientHandler';
+import { getActiveTextEditor } from '../vscodeUtils';
+
+class ModuleCall extends vscode.TreeItem {
+  constructor(
+    public label: string,
+    public sourceAddr: string,
+    public version: string,
+    public sourceType: string,
+    public docsLink: string,
+    public terraformIcon: string,
+    public readonly children: ModuleCall[],
+  ) {
+    super(
+      label,
+      children.length >= 1 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None,
+    );
+
+    this.description = this.version ? `${this.version}` : '';
+
+    if (this.version === undefined) {
+      this.tooltip = `${this.sourceAddr}`;
+    } else {
+      this.tooltip = `${this.sourceAddr}@${this.version}`;
+    }
+  }
+
+  iconPath = this.getIcon(this.sourceType);
+
+  getIcon(type: string) {
+    switch (type) {
+      case 'tfregistry':
+        return {
+          light: this.terraformIcon,
+          dark: this.terraformIcon,
+        };
+      case 'local':
+        return new vscode.ThemeIcon('symbol-folder');
+      case 'github':
+        return new vscode.ThemeIcon('github');
+      case 'git':
+        return new vscode.ThemeIcon('git-branch');
+      default:
+        return new vscode.ThemeIcon('extensions-view-icon');
+    }
+  }
+}
+
+export class ModuleProvider implements vscode.TreeDataProvider<ModuleCall> {
+  private _onDidChangeTreeData: vscode.EventEmitter<ModuleCall | undefined | null | void> = new vscode.EventEmitter<
+    ModuleCall | undefined | null | void
+  >();
+  readonly onDidChangeTreeData: vscode.Event<ModuleCall | undefined | null | void> = this._onDidChangeTreeData.event;
+
+  private svg = '';
+
+  constructor(ctx: vscode.ExtensionContext, public handler: ClientHandler) {
+    this.svg = ctx.asAbsolutePath(path.join('assets', 'icons', 'terraform.svg'));
+    ctx.subscriptions.push(
+      vscode.commands.registerCommand('terraform.modules.refreshList', () => this.refresh()),
+      vscode.commands.registerCommand('terraform.modules.openDocumentation', (module: ModuleCall) => {
+        vscode.env.openExternal(vscode.Uri.parse(module.docsLink));
+      }),
+      vscode.window.onDidChangeActiveTextEditor(async (event: vscode.TextEditor | undefined) => {
+        if (event && getActiveTextEditor()) {
+          this.refresh();
+        }
+      }),
+    );
+  }
+
+  refresh(): void {
+    this._onDidChangeTreeData.fire();
+  }
+
+  getTreeItem(element: ModuleCall): ModuleCall | Thenable<ModuleCall> {
+    return element;
+  }
+
+  getChildren(element?: ModuleCall): vscode.ProviderResult<ModuleCall[]> {
+    if (element) {
+      return Promise.resolve(element.children);
+    } else {
+      const m = this.getModules();
+      return Promise.resolve(m);
+    }
+  }
+
+  async getModules(): Promise<ModuleCall[]> {
+    const activeEditor = getActiveTextEditor();
+    if (activeEditor === undefined) {
+      return Promise.resolve([]);
+    }
+
+    const document = activeEditor.document;
+    if (document === undefined) {
+      return Promise.resolve([]);
+    }
+
+    const editor = document.uri;
+    const documentURI = Utils.dirname(editor);
+    const handler = this.handler.getClient(editor);
+
+    return await handler.client.onReady().then(async () => {
+      const params: ExecuteCommandParams = {
+        command: `${handler.commandPrefix}.terraform-ls.module.calls`,
+        arguments: [`uri=${documentURI}`],
+      };
+
+      const response = await handler.client.sendRequest(ExecuteCommandRequest.type, params);
+      if (response == null) {
+        return Promise.resolve([]);
+      }
+
+      const list = response.module_calls.map((m) =>
+        this.toModuleCall(m.name, m.source_addr, m.version, m.source_type, m.docs_link, this.svg, m.dependent_modules),
+      );
+
+      return list;
+    });
+  }
+
+  toModuleCall(
+    name: string,
+    sourceAddr: string,
+    version: string,
+    sourceType: string,
+    docsLink: string,
+    terraformIcon: string,
+    dependents: any,
+  ): ModuleCall {
+    let deps: ModuleCall[] = [];
+    if (dependents.length != 0) {
+      deps = dependents.map((dp) =>
+        this.toModuleCall(
+          dp.name,
+          dp.source_addr,
+          dp.version,
+          dp.source_type,
+          dp.docs_link,
+          terraformIcon,
+          dp.dependent_modules,
+        ),
+      );
+    }
+
+    return new ModuleCall(name, sourceAddr, version, sourceType, docsLink, terraformIcon, deps);
+  }
+}


### PR DESCRIPTION
- [x] List modules used in current workspace
- [x] Detect module type and use Terraform icon
- [x] Detect module type and use Github icon
- [x] Detect module type and use local folder icon
- [x] Provide context menu item to open link to documentation website
- [x] List dependent modules used by module in expanded state

Module view inside Explorer view container, with nested modules displayed

![image](https://user-images.githubusercontent.com/272569/133169365-415fd66d-2dfe-4677-90ee-45d7aa5b943a.png)

Documentation Link

![image](https://user-images.githubusercontent.com/272569/133169384-a44530c3-fdb8-4603-af83-811cfed7707c.png)

Closes #698

Needs https://github.com/hashicorp/terraform-ls/pull/632