### PR TITLE
ci: constraint Terraform for testing to `~1.0`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -47,6 +47,7 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           terraform_wrapper: false
+          terraform_version: "~1.0"
       - name: Clean Install Dependencies
         run: npm ci
       - name: Run Tests


### PR DESCRIPTION
We generally expect the extension to work with latest stable versions of Terraform, but this gives us more predictability and better reproducible test failures (if any occur).

https://www.npmjs.com/package/semver#ranges