### PR TITLE
Resolve extension identifiers from manifest

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,12 +5,13 @@
   "description": "Syntax highlighting and autocompletion for Terraform",
   "version": "2.15.0",
   "publisher": "hashicorp",
+  "appInsightsKey": "885372d2-6f3c-499f-9d25-b8b219983a52",
   "license": "MPL-2.0",
   "private": true,
   "engines": {
     "npm": "~6.X",
     "node": "~14.X",
-    "vscode": "^1.52.0"
+    "vscode": "^1.55.0"
   },
   "qna": "https://discuss.hashicorp.com/c/terraform-core/terraform-editor-integrations/46",
   "bugs": {

--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -8,7 +8,6 @@ import TelemetryReporter from 'vscode-extension-telemetry';
 import { ServerPath } from './serverPath';
 import { exec } from './utils';
 
-const extensionVersion = vscode.extensions.getExtension('hashicorp.terraform').packageJSON.version;
 export const defaultVersionString = 'latest';
 
 export function isValidVersionString(value: string): boolean {
@@ -16,9 +15,9 @@ export function isValidVersionString(value: string): boolean {
 }
 
 export class LanguageServerInstaller {
-  constructor(private lsPath: ServerPath, private reporter: TelemetryReporter) {}
+  constructor(private extensionVersion: string, private lsPath: ServerPath, private reporter: TelemetryReporter) {}
 
-  private userAgent = `Terraform-VSCode/${extensionVersion} VSCode/${vscode.version}`;
+  private userAgent = `Terraform-VSCode/${this.extensionVersion} VSCode/${vscode.version}`;
   private release: Release;
 
   private async getRequiredVersionRelease(versionString: string): Promise<Release> {

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -8,51 +8,54 @@ export let documentEol: string;
 export let platformEol: string;
 
 export async function open(docUri: vscode.Uri): Promise<void> {
-	try {
-		await activated();
-		doc = await vscode.workspace.openTextDocument(docUri);
-		editor = await vscode.window.showTextDocument(doc);
-	} catch (e) {
-		console.error(e);
-		throw e;
-	}
+  try {
+    await activated();
+    doc = await vscode.workspace.openTextDocument(docUri);
+    editor = await vscode.window.showTextDocument(doc);
+  } catch (e) {
+    console.error(e);
+    throw e;
+  }
+}
+
+export function getExtensionId(): string {
+  var pjson = require('../../package.json');
+  return `${pjson.publisher}.${pjson.name}`;
 }
 
 let _activatedPromise: Promise<void>;
 async function activated() {
-	if (!_activatedPromise) {
-		try {
-			// The extensionId is `publisher.name` from package.json
-			const ext = vscode.extensions.getExtension('hashicorp.terraform');
-			if (!ext.isActive) {
-				console.log('Activating hashicorp.terraform extension');
-				await ext.activate();
-			} else {
-				console.log('hashicorp.terraform is already active');
-			}
-			// TODO: implement proper synchronization/status check in LS
-			// give server(s) some time to startup
-			_activatedPromise = sleep(8000);
-		} catch (err) {
-			_activatedPromise = Promise.reject(err);
-		}
-	}
-	return _activatedPromise;
+  if (!_activatedPromise) {
+    try {
+      // The extensionId is `publisher.name` from package.json
+			const extId = getExtensionId()
+      const ext = vscode.extensions.getExtension(extId);
+      if (!ext.isActive) {
+        console.log('Activating hashicorp.terraform extension');
+        await ext.activate();
+      } else {
+        console.log('hashicorp.terraform is already active');
+      }
+      // TODO: implement proper synchronization/status check in LS
+      // give server(s) some time to startup
+      _activatedPromise = sleep(8000);
+    } catch (err) {
+      _activatedPromise = Promise.reject(err);
+    }
+  }
+  return _activatedPromise;
 }
 
 export const testFolderPath = path.resolve(__dirname, '..', '..', 'testFixture');
 
 export const getDocPath = (p: string): string => {
-	return path.resolve(__dirname, '../../testFixture', p);
+  return path.resolve(__dirname, '../../testFixture', p);
 };
 export const getDocUri = (p: string): vscode.Uri => {
-	return vscode.Uri.file(getDocPath(p));
+  return vscode.Uri.file(getDocPath(p));
 };
 
 export async function setTestContent(content: string): Promise<boolean> {
-	const all = new vscode.Range(
-		doc.positionAt(0),
-		doc.positionAt(doc.getText().length)
-	);
-	return editor.edit(eb => eb.replace(all, content));
+  const all = new vscode.Range(doc.positionAt(0), doc.positionAt(doc.getText().length));
+  return editor.edit((eb) => eb.replace(all, content));
 }

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -42,7 +42,7 @@ async function main(): Promise<void> {
     await runTests({
       extensionDevelopmentPath,
       extensionTestsPath,
-      version: '1.52.0',
+      version: '1.55.0',
       launchArgs: ['testFixture', '--disable-extensions'],
     });
   } catch (err) {

--- a/src/test/workspaces.test.ts
+++ b/src/test/workspaces.test.ts
@@ -1,9 +1,11 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { Utils } from 'vscode-uri';
-import { getDocUri, open, testFolderPath } from './helper';
+import { getDocUri, getExtensionId, open, testFolderPath } from './helper';
 
-const ext = vscode.extensions.getExtension('hashicorp.terraform');
+
+const extId = getExtensionId()
+const ext = vscode.extensions.getExtension(extId);
 
 suite('moduleCallers', () => {
 	test('should execute language server command', async () => {


### PR DESCRIPTION
This pulls the extension identifiers from the package.json file using the extension context instead of hard coding them. It also moves the appInsightsKey to the package.json file.

Closes #786 