### PR TITLE
ci: Read node version from nvmrc

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,15 +7,22 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: windows-latest
+    runs-on: ubuntu-latest
     steps:
       - name: checkout repo
         uses: actions/checkout@v2
 
+      - name: Read NodeJS version
+        id: nodejs-version
+        run: |
+          content=`cat ./.nvmrc`
+          echo "::set-output name=content::$content"
+
       - name: setup node
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          # See https://github.com/actions/setup-node/issues/32
+          node-version: ${{ steps.nodejs-version.outputs.content }}
 
       - name: clean install dependencies
         run: npm ci    

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,10 +15,17 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Use Node.js 14.x
+      -
+        name: Read Node.js version (Unix)
+        id: nodejs-version
+        run: |
+          content=`cat ./.nvmrc`
+          echo "::set-output name=content::$content"
+      - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          # See https://github.com/actions/setup-node/issues/32
+          node-version: ${{ steps.nodejs-version.outputs.content }}
       - name: npm install
         run: npm install
       - name: lint
@@ -27,17 +34,36 @@ jobs:
   test:
     strategy:
       matrix:
-        os: [windows-latest, macos-latest, macos-11.0, ubuntu-latest]
+        os:
+          - windows-latest
+          - macos-latest
+          - macos-11.0
+          - ubuntu-latest
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
 
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      - name: Use Node.js 14.x
+      -
+        name: Read Node.js version (Unix)
+        if: ${{ runner.os != 'Windows' }}
+        id: nodejs-version-unix
+        run: |
+          content=`cat ./.nvmrc`
+          echo "::set-output name=content::$content"
+      -
+        name: Read Node.js version (Windows)
+        if: ${{ runner.os == 'Windows' }}
+        id: nodejs-version-win
+        run: |
+          $content = Get-Content .\.nvmrc -Raw
+          echo "::set-output name=content::$content"
+      - name: Setup Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 14.x
+          # See https://github.com/actions/setup-node/issues/32
+          node-version: ${{ steps.nodejs-version-unix.outputs.content || steps.nodejs-version-win.outputs.content }}
       - name: Set up Xvfb (Ubuntu)
         run: |
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &


### PR DESCRIPTION
This is to make future updates of Node.js easier, to prepare for automation of Marketplace publishing and also to align version management with what we do in LS and elsewhere:

https://github.com/hashicorp/terraform-ls/blob/356136b9444ecf2274b9d28947f18e8a71f9fd0e/.github/workflows/ci.yml#L70-L90