### PR TITLE
Publish preview builds

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,0 +1,54 @@
+name: Publish Preview release
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  publish:
+    name: Publish Preview to VS Code Marketplace
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+
+      - name: Set preview in package.json
+        id: set-preview
+        run: |
+          ./build/preview
+
+      - name: Read extension version
+        id: ext-version
+        run: |
+          content=`cat ./package.json | jq -r .version`
+          echo "::set-output name=content::$content"
+
+      - name: Read Node.js version
+        id: nodejs-version
+        run: |
+          content=`cat ./.nvmrc`
+          echo "::set-output name=content::$content"
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v2
+        with:
+          # See https://github.com/actions/setup-node/issues/32
+          node-version: ${{ steps.nodejs-version.outputs.content }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: vsce package
+        run: npx -- vsce package --out=${{ runner.temp }}/terraform-${{ steps.ext-version.outputs.content }}.vsix
+
+      - name: Check latest published version
+        run: |
+          export EXTENSION_ID=`cat package.json | jq -r '.publisher + "." + .name'`
+          npx -- vsce show --json $EXTENSION_ID | jq '.versions[0]'
+
+      - name: vsce publish
+        run: npx -- vsce publish --no-git-tag-version --packagePath=${{ runner.temp }}/terraform-${{ steps.ext-version.outputs.content }}.vsix
+        env:
+          VSCE_PAT: ${{ secrets.VSCE_PAT }}

--- a/build/nightly.md
+++ b/build/nightly.md
@@ -1,0 +1,13 @@
+# Terraform Preivew Visual Studio Code Extension
+
+> ### **ATTENTION: This is the *preview* version of the [VS Code Terraform extension](https://github.com/golang/vscode-terraform), used for early feedback and testing.**
+> It is contains previews of new features and bug fixes that are still under review or test. Therefore, this extension can be broken or unstable at times. If you are looking for the stable version,
+please install [the default VS Code Terraform extension](https://marketplace.visualstudio.com/items?itemName=hashicorp.terraform) instead.
+>
+> **NOTE: The stable Terraform extension (`hashicorp.terraform`) cannot be used at the same time as the Terraform Preview extension (`hashicorp.terraform-preview`)**. If you have installed both extensions, you **must disable or uninstall** one of them. For further guidance, read the [documentation on how to disable an extension](https://code.visualstudio.com/docs/editor/extension-gallery#_disable-an-extension).
+
+> ### **Differences between Terraform and Terraform Preview**
+>
+> * Terraform Preview is released more frequently than the stable version.
+> * Terraform Preview includes features and bug fixes that are not yet finalized.
+> * Terraform Preview may use pre-release versions of tools (such as `terraform-ls`) instead of released versions.

--- a/build/preview
+++ b/build/preview
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+set -eEuo pipefail
+
+SCRIPT_RELATIVE_DIR=$(dirname "${BASH_SOURCE[0]}")
+ROOT_RELATIVE_DIR=$(dirname "${SCRIPT_RELATIVE_DIR}")
+
+cd $ROOT_RELATIVE_DIR
+
+# get current version info
+VERSION=`git log -1 --format=%cd --date="format:%Y.%-m.%-d%H"`
+
+# Get existing name & description
+DISPLAY_NAME="$(jq -r .displayName package.json) (Preview)"
+DESCRIPTION="$(jq -r .description package.json) (Preview)"
+
+# set preview info in package.json
+(cat package.json | jq --arg VER $VERSION --arg NAME "$DISPLAY_NAME" --arg DESC "$DESCRIPTION" '
+.version=$VER |
+.preview=true |
+.name="terraform-preview" |
+.displayName=$NAME |
+.description=$DESC
+') > /tmp/package.json && mv /tmp/package.json package.json
+
+# prepend preview info to README.md
+sed '/^# Terraform Visual Studio Code Extension$/d' README.md | cat build/nightly.md - > /tmp/rdme && mv /tmp/rdme README.md

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   "publisher": "hashicorp",
   "appInsightsKey": "885372d2-6f3c-499f-9d25-b8b219983a52",
   "license": "MPL-2.0",
+  "preview": false,
   "private": true,
   "engines": {
     "npm": "~6.X",


### PR DESCRIPTION
This adds a new Github Action that publishes the `hashicorp.terraform-preview` extension to the VS Code Marketplace.

https://marketplace.visualstudio.com/items?itemName=HashiCorp.terraform-preview