### PR TITLE
Include node_modules in VS Code editor

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,7 +9,6 @@
   "files.trimTrailingWhitespace": true,
 
   "files.exclude": {
-    "node_modules": true,
     "out": true
   },
   "search.exclude": {


### PR DESCRIPTION
This removes excluding node_modules from the file explorer tree in VS Code. Typically node_modules is hidden from search in VS Code as a speed improvement, but hiding it from the treeview is more of a personal preference than a requirement.
