### PR TITLE
gitattributes: ensure all text files end with LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,4 +1,8 @@
-* text eol=lf
-# special shasum test can't have linefeeds change
-# https://github.com/actions/checkout/issues/226
-shasumtest.txt text eol=lf
+# Ensure line endings are always Unix-style for known text files
+# GitHub Actions CI doesn't have "native" solution for this
+# See https://github.com/actions/checkout/issues/226
+*.ts text eol=lf
+*.json text eol=lf
+*.md text eol=lf
+*.tf text eol=lf
+*.txt text eol=lf


### PR DESCRIPTION
This is in preparation for automating marketplace publishing, which will run on GitHub-hosted Windows instance.

The original configuration has a few problems:
 - every file is treated as text (including files which should be treated as binaries)
 - some binary files have their line endings converted after checkout on Windows, which then prevents publishing

```
Run npx -- vsce publish 2.14.1
 ERROR  Command failed: npm version 2.14.1
npm ERR! Git working directory not clean.
npm ERR! M terraform-banner.png
npm ERR! M terraform.png

npm ERR! A complete log of this run can be found in:
npm ERR!     C:\npm\cache\_logs\2021-09-15T07_53_35_881Z-debug.log
```