### PR TITLE
TCP Client Handler

### DIFF
--- a/package.json
+++ b/package.json
@@ -310,6 +310,16 @@
             ],
             "description": "Arguments to pass to language server binary"
           },
+          "terraform.languageServer.tcp.port": {
+            "order": 4,
+            "type": [
+              "number",
+              null
+            ],
+            "scope": "machine-overridable",
+            "default": null,
+            "markdownDescription": "Language server TCP port to connect to. This is not compatible with `#terraform.languageServer.path#`. This is used when you want the extension to connect via TCP to an already running language server process."
+          },
           "terraform.languageServer.ignoreSingleFileWarning": {
             "order": "3",
             "scope": "window",
@@ -435,15 +445,6 @@
             "scope": "window",
             "type": "boolean",
             "default": false
-          },
-          "terraform.experimentalFeatures.languageServer.tcp.port": {
-            "type": [
-              "number",
-              null
-            ],
-            "scope": "machine-overridable",
-            "default": null,
-            "markdownDescription": "Language server TCP port to connect to. This is not compatible with `#terraform.languageServer.path#`. This is used when you want the extension to connect via TCP to an already running language server process."
           },
           "terraform-ls.experimentalFeatures": {
             "scope": "window",

--- a/package.json
+++ b/package.json
@@ -443,7 +443,7 @@
             ],
             "scope": "machine-overridable",
             "default": null,
-            "markdownDescription": "Language server TCP port to connect to. This is not compatible with `#terraform.languageServer.path#`. This is used when you want the extension to connect via TCP to an already running Language Server is already running Language Server process."
+            "markdownDescription": "Language server TCP port to connect to. This is not compatible with `#terraform.languageServer.path#`. This is used when you want the extension to connect via TCP to an already running language server process."
           },
           "terraform-ls.experimentalFeatures": {
             "scope": "window",

--- a/package.json
+++ b/package.json
@@ -436,6 +436,15 @@
             "type": "boolean",
             "default": false
           },
+          "terraform.experimentalFeatures.languageServer.tcp.port": {
+            "type": [
+              "number",
+              null
+            ],
+            "scope": "machine-overridable",
+            "default": null,
+            "markdownDescription": "Language server TCP port to connect to. This is not compatible with `#terraform.languageServer.path#`. This is used when you want the extension to connect via TCP to an already running Language Server is already running Language Server process."
+          },
           "terraform-ls.experimentalFeatures": {
             "scope": "window",
             "type": "object",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -38,7 +38,7 @@ const documentSelector: DocumentSelector = [
   { scheme: 'file', language: 'terraform' },
   { scheme: 'file', language: 'terraform-vars' },
 ];
-const outputChannel = vscode.window.createOutputChannel(brand);
+export const outputChannel = vscode.window.createOutputChannel(brand);
 export let terraformStatus: vscode.StatusBarItem;
 
 let reporter: TelemetryReporter;
@@ -112,7 +112,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     reporter.sendTelemetryEvent('usePathToBinary');
   }
   const serverOptions: ServerOptions = await getServerOptions(lsPath);
-  // outputChannel.appendLine(`Launching language server: ${executable.command} ${executable.args?.join(' ')}`);
 
   const initializationOptions = getInitializationOptions();
   const clientOptions: LanguageClientOptions = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import {
   ServerOptions,
 } from 'vscode-languageclient/node';
 import { Utils } from 'vscode-uri';
-import { clientSupportsCommand, getInitializationOptions, getServerExecutable } from './utils/clientHelpers';
+import { clientSupportsCommand, getInitializationOptions, getServerOptions } from './utils/clientHelpers';
 import { GenerateBugReportCommand } from './commands/generateBugReport';
 import { ModuleCallsDataProvider } from './providers/moduleCalls';
 import { ModuleProvidersDataProvider } from './providers/moduleProviders';
@@ -111,12 +111,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   if (lsPath.hasCustomBinPath()) {
     reporter.sendTelemetryEvent('usePathToBinary');
   }
-  const executable = await getServerExecutable(lsPath);
-  const serverOptions: ServerOptions = {
-    run: executable,
-    debug: executable,
-  };
-  outputChannel.appendLine(`Launching language server: ${executable.command} ${executable.args?.join(' ')}`);
+  const serverOptions: ServerOptions = await getServerOptions(lsPath);
+  // outputChannel.appendLine(`Launching language server: ${executable.command} ${executable.args?.join(' ')}`);
 
   const initializationOptions = getInitializationOptions();
   const clientOptions: LanguageClientOptions = {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -9,7 +9,6 @@ import {
   RevealOutputChannelOn,
   State,
   StaticFeature,
-  ServerOptions,
   CloseAction,
   ErrorAction,
   Message,

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,6 @@ import {
   StaticFeature,
   CloseAction,
   ErrorAction,
-  Message,
 } from 'vscode-languageclient/node';
 import { Utils } from 'vscode-uri';
 import { clientSupportsCommand, getInitializationOptions, getServerOptions } from './utils/clientHelpers';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -114,7 +114,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   if (lsPath.hasCustomBinPath()) {
     reporter.sendTelemetryEvent('usePathToBinary');
   }
-  const serverOptions: ServerOptions = await getServerOptions(lsPath);
+  const serverOptions = await getServerOptions(lsPath);
 
   const initializationOptions = getInitializationOptions();
 

--- a/src/utils/clientHelpers.ts
+++ b/src/utils/clientHelpers.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { Executable, InitializeResult, ServerOptions, StreamInfo } from 'vscode-languageclient/node';
 import { config } from './vscode';
 import { ServerPath } from './serverPath';
+import { outputChannel } from '../extension';
 
 export async function getServerOptions(lsPath: ServerPath): Promise<ServerOptions> {
   let serverOptions: ServerOptions;
@@ -31,12 +32,14 @@ export async function getServerOptions(lsPath: ServerPath): Promise<ServerOption
       };
       return Promise.resolve(result);
     };
+
+    outputChannel?.appendLine(`Connecting to language server via TCP at localhost:${port}`);
     return serverOptions;
   }
 
   const cmd = await lsPath.resolvedPathToBinary();
   const serverArgs = config('terraform').get<string[]>('languageServer.args', []);
-  // this.outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
+  outputChannel?.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
   const executable: Executable = {
     command: cmd,
     args: serverArgs,

--- a/src/utils/clientHelpers.ts
+++ b/src/utils/clientHelpers.ts
@@ -8,12 +8,12 @@ import { outputChannel } from '../extension';
 export async function getServerOptions(lsPath: ServerPath): Promise<ServerOptions> {
   let serverOptions: ServerOptions;
 
-  const port = config('terraform').get<number>('experimentalFeatures.languageServer.tcp.port');
+  const port = config('terraform').get<number>('languageServer.tcp.port');
   if (port) {
     const inspect = vscode.workspace.getConfiguration('terraform').inspect('languageServer.path');
     if (inspect !== undefined && (inspect.globalValue || inspect.workspaceFolderValue || inspect.workspaceValue)) {
       vscode.window.showWarningMessage(
-        'You cannot use experimentalFeatures.languageServer.tcp.port with terraform.languageServer.path. Ignoring terraform.languageServer.path and proceeding to connect via TCP',
+        'You cannot use terraform.languageServer.tcp.port with terraform.languageServer.path. Ignoring terraform.languageServer.path and proceeding to connect via TCP',
       );
     }
 

--- a/src/utils/clientHelpers.ts
+++ b/src/utils/clientHelpers.ts
@@ -8,7 +8,7 @@ import { outputChannel } from '../extension';
 export async function getServerOptions(lsPath: ServerPath): Promise<ServerOptions> {
   let serverOptions: ServerOptions;
 
-  const port: number | undefined = config('terraform').get('experimentalFeatures.languageServer.tcp.port');
+  const port = config('terraform').get<number>('experimentalFeatures.languageServer.tcp.port');
   if (port) {
     const inspect = vscode.workspace.getConfiguration('terraform').inspect('languageServer.path');
     if (inspect !== undefined && (inspect.globalValue || inspect.workspaceFolderValue || inspect.workspaceValue)) {

--- a/src/utils/clientHelpers.ts
+++ b/src/utils/clientHelpers.ts
@@ -11,26 +11,22 @@ export async function getServerOptions(lsPath: ServerPath): Promise<ServerOption
   const port: number | undefined = config('terraform').get('experimentalFeatures.languageServer.tcp.port');
   if (port) {
     const inspect = vscode.workspace.getConfiguration('terraform').inspect('languageServer.path');
-    if (inspect !== undefined) {
-      ///
-      if (inspect.globalValue || inspect.workspaceFolderValue || inspect.workspaceValue) {
-        vscode.window.showWarningMessage(
-          'You cannot use experimentalFeatures.languageServer.tcp.port with terraform.languageServer.path. Ignoring terraform.languageServer.path and proceeding to connect via TCP',
-        );
-      }
+    if (inspect !== undefined && (inspect.globalValue || inspect.workspaceFolderValue || inspect.workspaceValue)) {
+      vscode.window.showWarningMessage(
+        'You cannot use experimentalFeatures.languageServer.tcp.port with terraform.languageServer.path. Ignoring terraform.languageServer.path and proceeding to connect via TCP',
+      );
     }
 
-    serverOptions = () => {
+    serverOptions = async () => {
       const socket = new net.Socket();
       socket.connect({
         port: port,
         host: 'localhost',
       });
-      const result: StreamInfo = {
+      return {
         writer: socket,
         reader: socket,
       };
-      return Promise.resolve(result);
     };
 
     outputChannel?.appendLine(`Connecting to language server via TCP at localhost:${port}`);

--- a/src/utils/clientHelpers.ts
+++ b/src/utils/clientHelpers.ts
@@ -1,6 +1,6 @@
 import * as net from 'net';
 import * as vscode from 'vscode';
-import { Executable, InitializeResult, ServerOptions, StreamInfo } from 'vscode-languageclient/node';
+import { Executable, InitializeResult, ServerOptions } from 'vscode-languageclient/node';
 import { config } from './vscode';
 import { ServerPath } from './serverPath';
 import { outputChannel } from '../extension';


### PR DESCRIPTION
Add TCP connection settings

This commit adds `terraform.experimentalFeatures.languageServer.tcp.port` to enable connecting to a terraform-ls instance using TCP instead of STDIO. The terraform-ls instance has to be already running, this will not start it for the user.

This also adds a custom error handler to the LanguageClient implementation. This custom implementation attempts to start the LS and returns after one failure, but ensures an error window is raised when it fails to start or connect to a terraform-ls instance. This is needed because the LanguageClient handles errors by default but relies on the OutputChannel not being hidden to show errors. 