### PR TITLE
Update launch configuration and tasks

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,31 +1,30 @@
 {
-	"version": "0.2.0",
-	"configurations": [
-
-		{
-			"type": "extensionHost",
-			"request": "launch",
-			"name": "Launch Client",
-			"runtimeExecutable": "${execPath}",
-			"args": ["--extensionDevelopmentPath=${workspaceRoot}"],
-			"outFiles": ["${workspaceRoot}/out/**/*.js"],
-			"preLaunchTask": {
-				"type": "npm",
-				"script": "watch"
-			}
-		},
-		{
-			"name": "Run Extension Tests",
-			"type": "extensionHost",
-			"request": "launch",
-			"runtimeExecutable": "${execPath}",
-			"args": [
-				"--extensionDevelopmentPath=${workspaceFolder}",
-				"--extensionTestsPath=${workspaceFolder}/out/test/index",
-				"${workspaceFolder}/testFixture"
-			],
-			"outFiles": ["${workspaceFolder}/out/test/**/*.js"],
-			"preLaunchTask": "initAndWatch"
-		}
-	]
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Launch Client",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": ["--extensionDevelopmentPath=${workspaceRoot}"],
+      "outFiles": ["${workspaceRoot}/out/**/*.js"],
+      "preLaunchTask": {
+        "type": "npm",
+        "script": "watch"
+      }
+    },
+    {
+      "name": "Run Extension Tests",
+      "type": "extensionHost",
+      "request": "launch",
+      "runtimeExecutable": "${execPath}",
+      "args": [
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--extensionTestsPath=${workspaceFolder}/out/test/index",
+        "${workspaceFolder}/testFixture"
+      ],
+      "outFiles": ["${workspaceFolder}/out/test/**/*.js"],
+      "preLaunchTask": "terraformInitAndWatch"
+    }
+  ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,68 +1,32 @@
 {
-	"version": "2.0.0",
-	"tasks": [
-		{
-			"type": "npm",
-			"script": "compile",
-			"group": "build",
-			"presentation": {
-				"panel": "dedicated",
-				"reveal": "never"
-			},
-			"problemMatcher": [
-				"$tsc"
-			]
-		},
-		{
-			"type": "npm",
-			"script": "watch",
-			"isBackground": true,
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
-			"presentation": {
-				"panel": "dedicated",
-				"reveal": "never"
-			},
-			"problemMatcher": [
-				"$tsc-watch"
-			]
-		},
-		{
-			"label": "init",
-			"type": "process",
-			"command": "terraform",
-			"args": [
-				"init"
-			],
-			"options": {
-				"cwd": "${workspaceFolder}/testFixture"
-			},
-			"presentation": {
-				"panel": "dedicated",
-				"reveal": "never"
-			},
-		},
-		{
-			"label": "initAndWatch",
-			"type": "npm",
-			"script": "watch",
-			"isBackground": true,
-			"group": {
-				"kind": "build",
-				"isDefault": true
-			},
-			"presentation": {
-				"panel": "dedicated",
-				"reveal": "never"
-			},
-			"problemMatcher": [
-				"$tsc-watch"
-			],
-			"dependsOn": [
-				"init"
-			]
-		},
-	]
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "type": "npm",
+      "script": "watch",
+      "problemMatcher": "$tsc-watch",
+      "isBackground": true,
+      "presentation": {
+        "reveal": "never"
+      },
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      }
+    },
+    {
+      "label": "terraformInitAndWatch",
+      "type": "process",
+      "command": "terraform",
+      "args": ["init"],
+      "options": {
+        "cwd": "${workspaceFolder}/testFixture"
+      },
+      "presentation": {
+        "panel": "dedicated",
+        "reveal": "never"
+      },
+      "dependsOn":"npm: watch"
+    },
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -270,12 +270,12 @@
   },
   "scripts": {
     "vscode:prepublish": "npm run compile",
-    "package": "vsce package",
-    "compile": "tsc -b",
-    "watch": "tsc -b -w",
-    "lint": "eslint src/**/*.ts",
-    "test-compile": "tsc -p ./",
-    "test": "npm run test-compile && node ./out/test/runTest.js"
+    "compile": "tsc -p ./",
+    "watch": "tsc -watch -p ./",
+    "lint": "eslint src --ext ts",
+    "pretest": "npm run compile && npm run lint",
+    "test": "node ./out/test/runTest.js",
+    "package": "vsce package"
   },
   "dependencies": {
     "@hashicorp/js-releases": "^1.4.0",


### PR DESCRIPTION
This modifies `launch.json` and `tasks.json` to only run `terraform init` when running the tests through the ExtensionHost. This allows debugging the extension without running terraform each time, taking the total time to start the ExtensionHost from several seconds to less than one.

This also reduces tasks.json task references to npm scripts to one entry for `npm watch` and consolidates the `terraform init` task to one entry.

It also removes the need to have terraform installed just to debug the extension, as the primary reason is to debug is interactions with the language server which doesn't use the binary for most operations.

Fixes #622
