### PR TITLE
Align formatting and code style

### DIFF
--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -1,34 +1,28 @@
-import * as vscode from 'vscode';
-import ShortUniqueId from 'short-unique-id';
 import * as fs from 'fs';
 import * as path from 'path';
-import * as which from 'which';
-import {
-	Executable,
-	LanguageClient,
-	LanguageClientOptions,
-	ServerOptions,
-	State,
-	DocumentSelector,
-	RevealOutputChannelOn
-} from 'vscode-languageclient/node';
-import {
-	config,
-	getFolderName,
-	getWorkspaceFolder,
-	normalizeFolderName,
-	sortedWorkspaceFolders
-} from './vscodeUtils';
+import ShortUniqueId from 'short-unique-id';
+import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
+import {
+  DocumentSelector,
+  Executable,
+  LanguageClient,
+  LanguageClientOptions,
+  RevealOutputChannelOn,
+  ServerOptions,
+  State,
+} from 'vscode-languageclient/node';
+import * as which from 'which';
+import { CUSTOM_BIN_PATH_OPTION_NAME, ServerPath } from './serverPath';
 import { ShowReferencesFeature } from './showReferences';
-import { ServerPath, CUSTOM_BIN_PATH_OPTION_NAME } from './serverPath';
+import { config, getFolderName, getWorkspaceFolder, normalizeFolderName, sortedWorkspaceFolders } from './vscodeUtils';
 
 export interface TerraformLanguageClient {
-	commandPrefix: string,
-	client: LanguageClient
+  commandPrefix: string;
+  client: LanguageClient;
 }
 
-const MULTI_FOLDER_CLIENT = "";
+const MULTI_FOLDER_CLIENT = '';
 const clients: Map<string, TerraformLanguageClient> = new Map();
 
 /**
@@ -37,259 +31,261 @@ const clients: Map<string, TerraformLanguageClient> = new Map();
  * workspaces are supported).
  */
 export class ClientHandler {
-	private shortUid: ShortUniqueId;
-	private supportsMultiFolders = true;
+  private shortUid: ShortUniqueId;
+  private supportsMultiFolders = true;
 
-	constructor(private lsPath: ServerPath, private reporter: TelemetryReporter ) {
-		this.shortUid = new ShortUniqueId();
-		if (lsPath.hasCustomBinPath()) {
-			this.reporter.sendTelemetryEvent('usePathToBinary');
-		}
-	}
+  constructor(private lsPath: ServerPath, private reporter: TelemetryReporter) {
+    this.shortUid = new ShortUniqueId();
+    if (lsPath.hasCustomBinPath()) {
+      this.reporter.sendTelemetryEvent('usePathToBinary');
+    }
+  }
 
-	public startClients(folders?: string[]): vscode.Disposable[] {
-		const disposables: vscode.Disposable[] = [];
+  public startClients(folders?: string[]): vscode.Disposable[] {
+    const disposables: vscode.Disposable[] = [];
 
-		if (this.supportsMultiFolders) {
-			if (clients.has(MULTI_FOLDER_CLIENT)) {
-				console.log(`No need to start another client for ${folders}`)
-				return disposables;
-			}
+    if (this.supportsMultiFolders) {
+      if (clients.has(MULTI_FOLDER_CLIENT)) {
+        console.log(`No need to start another client for ${folders}`);
+        return disposables;
+      }
 
-			console.log('Starting client');
+      console.log('Starting client');
 
-			const tfClient = this.createTerraformClient();
-			tfClient.client.onReady().then(async () => {
-				this.reporter.sendTelemetryEvent('startClient');
-				const multiFoldersSupported = tfClient.client.initializeResult.capabilities.workspace?.workspaceFolders?.supported;
-				console.log(`Multi-folder support: ${multiFoldersSupported}`);
+      const tfClient = this.createTerraformClient();
+      tfClient.client.onReady().then(async () => {
+        this.reporter.sendTelemetryEvent('startClient');
+        const multiFoldersSupported =
+          tfClient.client.initializeResult.capabilities.workspace?.workspaceFolders?.supported;
+        console.log(`Multi-folder support: ${multiFoldersSupported}`);
 
-				if (!multiFoldersSupported) {
-					// restart is needed to launch folder-focused instances
-					console.log('Restarting clients as folder-focused');
-					await this.stopClients(folders);
-					this.supportsMultiFolders = false;
-					this.startClients(folders);
-				}
-			});
+        if (!multiFoldersSupported) {
+          // restart is needed to launch folder-focused instances
+          console.log('Restarting clients as folder-focused');
+          await this.stopClients(folders);
+          this.supportsMultiFolders = false;
+          this.startClients(folders);
+        }
+      });
 
-			disposables.push(tfClient.client.start());
-			clients.set(MULTI_FOLDER_CLIENT, tfClient);
+      disposables.push(tfClient.client.start());
+      clients.set(MULTI_FOLDER_CLIENT, tfClient);
 
-			return disposables;
-		}
+      return disposables;
+    }
 
-		if (folders && folders.length > 0) {
-			for (const folder of folders) {
-				if (!clients.has(folder)) {
-					console.log(`Starting client for ${folder}`);
-					const folderClient = this.createTerraformClient(folder);
-					folderClient.client.onReady().then(() => {
-						this.reporter.sendTelemetryEvent('startClient');
-					});
+    if (folders && folders.length > 0) {
+      for (const folder of folders) {
+        if (!clients.has(folder)) {
+          console.log(`Starting client for ${folder}`);
+          const folderClient = this.createTerraformClient(folder);
+          folderClient.client.onReady().then(() => {
+            this.reporter.sendTelemetryEvent('startClient');
+          });
 
-					disposables.push(folderClient.client.start());
-					clients.set(folder, folderClient);
-				} else {
-					console.log(`Client for folder: ${folder} already started`);
-				}
-			}
-		}
-		return disposables;
-	}
+          disposables.push(folderClient.client.start());
+          clients.set(folder, folderClient);
+        } else {
+          console.log(`Client for folder: ${folder} already started`);
+        }
+      }
+    }
+    return disposables;
+  }
 
-	private createTerraformClient(location?: string): TerraformLanguageClient {
-		const cmd = this.resolvedPathToBinary();
-		const binaryName = this.lsPath.binName();
+  private createTerraformClient(location?: string): TerraformLanguageClient {
+    const cmd = this.resolvedPathToBinary();
+    const binaryName = this.lsPath.binName();
 
-		const serverArgs: string[] = config('terraform').get('languageServer.args');
-		const experimentalFeatures = config('terraform-ls').get('experimentalFeatures');
+    const serverArgs: string[] = config('terraform').get('languageServer.args');
+    const experimentalFeatures = config('terraform-ls').get('experimentalFeatures');
 
-		let channelName = `${binaryName}`;
-		let id = `terraform-ls`
-		let name = `Terraform LS`
-		let wsFolder: vscode.WorkspaceFolder;
-		let rootModulePaths: string[];
-		let terraformExecPath: string;
-		let terraformExecTimeout: string;
-		let terraformLogFilePath: string;
-		let excludeModulePaths: string[];
-		let documentSelector: DocumentSelector;
-		let outputChannel: vscode.OutputChannel;
-		if (location) {
-			channelName = `${binaryName}: ${location}`;
-			id = `terraform-ls/${location}`
-			name = `Terraform LS: ${location}`
-			wsFolder = getWorkspaceFolder(location);
-			documentSelector = [
-				{ scheme: 'file', language: 'terraform', pattern: `${wsFolder.uri.fsPath}/**/*` },
-				{ scheme: 'file', language: 'terraform-vars', pattern: `${wsFolder.uri.fsPath}/**/*` }
-			]
-			terraformExecPath = config('terraform-ls', wsFolder).get('terraformExecPath');
-			terraformExecTimeout = config('terraform-ls', wsFolder).get('terraformExecTimeout');
-			terraformLogFilePath = config('terraform-ls', wsFolder).get('terraformLogFilePath');
-			rootModulePaths = config('terraform-ls', wsFolder).get('rootModules');
-			excludeModulePaths = config('terraform-ls', wsFolder).get('excludeRootModules');
-			outputChannel = vscode.window.createOutputChannel(channelName);
-			outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')} for folder: ${location}`);
-		} else {
-			documentSelector = [
-				{ scheme: 'file', language: 'terraform' },
-				{ scheme: 'file', language: 'terraform-vars' }
-			]
-			terraformExecPath = config('terraform-ls').get('terraformExecPath');
-			terraformExecTimeout = config('terraform-ls').get('terraformExecTimeout');
-			terraformLogFilePath = config('terraform-ls').get('terraformLogFilePath');
-			rootModulePaths = config('terraform-ls').get('rootModules');
-			excludeModulePaths = config('terraform-ls').get('excludeRootModules');
-			outputChannel = vscode.window.createOutputChannel(channelName);
-			outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
-		}
+    let channelName = `${binaryName}`;
+    let id = `terraform-ls`;
+    let name = `Terraform LS`;
+    let wsFolder: vscode.WorkspaceFolder;
+    let rootModulePaths: string[];
+    let terraformExecPath: string;
+    let terraformExecTimeout: string;
+    let terraformLogFilePath: string;
+    let excludeModulePaths: string[];
+    let documentSelector: DocumentSelector;
+    let outputChannel: vscode.OutputChannel;
+    if (location) {
+      channelName = `${binaryName}: ${location}`;
+      id = `terraform-ls/${location}`;
+      name = `Terraform LS: ${location}`;
+      wsFolder = getWorkspaceFolder(location);
+      documentSelector = [
+        { scheme: 'file', language: 'terraform', pattern: `${wsFolder.uri.fsPath}/**/*` },
+        { scheme: 'file', language: 'terraform-vars', pattern: `${wsFolder.uri.fsPath}/**/*` },
+      ];
+      terraformExecPath = config('terraform-ls', wsFolder).get('terraformExecPath');
+      terraformExecTimeout = config('terraform-ls', wsFolder).get('terraformExecTimeout');
+      terraformLogFilePath = config('terraform-ls', wsFolder).get('terraformLogFilePath');
+      rootModulePaths = config('terraform-ls', wsFolder).get('rootModules');
+      excludeModulePaths = config('terraform-ls', wsFolder).get('excludeRootModules');
+      outputChannel = vscode.window.createOutputChannel(channelName);
+      outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')} for folder: ${location}`);
+    } else {
+      documentSelector = [
+        { scheme: 'file', language: 'terraform' },
+        { scheme: 'file', language: 'terraform-vars' },
+      ];
+      terraformExecPath = config('terraform-ls').get('terraformExecPath');
+      terraformExecTimeout = config('terraform-ls').get('terraformExecTimeout');
+      terraformLogFilePath = config('terraform-ls').get('terraformLogFilePath');
+      rootModulePaths = config('terraform-ls').get('rootModules');
+      excludeModulePaths = config('terraform-ls').get('excludeRootModules');
+      outputChannel = vscode.window.createOutputChannel(channelName);
+      outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
+    }
 
-		if (rootModulePaths.length > 0 && excludeModulePaths.length > 0) {
-			throw new Error('Only one of rootModules and excludeRootModules can be set at the same time, please remove the conflicting config and reload');
-		}
+    if (rootModulePaths.length > 0 && excludeModulePaths.length > 0) {
+      throw new Error(
+        'Only one of rootModules and excludeRootModules can be set at the same time, please remove the conflicting config and reload',
+      );
+    }
 
-		const commandPrefix = this.shortUid.seq();
-		let initializationOptions = { commandPrefix, experimentalFeatures };
-		if (terraformExecPath.length > 0) {
-			initializationOptions = Object.assign(initializationOptions, { terraformExecPath });
-		}
-		if (terraformExecTimeout.length > 0) {
-			initializationOptions = Object.assign(initializationOptions, { terraformExecTimeout });
-		}
-		if (terraformLogFilePath.length > 0) {
-			initializationOptions = Object.assign(initializationOptions, { terraformLogFilePath });
-		}
-		if (rootModulePaths.length > 0) {
-			initializationOptions = Object.assign(initializationOptions, { rootModulePaths });
-		}
-		if (excludeModulePaths.length > 0) {
-			initializationOptions = Object.assign(initializationOptions, { excludeModulePaths });
-		}
+    const commandPrefix = this.shortUid.seq();
+    let initializationOptions = { commandPrefix, experimentalFeatures };
+    if (terraformExecPath.length > 0) {
+      initializationOptions = Object.assign(initializationOptions, { terraformExecPath });
+    }
+    if (terraformExecTimeout.length > 0) {
+      initializationOptions = Object.assign(initializationOptions, { terraformExecTimeout });
+    }
+    if (terraformLogFilePath.length > 0) {
+      initializationOptions = Object.assign(initializationOptions, { terraformLogFilePath });
+    }
+    if (rootModulePaths.length > 0) {
+      initializationOptions = Object.assign(initializationOptions, { rootModulePaths });
+    }
+    if (excludeModulePaths.length > 0) {
+      initializationOptions = Object.assign(initializationOptions, { excludeModulePaths });
+    }
 
-		const executable: Executable = {
-			command: cmd,
-			args: serverArgs,
-			options: {}
-		};
-		const serverOptions: ServerOptions = {
-			run: executable,
-			debug: executable
-		};
-		const clientOptions: LanguageClientOptions = {
-			documentSelector: documentSelector,
-			workspaceFolder: wsFolder,
-			initializationOptions: initializationOptions,
-			initializationFailedHandler: (error) => {
-				this.reporter.sendTelemetryException(error);
-				return false;
-			},
-			outputChannel: outputChannel,
-			revealOutputChannelOn: RevealOutputChannelOn.Never,
-		};
+    const executable: Executable = {
+      command: cmd,
+      args: serverArgs,
+      options: {},
+    };
+    const serverOptions: ServerOptions = {
+      run: executable,
+      debug: executable,
+    };
+    const clientOptions: LanguageClientOptions = {
+      documentSelector: documentSelector,
+      workspaceFolder: wsFolder,
+      initializationOptions: initializationOptions,
+      initializationFailedHandler: (error) => {
+        this.reporter.sendTelemetryException(error);
+        return false;
+      },
+      outputChannel: outputChannel,
+      revealOutputChannelOn: RevealOutputChannelOn.Never,
+    };
 
-		const client = new LanguageClient(
-			id,
-			name,
-			serverOptions,
-			clientOptions
-		);
+    const client = new LanguageClient(id, name, serverOptions, clientOptions);
 
-		client.registerFeature(new ShowReferencesFeature(client));
+    client.registerFeature(new ShowReferencesFeature(client));
 
-		client.onDidChangeState((event) => {
-			if (event.newState === State.Stopped) {
-				clients.delete(location);
-				this.reporter.sendTelemetryEvent('stopClient');
-			}
-		});
+    client.onDidChangeState((event) => {
+      if (event.newState === State.Stopped) {
+        clients.delete(location);
+        this.reporter.sendTelemetryEvent('stopClient');
+      }
+    });
 
-		return {commandPrefix, client}
-	}
+    return { commandPrefix, client };
+  }
 
-	public async stopClients(folders?: string[]): Promise<void[]> {
-		const promises: Promise<void>[] = [];
+  public async stopClients(folders?: string[]): Promise<void[]> {
+    const promises: Promise<void>[] = [];
 
-		if (this.supportsMultiFolders) {
-			promises.push(this.stopClient(MULTI_FOLDER_CLIENT));
-			return Promise.all(promises);
-		}
+    if (this.supportsMultiFolders) {
+      promises.push(this.stopClient(MULTI_FOLDER_CLIENT));
+      return Promise.all(promises);
+    }
 
-		if (!folders) {
-			folders = [];
-			for (const key of clients.keys()) {
-				folders.push(key);
-			}
-		}
+    if (!folders) {
+      folders = [];
+      for (const key of clients.keys()) {
+        folders.push(key);
+      }
+    }
 
-		for (const folder of folders) {
-			promises.push(this.stopClient(folder));
-		}
-		return Promise.all(promises);
-	}
+    for (const folder of folders) {
+      promises.push(this.stopClient(folder));
+    }
+    return Promise.all(promises);
+  }
 
-	private async stopClient(folder: string): Promise<void> {
-		if (!clients.has(folder)) {
-			console.log(`Attempted to stop a client for folder: ${folder} but no client exists`);
-			return;
-		}
-		
-		return clients.get(folder).client.stop().then(() => {
-			if (folder === "") {
-				console.log('Client stopped');
-				return
-			}
-			console.log(`Client stopped for ${folder}`);
-		}).then(() => {
-			const ok = clients.delete(folder);
-			if (ok) {
-				if (folder === "") {
-					console.log('Client deleted');
-					return
-				}
-				console.log(`Client deleted for ${folder}`);
-			}
-		});
-	}
+  private async stopClient(folder: string): Promise<void> {
+    if (!clients.has(folder)) {
+      console.log(`Attempted to stop a client for folder: ${folder} but no client exists`);
+      return;
+    }
 
-	private resolvedPathToBinary(): string {
-		const pathToBinary = this.lsPath.binPath()
-		let cmd: string
-		try {
-			if (path.isAbsolute(pathToBinary)) {
-				fs.accessSync(pathToBinary, fs.constants.X_OK);
-				cmd = pathToBinary;
-			} else {
-				cmd = which.sync(pathToBinary);
-			}
-			console.log(`Found server at ${cmd}`);
-		} catch (err) {
-			let extraHint: string;
-			if (this.lsPath.hasCustomBinPath()) {
-				extraHint = `. Check "${CUSTOM_BIN_PATH_OPTION_NAME}" in your settings.`
-			}
-			throw new Error(`Unable to launch language server: ${err.message}${extraHint}`);
-		}
+    return clients
+      .get(folder)
+      .client.stop()
+      .then(() => {
+        if (folder === '') {
+          console.log('Client stopped');
+          return;
+        }
+        console.log(`Client stopped for ${folder}`);
+      })
+      .then(() => {
+        const ok = clients.delete(folder);
+        if (ok) {
+          if (folder === '') {
+            console.log('Client deleted');
+            return;
+          }
+          console.log(`Client deleted for ${folder}`);
+        }
+      });
+  }
 
-		return cmd;
-	}
+  private resolvedPathToBinary(): string {
+    const pathToBinary = this.lsPath.binPath();
+    let cmd: string;
+    try {
+      if (path.isAbsolute(pathToBinary)) {
+        fs.accessSync(pathToBinary, fs.constants.X_OK);
+        cmd = pathToBinary;
+      } else {
+        cmd = which.sync(pathToBinary);
+      }
+      console.log(`Found server at ${cmd}`);
+    } catch (err) {
+      let extraHint: string;
+      if (this.lsPath.hasCustomBinPath()) {
+        extraHint = `. Check "${CUSTOM_BIN_PATH_OPTION_NAME}" in your settings.`;
+      }
+      throw new Error(`Unable to launch language server: ${err.message}${extraHint}`);
+    }
 
-	public getClient(document?: vscode.Uri): TerraformLanguageClient {
-		if (this.supportsMultiFolders) {
-			return clients.get(MULTI_FOLDER_CLIENT);
-		}
+    return cmd;
+  }
 
-		return clients.get(this.clientName(document.toString()));
-	}
+  public getClient(document?: vscode.Uri): TerraformLanguageClient {
+    if (this.supportsMultiFolders) {
+      return clients.get(MULTI_FOLDER_CLIENT);
+    }
 
-	private clientName(folderName: string, workspaceFolders: readonly string[] = sortedWorkspaceFolders()): string {
-		folderName = normalizeFolderName(folderName);
-		const outerFolder = workspaceFolders.find(element => folderName.startsWith(element));
-		// If this folder isn't nested, the found item will be itself
-		if (outerFolder && (outerFolder !== folderName)) {
-			folderName = getFolderName(getWorkspaceFolder(outerFolder));
-		}
-		return folderName;
-	}
+    return clients.get(this.clientName(document.toString()));
+  }
+
+  private clientName(folderName: string, workspaceFolders: readonly string[] = sortedWorkspaceFolders()): string {
+    folderName = normalizeFolderName(folderName);
+    const outerFolder = workspaceFolders.find((element) => folderName.startsWith(element));
+    // If this folder isn't nested, the found item will be itself
+    if (outerFolder && outerFolder !== folderName) {
+      folderName = getFolderName(getWorkspaceFolder(outerFolder));
+    }
+    return folderName;
+  }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,16 +1,13 @@
 import * as vscode from 'vscode';
-import {
-	ExecuteCommandParams,
-	ExecuteCommandRequest
-} from 'vscode-languageclient';
-import { LanguageClient } from 'vscode-languageclient/node';
-import { Utils } from 'vscode-uri'
 import TelemetryReporter from 'vscode-extension-telemetry';
-import { LanguageServerInstaller, isValidVersionString, defaultVersionString } from './languageServerInstaller';
+import { ExecuteCommandParams, ExecuteCommandRequest } from 'vscode-languageclient';
+import { LanguageClient } from 'vscode-languageclient/node';
+import { Utils } from 'vscode-uri';
 import { ClientHandler, TerraformLanguageClient } from './clientHandler';
-import { config, prunedFolderNames } from './vscodeUtils';
-import { SingleInstanceTimeout } from './utils';
+import { defaultVersionString, isValidVersionString, LanguageServerInstaller } from './languageServerInstaller';
 import { ServerPath } from './serverPath';
+import { SingleInstanceTimeout } from './utils';
+import { config, prunedFolderNames } from './vscodeUtils';
 
 const terraformStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
 
@@ -23,244 +20,275 @@ let clientHandler: ClientHandler;
 const languageServerUpdater = new SingleInstanceTimeout();
 
 export async function activate(context: vscode.ExtensionContext): Promise<any> {
-	const extensionVersion = vscode.extensions.getExtension(extensionId).packageJSON.version;
-	reporter = new TelemetryReporter(extensionId, extensionVersion, appInsightsKey);
-	context.subscriptions.push(reporter);
+  const extensionVersion = vscode.extensions.getExtension(extensionId).packageJSON.version;
+  reporter = new TelemetryReporter(extensionId, extensionVersion, appInsightsKey);
+  context.subscriptions.push(reporter);
 
-	const lsPath = new ServerPath(context);
-	clientHandler = new ClientHandler(lsPath, reporter);
+  const lsPath = new ServerPath(context);
+  clientHandler = new ClientHandler(lsPath, reporter);
 
-	// get rid of pre-2.0.0 settings
-	if (config('terraform').has('languageServer.enabled')) {
-		try {
-			await config('terraform').update('languageServer', { enabled: undefined, external: true }, vscode.ConfigurationTarget.Global);
-		} catch (err) {
-			console.error(`Error trying to erase pre-2.0.0 settings: ${err.message}`);
-		}
-	}
+  // get rid of pre-2.0.0 settings
+  if (config('terraform').has('languageServer.enabled')) {
+    try {
+      await config('terraform').update(
+        'languageServer',
+        { enabled: undefined, external: true },
+        vscode.ConfigurationTarget.Global,
+      );
+    } catch (err) {
+      console.error(`Error trying to erase pre-2.0.0 settings: ${err.message}`);
+    }
+  }
 
-	if (config('terraform').has('languageServer.requiredVersion')) {
-		const langServerVer = config('terraform').get('languageServer.requiredVersion', defaultVersionString)
-		if (!isValidVersionString(langServerVer)) {
-			vscode.window.showWarningMessage(`The Terraform Language Server Version string '${langServerVer}' is not a valid semantic version and will be ignored.`);
-		}
-	}
+  if (config('terraform').has('languageServer.requiredVersion')) {
+    const langServerVer = config('terraform').get('languageServer.requiredVersion', defaultVersionString);
+    if (!isValidVersionString(langServerVer)) {
+      vscode.window.showWarningMessage(
+        `The Terraform Language Server Version string '${langServerVer}' is not a valid semantic version and will be ignored.`,
+      );
+    }
+  }
 
-	// Subscriptions
-	context.subscriptions.push(
-		vscode.commands.registerCommand('terraform.enableLanguageServer', async () => {
-			if (!enabled()) {
-				const current = config('terraform').get('languageServer');
-				await config('terraform').update('languageServer', Object.assign(current, { external: true }), vscode.ConfigurationTarget.Global);
-			}
-			return updateLanguageServer(clientHandler, lsPath);
-		}),
-		vscode.commands.registerCommand('terraform.disableLanguageServer', async () => {
-			if (enabled()) {
-				const current = config('terraform').get('languageServer');
-				await config('terraform').update('languageServer', Object.assign(current, { external: false }), vscode.ConfigurationTarget.Global);
-			}
-			languageServerUpdater.clear();
-			return clientHandler.stopClients();
-		}),
-		vscode.commands.registerCommand('terraform.apply', async () => {
-			await terraformCommand('apply', false, clientHandler);
-		}),
-		vscode.commands.registerCommand('terraform.init', async () => {
-			const selected = await vscode.window.showOpenDialog({
-				canSelectFiles: false,
-				canSelectFolders: true,
-				canSelectMany: false,
-				defaultUri: vscode.workspace.workspaceFolders[0].uri,
-				openLabel: "Initialize"
-			});
-			if (selected) {
-				const moduleUri = selected[0];
-				const client = clientHandler.getClient(moduleUri);
-				const requestParams: ExecuteCommandParams = { command: `${client.commandPrefix}.terraform-ls.terraform.init`, arguments: [`uri=${moduleUri}`] };
-				await execWorkspaceCommand(client.client, requestParams);
-			}
-		}),
-		vscode.commands.registerCommand('terraform.initCurrent', async () => {
-			await terraformCommand('init', true, clientHandler);
-		}),
-		vscode.commands.registerCommand('terraform.plan', async () => {
-			await terraformCommand('plan', false, clientHandler);
-		}),
-		vscode.commands.registerCommand('terraform.validate', async () => {
-			await terraformCommand('validate', true, clientHandler);
-		}),
-		vscode.workspace.onDidChangeConfiguration(
-			async (event: vscode.ConfigurationChangeEvent) => {
-				if (event.affectsConfiguration('terraform') || event.affectsConfiguration('terraform-ls')) {
-					const reloadMsg = 'Reload VSCode window to apply language server changes';
-					const selected = await vscode.window.showInformationMessage(reloadMsg, 'Reload');
-					if (selected === 'Reload') {
-						vscode.commands.executeCommand('workbench.action.reloadWindow');
-					}
-				}
-			}
-		),
-		vscode.workspace.onDidChangeWorkspaceFolders(
-			async (event: vscode.WorkspaceFoldersChangeEvent) => {
-				if (event.removed.length > 0) {
-					await clientHandler.stopClients(prunedFolderNames(event.removed));
-				}
-				if (event.added.length > 0) {
-					clientHandler.startClients(prunedFolderNames(event.added));
-				}
-			}
-		),
-		vscode.window.onDidChangeActiveTextEditor(
-			async (event: vscode.TextEditor | undefined) => {
-				// Make sure there's an open document in a folder
-				// Also check whether they're running a different language server
-				// TODO: Check initializationOptions for command presence instead of pathToBinary
-				if (event && vscode.workspace.workspaceFolders[0] && !lsPath.hasCustomBinPath()) {
-					const documentUri = event.document.uri;
-					const client = clientHandler.getClient(documentUri);
-					const moduleUri = Utils.dirname(documentUri);
+  // Subscriptions
+  context.subscriptions.push(
+    vscode.commands.registerCommand('terraform.enableLanguageServer', async () => {
+      if (!enabled()) {
+        const current = config('terraform').get('languageServer');
+        await config('terraform').update(
+          'languageServer',
+          Object.assign(current, { external: true }),
+          vscode.ConfigurationTarget.Global,
+        );
+      }
+      return updateLanguageServer(clientHandler, lsPath);
+    }),
+    vscode.commands.registerCommand('terraform.disableLanguageServer', async () => {
+      if (enabled()) {
+        const current = config('terraform').get('languageServer');
+        await config('terraform').update(
+          'languageServer',
+          Object.assign(current, { external: false }),
+          vscode.ConfigurationTarget.Global,
+        );
+      }
+      languageServerUpdater.clear();
+      return clientHandler.stopClients();
+    }),
+    vscode.commands.registerCommand('terraform.apply', async () => {
+      await terraformCommand('apply', false, clientHandler);
+    }),
+    vscode.commands.registerCommand('terraform.init', async () => {
+      const selected = await vscode.window.showOpenDialog({
+        canSelectFiles: false,
+        canSelectFolders: true,
+        canSelectMany: false,
+        defaultUri: vscode.workspace.workspaceFolders[0].uri,
+        openLabel: 'Initialize',
+      });
+      if (selected) {
+        const moduleUri = selected[0];
+        const client = clientHandler.getClient(moduleUri);
+        const requestParams: ExecuteCommandParams = {
+          command: `${client.commandPrefix}.terraform-ls.terraform.init`,
+          arguments: [`uri=${moduleUri}`],
+        };
+        await execWorkspaceCommand(client.client, requestParams);
+      }
+    }),
+    vscode.commands.registerCommand('terraform.initCurrent', async () => {
+      await terraformCommand('init', true, clientHandler);
+    }),
+    vscode.commands.registerCommand('terraform.plan', async () => {
+      await terraformCommand('plan', false, clientHandler);
+    }),
+    vscode.commands.registerCommand('terraform.validate', async () => {
+      await terraformCommand('validate', true, clientHandler);
+    }),
+    vscode.workspace.onDidChangeConfiguration(async (event: vscode.ConfigurationChangeEvent) => {
+      if (event.affectsConfiguration('terraform') || event.affectsConfiguration('terraform-ls')) {
+        const reloadMsg = 'Reload VSCode window to apply language server changes';
+        const selected = await vscode.window.showInformationMessage(reloadMsg, 'Reload');
+        if (selected === 'Reload') {
+          vscode.commands.executeCommand('workbench.action.reloadWindow');
+        }
+      }
+    }),
+    vscode.workspace.onDidChangeWorkspaceFolders(async (event: vscode.WorkspaceFoldersChangeEvent) => {
+      if (event.removed.length > 0) {
+        await clientHandler.stopClients(prunedFolderNames(event.removed));
+      }
+      if (event.added.length > 0) {
+        clientHandler.startClients(prunedFolderNames(event.added));
+      }
+    }),
+    vscode.window.onDidChangeActiveTextEditor(async (event: vscode.TextEditor | undefined) => {
+      // Make sure there's an open document in a folder
+      // Also check whether they're running a different language server
+      // TODO: Check initializationOptions for command presence instead of pathToBinary
+      if (event && vscode.workspace.workspaceFolders[0] && !lsPath.hasCustomBinPath()) {
+        const documentUri = event.document.uri;
+        const client = clientHandler.getClient(documentUri);
+        const moduleUri = Utils.dirname(documentUri);
 
-					if (client) {
-						try {
-							const response = await moduleCallers(client, moduleUri.toString());
-							if (response.moduleCallers.length === 0) {
-								const dirName = Utils.basename(moduleUri);
-								terraformStatus.text = `$(refresh) ${dirName}`;
-								terraformStatus.color = new vscode.ThemeColor('statusBar.foreground');
-								terraformStatus.tooltip = `Click to run terraform init`;
-								terraformStatus.command = "terraform.initCurrent";
-								terraformStatus.show();
-							} else {
-								terraformStatus.hide();
-							}
-						} catch (err) {
-							vscode.window.showErrorMessage(err);
-							reporter.sendTelemetryException(err);
-							terraformStatus.hide();
-						}
-					}
-				}
-			}
-		)
-	);
+        if (client) {
+          try {
+            const response = await moduleCallers(client, moduleUri.toString());
+            if (response.moduleCallers.length === 0) {
+              const dirName = Utils.basename(moduleUri);
+              terraformStatus.text = `$(refresh) ${dirName}`;
+              terraformStatus.color = new vscode.ThemeColor('statusBar.foreground');
+              terraformStatus.tooltip = `Click to run terraform init`;
+              terraformStatus.command = 'terraform.initCurrent';
+              terraformStatus.show();
+            } else {
+              terraformStatus.hide();
+            }
+          } catch (err) {
+            vscode.window.showErrorMessage(err);
+            reporter.sendTelemetryException(err);
+            terraformStatus.hide();
+          }
+        }
+      }
+    }),
+  );
 
-	if (enabled()) {
-		try {
-			await vscode.commands.executeCommand('terraform.enableLanguageServer');
-		} catch (error) {
-			reporter.sendTelemetryException(error);
-		}
-	}
+  if (enabled()) {
+    try {
+      await vscode.commands.executeCommand('terraform.enableLanguageServer');
+    } catch (error) {
+      reporter.sendTelemetryException(error);
+    }
+  }
 
-	// export public API
-	return { clientHandler, moduleCallers };
+  // export public API
+  return { clientHandler, moduleCallers };
 }
 
 export function deactivate(): Promise<void[]> {
-	return clientHandler.stopClients();
+  return clientHandler.stopClients();
 }
 
 async function updateLanguageServer(clientHandler: ClientHandler, lsPath: ServerPath) {
-	console.log('Checking for language server updates...')
-	const hour = 1000 * 60 * 60;
-	languageServerUpdater.timeout(function() {
-		updateLanguageServer(clientHandler, lsPath);
-	}, 24 * hour);
+  console.log('Checking for language server updates...');
+  const hour = 1000 * 60 * 60;
+  languageServerUpdater.timeout(function () {
+    updateLanguageServer(clientHandler, lsPath);
+  }, 24 * hour);
 
-	try {
-		// skip install if a language server binary path is set
-		if (!lsPath.hasCustomBinPath()) {
-			const installer = new LanguageServerInstaller(lsPath, reporter);
-			const install = await installer.needsInstall(config('terraform').get('languageServer.requiredVersion', defaultVersionString));
-			if (install) {
-				await clientHandler.stopClients();
-				try {
-					await installer.install();
-				} catch (err) {
-					console.log(err); // for test failure reporting
-					reporter.sendTelemetryException(err);
-					throw err;
-				} finally {
-					await installer.cleanupZips();
-				}
-			}
-		}
-		// on repeat runs with no install, this will be a no-op
-		return clientHandler.startClients(prunedFolderNames());
-	} catch (error) {
-		console.log(error); // for test failure reporting
-		vscode.window.showErrorMessage(error.message);
-	}
+  try {
+    // skip install if a language server binary path is set
+    if (!lsPath.hasCustomBinPath()) {
+      const installer = new LanguageServerInstaller(lsPath, reporter);
+      const install = await installer.needsInstall(
+        config('terraform').get('languageServer.requiredVersion', defaultVersionString),
+      );
+      if (install) {
+        await clientHandler.stopClients();
+        try {
+          await installer.install();
+        } catch (err) {
+          console.log(err); // for test failure reporting
+          reporter.sendTelemetryException(err);
+          throw err;
+        } finally {
+          await installer.cleanupZips();
+        }
+      }
+    }
+    // on repeat runs with no install, this will be a no-op
+    return clientHandler.startClients(prunedFolderNames());
+  } catch (error) {
+    console.log(error); // for test failure reporting
+    vscode.window.showErrorMessage(error.message);
+  }
 }
 
 function execWorkspaceCommand(client: LanguageClient, params: ExecuteCommandParams): Promise<any> {
-	reporter.sendTelemetryEvent('execWorkspaceCommand', { command: params.command });
-	return client.sendRequest(ExecuteCommandRequest.type, params);
+  reporter.sendTelemetryEvent('execWorkspaceCommand', { command: params.command });
+  return client.sendRequest(ExecuteCommandRequest.type, params);
 }
 
 interface moduleCaller {
-	uri: string
+  uri: string;
 }
 
 interface moduleCallersResponse {
-	version: number,
-	moduleCallers: moduleCaller[]
+  version: number;
+  moduleCallers: moduleCaller[];
 }
 
 async function modulesCallersCommand(languageClient: TerraformLanguageClient, moduleUri: string): Promise<any> {
-	const requestParams: ExecuteCommandParams = { command: `${languageClient.commandPrefix}.terraform-ls.module.callers`, arguments: [`uri=${moduleUri}`] };
-	return execWorkspaceCommand(languageClient.client, requestParams);
+  const requestParams: ExecuteCommandParams = {
+    command: `${languageClient.commandPrefix}.terraform-ls.module.callers`,
+    arguments: [`uri=${moduleUri}`],
+  };
+  return execWorkspaceCommand(languageClient.client, requestParams);
 }
 
-async function moduleCallers(languageClient: TerraformLanguageClient, moduleUri: string): Promise<moduleCallersResponse> {
-	const response = await modulesCallersCommand(languageClient, moduleUri);
-	const moduleCallers: moduleCaller[] = response.callers;
+async function moduleCallers(
+  languageClient: TerraformLanguageClient,
+  moduleUri: string,
+): Promise<moduleCallersResponse> {
+  const response = await modulesCallersCommand(languageClient, moduleUri);
+  const moduleCallers: moduleCaller[] = response.callers;
 
-	return { version: response.v, moduleCallers };
+  return { version: response.v, moduleCallers };
 }
 
-async function terraformCommand(command: string, languageServerExec = true, clientHandler: ClientHandler): Promise<any> {
-	if (vscode.window.activeTextEditor) {
-		const documentUri = vscode.window.activeTextEditor.document.uri;
-		const languageClient = clientHandler.getClient(documentUri);
+async function terraformCommand(
+  command: string,
+  languageServerExec = true,
+  clientHandler: ClientHandler,
+): Promise<any> {
+  if (vscode.window.activeTextEditor) {
+    const documentUri = vscode.window.activeTextEditor.document.uri;
+    const languageClient = clientHandler.getClient(documentUri);
 
-		const moduleUri = Utils.dirname(documentUri)
-		const response = await moduleCallers(languageClient, moduleUri.toString());
+    const moduleUri = Utils.dirname(documentUri);
+    const response = await moduleCallers(languageClient, moduleUri.toString());
 
-		let selectedModule: string;
-		if (response.moduleCallers.length > 1) {
-			const selected = await vscode.window.showQuickPick(response.moduleCallers.map(m => m.uri), { canPickMany: false });
-			selectedModule = selected[0];
-		} else if (response.moduleCallers.length == 1) {
-			selectedModule = response.moduleCallers[0].uri;
-		} else {
-			selectedModule = moduleUri.toString();
-		}
+    let selectedModule: string;
+    if (response.moduleCallers.length > 1) {
+      const selected = await vscode.window.showQuickPick(
+        response.moduleCallers.map((m) => m.uri),
+        { canPickMany: false },
+      );
+      selectedModule = selected[0];
+    } else if (response.moduleCallers.length == 1) {
+      selectedModule = response.moduleCallers[0].uri;
+    } else {
+      selectedModule = moduleUri.toString();
+    }
 
-		if (languageServerExec) {
-			const requestParams: ExecuteCommandParams = { command: `${languageClient.commandPrefix}.terraform-ls.terraform.${command}`, arguments: [`uri=${selectedModule}`] };
-			return execWorkspaceCommand(languageClient.client, requestParams);
-		} else {
-			const terminalName = `Terraform ${selectedModule}`;
-			const moduleURI = vscode.Uri.parse(selectedModule);
-			const terraformCommand = await vscode.window.showInputBox(
-				{ value: `terraform ${command}`, prompt: `Run in ${selectedModule}` }
-			);
-			if (terraformCommand) {
-				const terminal = vscode.window.terminals.find(t => t.name == terminalName) ||
-					vscode.window.createTerminal({ name: `Terraform ${selectedModule}`, cwd: moduleURI });
-				terminal.sendText(terraformCommand);
-				terminal.show();
-			}
-			return;
-		}
-	} else {
-		vscode.window.showWarningMessage(`Open a module then run terraform ${command} again`);
-		return;
-	}
+    if (languageServerExec) {
+      const requestParams: ExecuteCommandParams = {
+        command: `${languageClient.commandPrefix}.terraform-ls.terraform.${command}`,
+        arguments: [`uri=${selectedModule}`],
+      };
+      return execWorkspaceCommand(languageClient.client, requestParams);
+    } else {
+      const terminalName = `Terraform ${selectedModule}`;
+      const moduleURI = vscode.Uri.parse(selectedModule);
+      const terraformCommand = await vscode.window.showInputBox({
+        value: `terraform ${command}`,
+        prompt: `Run in ${selectedModule}`,
+      });
+      if (terraformCommand) {
+        const terminal =
+          vscode.window.terminals.find((t) => t.name == terminalName) ||
+          vscode.window.createTerminal({ name: `Terraform ${selectedModule}`, cwd: moduleURI });
+        terminal.sendText(terraformCommand);
+        terminal.show();
+      }
+      return;
+    }
+  } else {
+    vscode.window.showWarningMessage(`Open a module then run terraform ${command} again`);
+    return;
+  }
 }
 
 function enabled(): boolean {
-	return config('terraform').get('languageServer.external');
+  return config('terraform').get('languageServer.external');
 }

--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -1,192 +1,211 @@
-import * as vscode from 'vscode';
+import { getRelease, Release } from '@hashicorp/js-releases';
 import * as del from 'del';
 import * as fs from 'fs';
 import * as path from 'path';
 import * as semver from 'semver';
+import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
-import { exec } from './utils';
 import { ServerPath } from './serverPath';
-import { Release, getRelease } from '@hashicorp/js-releases';
+import { exec } from './utils';
 
 const extensionVersion = vscode.extensions.getExtension('hashicorp.terraform').packageJSON.version;
-export const defaultVersionString = "latest";
+export const defaultVersionString = 'latest';
 
 export function isValidVersionString(value: string): boolean {
-	return semver.validRange(value,  { includePrerelease: true, loose: true }) !== null;
+  return semver.validRange(value, { includePrerelease: true, loose: true }) !== null;
 }
 
 export class LanguageServerInstaller {
-	constructor(
-		private lsPath: ServerPath,
-		private reporter: TelemetryReporter
-	) { }
+  constructor(private lsPath: ServerPath, private reporter: TelemetryReporter) {}
 
-	private userAgent = `Terraform-VSCode/${extensionVersion} VSCode/${vscode.version}`;
-	private release: Release;
+  private userAgent = `Terraform-VSCode/${extensionVersion} VSCode/${vscode.version}`;
+  private release: Release;
 
-	private async getRequiredVersionRelease(versionString: string): Promise<Release> {
-		try {
-			const release = await getRelease("terraform-ls", versionString, this.userAgent);
-			console.log(`Found Terraform language server version ${release.version} which satisfies range '${versionString}'`);
-			return release;
-		} catch (err) {
-			if (versionString == defaultVersionString) { throw err; }
-			console.log(`Error while finding Terraform language server release which satisfies range '${versionString}' and will reattempt with '${defaultVersionString}': ${err}`)
-			vscode.window.showWarningMessage(`No version matching ${versionString} found, searching for ${defaultVersionString} instead`);
-		}
+  private async getRequiredVersionRelease(versionString: string): Promise<Release> {
+    try {
+      const release = await getRelease('terraform-ls', versionString, this.userAgent);
+      console.log(
+        `Found Terraform language server version ${release.version} which satisfies range '${versionString}'`,
+      );
+      return release;
+    } catch (err) {
+      if (versionString == defaultVersionString) {
+        throw err;
+      }
+      console.log(
+        `Error while finding Terraform language server release which satisfies range '${versionString}' and will reattempt with '${defaultVersionString}': ${err}`,
+      );
+      vscode.window.showWarningMessage(
+        `No version matching ${versionString} found, searching for ${defaultVersionString} instead`,
+      );
+    }
 
-		// Attempt to find the latest release
-		const release = await getRelease("terraform-ls", defaultVersionString, this.userAgent);
-		console.log(`Found Default Terraform language server version ${release.version} which satisfies range '${defaultVersionString}'`);
-		return release;
-	}
+    // Attempt to find the latest release
+    const release = await getRelease('terraform-ls', defaultVersionString, this.userAgent);
+    console.log(
+      `Found Default Terraform language server version ${release.version} which satisfies range '${defaultVersionString}'`,
+    );
+    return release;
+  }
 
-	public async needsInstall(requiredVersion: string): Promise<boolean> {
-		// Silently default to latest if an invalid version string is passed.
-		// Actually telling the user about a bad string is left to the main extension code instead of here
-		const versionString = isValidVersionString(requiredVersion) ? requiredVersion : defaultVersionString;
-		try {
-			this.release = await this.getRequiredVersionRelease(versionString);
-		} catch (err) {
-			console.log(`Error while finding Terraform language server release which satisfies range '${versionString}': ${err}`)
-			// if the releases site is inaccessible, report it and skip the install
-			this.reporter.sendTelemetryException(err);
-			return false;
-		}
+  public async needsInstall(requiredVersion: string): Promise<boolean> {
+    // Silently default to latest if an invalid version string is passed.
+    // Actually telling the user about a bad string is left to the main extension code instead of here
+    const versionString = isValidVersionString(requiredVersion) ? requiredVersion : defaultVersionString;
+    try {
+      this.release = await this.getRequiredVersionRelease(versionString);
+    } catch (err) {
+      console.log(
+        `Error while finding Terraform language server release which satisfies range '${versionString}': ${err}`,
+      );
+      // if the releases site is inaccessible, report it and skip the install
+      this.reporter.sendTelemetryException(err);
+      return false;
+    }
 
-		let installedVersion: string;
-		try {
-			installedVersion = await getLsVersion(this.lsPath);
-			console.log(`Currently installed Terraform language server is version '${installedVersion}`)
-		} catch (err) {
-			// Most of the time, getLsVersion will produce "ENOENT: no such file or directory"
-			// on a fresh installation (unlike upgrade). It’s also possible that the file or directory
-			// is inaccessible for some other reason, but we catch that separately.
-			if (err.code !== 'ENOENT') {
-				this.reporter.sendTelemetryException(err);
-				throw err;
-			}
-			return true; // yes to new install
-		}
+    let installedVersion: string;
+    try {
+      installedVersion = await getLsVersion(this.lsPath);
+      console.log(`Currently installed Terraform language server is version '${installedVersion}`);
+    } catch (err) {
+      // Most of the time, getLsVersion will produce "ENOENT: no such file or directory"
+      // on a fresh installation (unlike upgrade). It’s also possible that the file or directory
+      // is inaccessible for some other reason, but we catch that separately.
+      if (err.code !== 'ENOENT') {
+        this.reporter.sendTelemetryException(err);
+        throw err;
+      }
+      return true; // yes to new install
+    }
 
-		this.reporter.sendTelemetryEvent('foundLsInstalled', { terraformLsVersion: installedVersion });
+    this.reporter.sendTelemetryEvent('foundLsInstalled', { terraformLsVersion: installedVersion });
 
-		if (semver.eq(this.release.version, installedVersion, { includePrerelease: true })) {
-			// Already at the specified version
-			return false;
-		} else if (semver.gt(this.release.version, installedVersion, { includePrerelease: true })) {
-			// Upgrade
-			const selected = await vscode.window.showInformationMessage(`A new language server release is available: ${this.release.version}. Install now?`, 'Install', 'Cancel');
-			return (selected === "Install");
-		} else {
-			// Downgrade
-			const selected = await vscode.window.showInformationMessage(`An older language server release is available: ${this.release.version}. Install now?`, 'Install', 'Cancel');
-			return (selected === "Install");
-		}
-	}
+    if (semver.eq(this.release.version, installedVersion, { includePrerelease: true })) {
+      // Already at the specified version
+      return false;
+    } else if (semver.gt(this.release.version, installedVersion, { includePrerelease: true })) {
+      // Upgrade
+      const selected = await vscode.window.showInformationMessage(
+        `A new language server release is available: ${this.release.version}. Install now?`,
+        'Install',
+        'Cancel',
+      );
+      return selected === 'Install';
+    } else {
+      // Downgrade
+      const selected = await vscode.window.showInformationMessage(
+        `An older language server release is available: ${this.release.version}. Install now?`,
+        'Install',
+        'Cancel',
+      );
+      return selected === 'Install';
+    }
+  }
 
-	public async install(): Promise<void> {
-		this.reporter.sendTelemetryEvent('installingLs', { terraformLsVersion: this.release.version });
-		try {
-			await this.installPkg(this.release);
-		} catch (err) {
-			vscode.window.showErrorMessage(`Unable to install terraform-ls: ${err.message}`);
-			throw err;
-		}
+  public async install(): Promise<void> {
+    this.reporter.sendTelemetryEvent('installingLs', { terraformLsVersion: this.release.version });
+    try {
+      await this.installPkg(this.release);
+    } catch (err) {
+      vscode.window.showErrorMessage(`Unable to install terraform-ls: ${err.message}`);
+      throw err;
+    }
 
-		this.showChangelog(this.release.version);
-	}
+    this.showChangelog(this.release.version);
+  }
 
-	async installPkg(release: Release): Promise<void> {
-		const installDir = this.lsPath.installPath();
-		const destination = path.resolve(installDir, `terraform-ls_v${release.version}.zip`);
-		fs.mkdirSync(installDir, { recursive: true }); // create install directory if missing
+  async installPkg(release: Release): Promise<void> {
+    const installDir = this.lsPath.installPath();
+    const destination = path.resolve(installDir, `terraform-ls_v${release.version}.zip`);
+    fs.mkdirSync(installDir, { recursive: true }); // create install directory if missing
 
-		const os = goOs();
-		const arch = goArch();
-		const build = release.getBuild(os, arch);
-		if (!build) {
-			throw new Error(`Install error: no matching terraform-ls binary for ${os}/${arch}`);
-		}
-		try {
-			this.removeOldBinary();
-		} catch {
-			// ignore missing binary (new install)
-		}
+    const os = goOs();
+    const arch = goArch();
+    const build = release.getBuild(os, arch);
+    if (!build) {
+      throw new Error(`Install error: no matching terraform-ls binary for ${os}/${arch}`);
+    }
+    try {
+      this.removeOldBinary();
+    } catch {
+      // ignore missing binary (new install)
+    }
 
-		return vscode.window.withProgress({
-			cancellable: true,
-			location: vscode.ProgressLocation.Notification,
-			title: "Installing terraform-ls"
-		}, async (progress) => {
-			progress.report({ increment: 30 });
-			await release.download(build.url, destination, this.userAgent);
-			progress.report({ increment: 30 });
-			await release.verify(destination, build.filename);
-			progress.report({ increment: 30 });
-			return release.unpack(installDir, destination);
-		});
-	}
+    return vscode.window.withProgress(
+      {
+        cancellable: true,
+        location: vscode.ProgressLocation.Notification,
+        title: 'Installing terraform-ls',
+      },
+      async (progress) => {
+        progress.report({ increment: 30 });
+        await release.download(build.url, destination, this.userAgent);
+        progress.report({ increment: 30 });
+        await release.verify(destination, build.filename);
+        progress.report({ increment: 30 });
+        return release.unpack(installDir, destination);
+      },
+    );
+  }
 
-	removeOldBinary(): void {
-		fs.unlinkSync(this.lsPath.binPath());
-	}
+  removeOldBinary(): void {
+    fs.unlinkSync(this.lsPath.binPath());
+  }
 
-	public async cleanupZips(): Promise<string[]> {
-		const pattern = path.resolve(this.lsPath.installPath(), 'terraform-ls*.zip');
-		return del(pattern, { force: true });
-	}
+  public async cleanupZips(): Promise<string[]> {
+    const pattern = path.resolve(this.lsPath.installPath(), 'terraform-ls*.zip');
+    return del(pattern, { force: true });
+  }
 
-	showChangelog(version: string): void {
-		vscode.window.showInformationMessage(`Installed terraform-ls ${version}.`, "View Changelog")
-			.then(selected => {
-				if (selected === "View Changelog") {
-					vscode.env.openExternal(vscode.Uri.parse(`https://github.com/hashicorp/terraform-ls/releases/tag/v${version}`));
-				}
-			});
-		return;
-	}
+  showChangelog(version: string): void {
+    vscode.window.showInformationMessage(`Installed terraform-ls ${version}.`, 'View Changelog').then((selected) => {
+      if (selected === 'View Changelog') {
+        vscode.env.openExternal(vscode.Uri.parse(`https://github.com/hashicorp/terraform-ls/releases/tag/v${version}`));
+      }
+    });
+    return;
+  }
 }
 
 async function getLsVersion(lsPath: ServerPath): Promise<string> {
-	const binPath = lsPath.binPath();
-	fs.accessSync(binPath, fs.constants.X_OK);
+  const binPath = lsPath.binPath();
+  fs.accessSync(binPath, fs.constants.X_OK);
 
-	try {
-		const jsonCmd: { stdout: string } = await exec(binPath, ['version', '-json']);
-		const jsonOutput = JSON.parse(jsonCmd.stdout);
-		return jsonOutput.version
-	} catch (err) {
-		// assume older version of LS which didn't have json flag
-		if (err.status != 0) {
-			const plainCmd: { stdout: string, stderr: string } = await exec(binPath, ['-version']);
-			return plainCmd.stdout || plainCmd.stderr;
-		} else {
-			throw err
-		}
-	}
+  try {
+    const jsonCmd: { stdout: string } = await exec(binPath, ['version', '-json']);
+    const jsonOutput = JSON.parse(jsonCmd.stdout);
+    return jsonOutput.version;
+  } catch (err) {
+    // assume older version of LS which didn't have json flag
+    if (err.status != 0) {
+      const plainCmd: { stdout: string; stderr: string } = await exec(binPath, ['-version']);
+      return plainCmd.stdout || plainCmd.stderr;
+    } else {
+      throw err;
+    }
+  }
 }
 
 function goOs(): string {
-	const platform = process.platform.toString();
-	if (platform === 'win32') {
-		return 'windows';
-	}
-	if (platform === 'sunos') {
-		return 'solaris';
-	}
-	return platform;
+  const platform = process.platform.toString();
+  if (platform === 'win32') {
+    return 'windows';
+  }
+  if (platform === 'sunos') {
+    return 'solaris';
+  }
+  return platform;
 }
 
 function goArch(): string {
-	const arch = process.arch;
+  const arch = process.arch;
 
-	if (arch === 'ia32') {
-		return '386';
-	}
-	if (arch === 'x64') {
-		return 'amd64';
-	}
+  if (arch === 'ia32') {
+    return '386';
+  }
+  if (arch === 'x64') {
+    return 'amd64';
+  }
 
-	return arch;
+  return arch;
 }

--- a/src/serverPath.ts
+++ b/src/serverPath.ts
@@ -1,40 +1,40 @@
-import * as vscode from 'vscode';
 import * as path from 'path';
+import * as vscode from 'vscode';
 
 const INSTALL_FOLDER_NAME = 'lsp';
 export const CUSTOM_BIN_PATH_OPTION_NAME = 'languageServer.pathToBinary';
 
 export class ServerPath {
-	private customBinPath: string;
+  private customBinPath: string;
 
-	constructor(private context: vscode.ExtensionContext ) {
-		this.customBinPath = vscode.workspace.getConfiguration('terraform').get(CUSTOM_BIN_PATH_OPTION_NAME);
-	}
+  constructor(private context: vscode.ExtensionContext) {
+    this.customBinPath = vscode.workspace.getConfiguration('terraform').get(CUSTOM_BIN_PATH_OPTION_NAME);
+  }
 
-	public installPath(): string {
-		return this.context.asAbsolutePath(INSTALL_FOLDER_NAME);
-	}
+  public installPath(): string {
+    return this.context.asAbsolutePath(INSTALL_FOLDER_NAME);
+  }
 
-	public hasCustomBinPath(): boolean {
-		return !!this.customBinPath;
-	}
+  public hasCustomBinPath(): boolean {
+    return !!this.customBinPath;
+  }
 
-	public binPath(): string {
-		if (this.hasCustomBinPath()) {
-			return this.customBinPath;
-		}
+  public binPath(): string {
+    if (this.hasCustomBinPath()) {
+      return this.customBinPath;
+    }
 
-		return path.resolve(this.installPath(), this.binName());
-	}
+    return path.resolve(this.installPath(), this.binName());
+  }
 
-	public binName(): string {
-		if (this.hasCustomBinPath()) {
-			return path.basename(this.customBinPath);
-		}
+  public binName(): string {
+    if (this.hasCustomBinPath()) {
+      return path.basename(this.customBinPath);
+    }
 
-		if (process.platform === 'win32') {
-			return 'terraform-ls.exe'
-		}
-		return 'terraform-ls';
-	}
+    if (process.platform === 'win32') {
+      return 'terraform-ls.exe';
+    }
+    return 'terraform-ls';
+  }
 }

--- a/src/showReferences.ts
+++ b/src/showReferences.ts
@@ -1,65 +1,64 @@
 import * as vscode from 'vscode';
 import {
-	ClientCapabilities,
-	ServerCapabilities,
-	StaticFeature,
-	ReferencesRequest,
-	ReferenceContext, 
-	BaseLanguageClient
+  BaseLanguageClient,
+  ClientCapabilities,
+  ReferenceContext,
+  ReferencesRequest,
+  ServerCapabilities,
+  StaticFeature,
 } from 'vscode-languageclient';
 
 type Position = {
-	line: number;
-	character: number;
-}
+  line: number;
+  character: number;
+};
 
 type RefContext = {
-	includeDeclaration: boolean;
-}
+  includeDeclaration: boolean;
+};
 
 const CLIENT_CMD_ID = 'client.showReferences';
-const VSCODE_SHOW_REFERENCES = 'editor.action.showReferences'
+const VSCODE_SHOW_REFERENCES = 'editor.action.showReferences';
 
 export class ShowReferencesFeature implements StaticFeature {
-	private registeredCommands: vscode.Disposable[] = [];
+  private registeredCommands: vscode.Disposable[] = [];
 
-	constructor(private _client: BaseLanguageClient) {
-	}
+  constructor(private _client: BaseLanguageClient) {}
 
-	public fillClientCapabilities(capabilities: ClientCapabilities): void {
-		if (!capabilities['experimental']) {
-			capabilities['experimental'] = {};
-		}
-		capabilities['experimental']['showReferencesCommandId'] = CLIENT_CMD_ID;
-	}
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    if (!capabilities['experimental']) {
+      capabilities['experimental'] = {};
+    }
+    capabilities['experimental']['showReferencesCommandId'] = CLIENT_CMD_ID;
+  }
 
-	public initialize(capabilities: ServerCapabilities): void {
-		if ( !capabilities.experimental?.referenceCountCodeLens ) {
-			return
-		}
+  public initialize(capabilities: ServerCapabilities): void {
+    if (!capabilities.experimental?.referenceCountCodeLens) {
+      return;
+    }
 
-		const showRefs = vscode.commands.registerCommand(CLIENT_CMD_ID, async (pos: Position, refCtx: RefContext) => {
-			const client = this._client;
+    const showRefs = vscode.commands.registerCommand(CLIENT_CMD_ID, async (pos: Position, refCtx: RefContext) => {
+      const client = this._client;
 
-			const doc = vscode.window.activeTextEditor.document;
+      const doc = vscode.window.activeTextEditor.document;
 
-			const position = new vscode.Position(pos.line, pos.character);
-			const context: ReferenceContext = {includeDeclaration: refCtx.includeDeclaration}
+      const position = new vscode.Position(pos.line, pos.character);
+      const context: ReferenceContext = { includeDeclaration: refCtx.includeDeclaration };
 
-			const provider: vscode.ReferenceProvider = client.getFeature(ReferencesRequest.method).getProvider(doc);
-			const tokenSource: vscode.CancellationTokenSource = new vscode.CancellationTokenSource();
+      const provider: vscode.ReferenceProvider = client.getFeature(ReferencesRequest.method).getProvider(doc);
+      const tokenSource: vscode.CancellationTokenSource = new vscode.CancellationTokenSource();
 
-			const locations = await provider.provideReferences(doc, position, context, tokenSource.token);
+      const locations = await provider.provideReferences(doc, position, context, tokenSource.token);
 
-			await vscode.commands.executeCommand(VSCODE_SHOW_REFERENCES, doc.uri, position, locations);
-		})
-		this.registeredCommands.push(showRefs);
-	}
- 
-	public dispose(): void {
-		this.registeredCommands.forEach(function(cmd, index, commands) {
-			cmd.dispose();
-			commands.splice(index, 1);
-		})
-	}
+      await vscode.commands.executeCommand(VSCODE_SHOW_REFERENCES, doc.uri, position, locations);
+    });
+    this.registeredCommands.push(showRefs);
+  }
+
+  public dispose(): void {
+    this.registeredCommands.forEach(function (cmd, index, commands) {
+      cmd.dispose();
+      commands.splice(index, 1);
+    });
+  }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,35 +1,44 @@
 import * as cp from 'child_process';
 
-export function exec(cmd: string, args: readonly string[]): Promise<{ stdout: string, stderr: string }> {
-	return new Promise((resolve, reject) => {
-		cp.execFile(cmd, args, (err, stdout, stderr) => {
-			if (err) {
-				return reject(err);
-			}
-			return resolve({ stdout, stderr });
-		});
-	});
+export function exec(cmd: string, args: readonly string[]): Promise<{ stdout: string; stderr: string }> {
+  return new Promise((resolve, reject) => {
+    cp.execFile(cmd, args, (err, stdout, stderr) => {
+      if (err) {
+        return reject(err);
+      }
+      return resolve({ stdout, stderr });
+    });
+  });
 }
 
 export async function sleep(ms: number): Promise<void> {
-	return new Promise(resolve => setTimeout(resolve, ms));
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
 // A small wrapper around setTimeout which ensures that only a single timeout
 // timer can be running at a time. Attempts to add a new timeout silently fail.
 export class SingleInstanceTimeout {
-	private timerLock = false;
-	private timerId: NodeJS.Timeout;
+  private timerLock = false;
+  private timerId: NodeJS.Timeout;
 
-	public timeout(fn, delay, ...args) {
-		if (!this.timerLock) {
-			this.timerLock = true;
-			this.timerId = setTimeout(function () { this.timerLock = false; fn() }, delay, args)
-		}
-	}
+  public timeout(fn, delay, ...args) {
+    if (!this.timerLock) {
+      this.timerLock = true;
+      this.timerId = setTimeout(
+        function () {
+          this.timerLock = false;
+          fn();
+        },
+        delay,
+        args,
+      );
+    }
+  }
 
-	public clear() {
-		if (this.timerId) { clearTimeout(this.timerId) }
-		this.timerLock = false;
-	}
+  public clear() {
+    if (this.timerId) {
+      clearTimeout(this.timerId);
+    }
+    this.timerLock = false;
+  }
 }

--- a/src/vscodeUtils.ts
+++ b/src/vscodeUtils.ts
@@ -1,51 +1,54 @@
 import * as vscode from 'vscode';
 
 export function config(section: string, scope?: vscode.ConfigurationScope): vscode.WorkspaceConfiguration {
-	return vscode.workspace.getConfiguration(section, scope);
+  return vscode.workspace.getConfiguration(section, scope);
 }
 
 export function getFolderName(folder: vscode.WorkspaceFolder): string {
-	return normalizeFolderName(folder.uri.toString());
+  return normalizeFolderName(folder.uri.toString());
 }
 
 // Make sure that folder uris always end with a slash
 export function normalizeFolderName(folderName: string): string {
-	if (folderName.charAt(folderName.length - 1) !== '/') {
-		folderName = folderName + '/';
-	}
-	return folderName;
+  if (folderName.charAt(folderName.length - 1) !== '/') {
+    folderName = folderName + '/';
+  }
+  return folderName;
 }
 
 export function getWorkspaceFolder(folderName: string): vscode.WorkspaceFolder {
-	return vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(folderName));
+  return vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(folderName));
 }
 
-export function prunedFolderNames(folders: readonly vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders): string[] {
-	const result = [];
-	// Sort workspace folders so that outer folders (shorter path) go before inner ones
-	const workspaceFolders = sortedWorkspaceFolders();
-	if (folders && workspaceFolders) {
-		const folderNames = folders.map(f => getFolderName(f));
-		for (let name of folderNames) {
-			const outerFolder = workspaceFolders.find(element => name.startsWith(element));
-			// If this folder isn't nested, the found item will be itself
-			if (outerFolder && (outerFolder !== name)) {
-				name = getFolderName(getWorkspaceFolder(outerFolder));
-			}
-			result.push(name);
-		}
-	}
+export function prunedFolderNames(
+  folders: readonly vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders,
+): string[] {
+  const result = [];
+  // Sort workspace folders so that outer folders (shorter path) go before inner ones
+  const workspaceFolders = sortedWorkspaceFolders();
+  if (folders && workspaceFolders) {
+    const folderNames = folders.map((f) => getFolderName(f));
+    for (let name of folderNames) {
+      const outerFolder = workspaceFolders.find((element) => name.startsWith(element));
+      // If this folder isn't nested, the found item will be itself
+      if (outerFolder && outerFolder !== name) {
+        name = getFolderName(getWorkspaceFolder(outerFolder));
+      }
+      result.push(name);
+    }
+  }
 
-	return result;
+  return result;
 }
 
 export function sortedWorkspaceFolders(): string[] {
-	const workspaceFolders = vscode.workspace.workspaceFolders;
-	if (workspaceFolders) {
-		return vscode.workspace.workspaceFolders.map(f => getFolderName(f)).sort(
-			(a, b) => {
-				return a.length - b.length;
-			});
-	}
-	return [];
+  const workspaceFolders = vscode.workspace.workspaceFolders;
+  if (workspaceFolders) {
+    return vscode.workspace.workspaceFolders
+      .map((f) => getFolderName(f))
+      .sort((a, b) => {
+        return a.length - b.length;
+      });
+  }
+  return [];
 }


### PR DESCRIPTION
Using the prettier and eslint configuration set in 790129a2d41f22afa398230c9c0c87d343d88d0a, this applies all formatting fixes and style changes necessary.

This also converts the spacing for the snippet, syntax and language configuration files to ensure consistent spacing, but does not format the file in order to not change the order of the snippets.

This also formarts the VS Code launch and task json files to cleanup the spacing and line endings.
