### PR TITLE
Prevent Module View Provider from failing to call LS

### DIFF
--- a/package.json
+++ b/package.json
@@ -264,7 +264,7 @@
     "viewsWelcome": [
       {
         "view": "terraform.modules",
-        "contents": "The active editor cannot provide information about installed modules. [Learn more about modules](https://www.terraform.io/docs/language/modules/develop/index.html) You may need to run 'terraform get'"
+        "contents": "The active editor cannot provide information about installed modules. [Learn more about modules](https://www.terraform.io/docs/language/modules/develop/index.html) You may need to run 'terraform get' or update your language server version."
       }
     ]
   },

--- a/src/providers/moduleProvider.ts
+++ b/src/providers/moduleProvider.ts
@@ -106,6 +106,14 @@ export class ModuleProvider implements vscode.TreeDataProvider<ModuleCall> {
     const handler = this.handler.getClient(editor);
 
     return await handler.client.onReady().then(async () => {
+      const moduleCallsSupported = this.handler.clientSupportsCommand(
+        `${handler.commandPrefix}.terraform-ls.module.calls`,
+        editor,
+      );
+      if (!moduleCallsSupported) {
+        return Promise.resolve([]);
+      }
+
       const params: ExecuteCommandParams = {
         command: `${handler.commandPrefix}.terraform-ls.module.calls`,
         arguments: [`uri=${documentURI}`],


### PR DESCRIPTION
This detects whether the currently installed Language Server supports the module calls command before calling the Language Server command. This prevents the provider from throwing an error with a LS that doesn't have the command.
