### PR TITLE
ci: change windows-style slash to unix-style

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,4 +34,4 @@ jobs:
         uses: actions/upload-artifact@v1
         with:
           name: vscode-terraform-${{github.sha}}.vsix
-          path: ${{github.workspace}}\extension.vsix
+          path: ${{github.workspace}}/extension.vsix


### PR DESCRIPTION
This is to address the following failure:
https://github.com/hashicorp/vscode-terraform/actions/runs/1258148142