### PR TITLE
Install LS into dedicated (persistent) global storage

### DIFF
--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -125,9 +125,16 @@ export class LanguageServerInstaller {
       throw new Error(`Install error: no matching terraform-ls binary for ${os}/${arch}`);
     }
     try {
-      this.removeOldBinary();
+      fs.unlinkSync(this.lsPath.binPath());
     } catch {
       // ignore missing binary (new install)
+    }
+
+    try {
+      fs.unlinkSync(this.lsPath.legacyBinPath());
+    } catch {
+      // clean up may fail for new installation
+      // or in new versions where this path is no longer in use
     }
 
     return vscode.window.withProgress(
@@ -145,10 +152,6 @@ export class LanguageServerInstaller {
         return release.unpack(installDir, destination);
       },
     );
-  }
-
-  removeOldBinary(): void {
-    fs.unlinkSync(this.lsPath.binPath());
   }
 
   public async cleanupZips(): Promise<string[]> {

--- a/src/serverPath.ts
+++ b/src/serverPath.ts
@@ -1,7 +1,7 @@
 import * as path from 'path';
 import * as vscode from 'vscode';
 
-const INSTALL_FOLDER_NAME = 'lsp';
+const INSTALL_FOLDER_NAME = 'bin';
 export const CUSTOM_BIN_PATH_OPTION_NAME = 'languageServer.pathToBinary';
 
 export class ServerPath {
@@ -12,7 +12,14 @@ export class ServerPath {
   }
 
   public installPath(): string {
-    return this.context.asAbsolutePath(INSTALL_FOLDER_NAME);
+    return path.join(this.context.globalStorageUri.fsPath, INSTALL_FOLDER_NAME);
+  }
+
+  // legacyBinPath represents old location where LS was installed.
+  // We only use it to ensure that old installations are removed
+  // from there after LS is installed into the new path.
+  public legacyBinPath(): string {
+    return path.resolve(this.context.asAbsolutePath('lsp'), this.binName());
   }
 
   public hasCustomBinPath(): boolean {


### PR DESCRIPTION
Closes https://github.com/hashicorp/vscode-terraform/issues/739

--- 

This changes where the language server gets installed upon first extension activation, or upgrade.

Previously we would install it under:

(macOS) `/Users/radeksimko/.vscode/extensions/hashicorp.terraform-2.15.0/lsp/terraform-ls`

now we install it into:

(macOS) `/Users/radeksimko/Library/Application Support/Code/User/globalStorage/hashicorp.terraform/bin/terraform-ls`

The intended benefit of this change is that LS doesn't need to be re-installed whenever an extension version changes and also we can reduce the likelihood of running into restrictive FS permissions which may rightly be applied to the `~/.vscode` in some cases.