### PR TITLE
fix: avoid tracking client which is not ready yet

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -118,7 +118,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
         await clientHandler.stopClients(prunedFolderNames(event.removed));
       }
       if (event.added.length > 0) {
-        clientHandler.startClients(prunedFolderNames(event.added));
+        await clientHandler.startClients(prunedFolderNames(event.added));
       }
     }),
     vscode.window.onDidChangeActiveTextEditor(async (event: vscode.TextEditor | undefined) => {
@@ -197,7 +197,7 @@ async function updateLanguageServer(clientHandler: ClientHandler, lsPath: Server
       }
     }
     // on repeat runs with no install, this will be a no-op
-    return clientHandler.startClients(prunedFolderNames());
+    return await clientHandler.startClients(prunedFolderNames());
   } catch (error) {
     console.log(error); // for test failure reporting
     vscode.window.showErrorMessage(error.message);


### PR DESCRIPTION
This is to address a long-term issue which was also spotted in https://github.com/hashicorp/vscode-terraform/pull/771#discussion_r709226812