### PR TITLE
package.json: prevent accidental npm publishing

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "version": "2.14.0",
   "publisher": "hashicorp",
   "license": "MPL-2.0",
+  "private": true,
   "engines": {
     "npm": "^7.17.0",
     "vscode": "^1.50.1"


### PR DESCRIPTION
VS Code Extensions are never published as NPM packages, so this prevents any accidental publishing and follows a practice used by Go VS Code extension.

https://github.com/golang/vscode-go/blob/23a2db0dca292ef4e5fdf951d309722eb9529813/package.json#L25