### PR TITLE
Process telemetry from language server

### DIFF
--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -12,6 +12,7 @@ import {
 } from 'vscode-languageclient/node';
 import { ServerPath } from './serverPath';
 import { ShowReferencesFeature } from './showReferences';
+import { TelemetryFeature } from './telemetry';
 import { config } from './vscodeUtils';
 
 export interface TerraformLanguageClient {
@@ -87,6 +88,10 @@ export class ClientHandler {
     const codeLensReferenceCount = config('terraform').get<boolean>('codelens.referenceCount');
     if (codeLensReferenceCount) {
       client.registerFeature(new ShowReferencesFeature(client));
+    }
+
+    if (vscode.env.isTelemetryEnabled) {
+      client.registerFeature(new TelemetryFeature(client, this.reporter));
     }
 
     client.onDidChangeState((event) => {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -10,7 +10,7 @@ type TelemetryEvent = {
 };
 
 export class TelemetryFeature implements StaticFeature {
-  constructor(private client: BaseLanguageClient, private reporter: TelemetryReporter) {
+  constructor(private client: BaseLanguageClient, reporter: TelemetryReporter) {
     this.client.onTelemetry((event: TelemetryEvent) => {
       if (event.v != TELEMETRY_VERSION) {
         console.log(`unsupported telemetry event: ${event}`);

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -6,7 +6,7 @@ const TELEMETRY_VERSION = 1;
 type TelemetryEvent = {
   v: number;
   name: string;
-  properties: { string };
+  properties: { [key: string]: unknown };
 };
 
 export class TelemetryFeature implements StaticFeature {

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,0 +1,38 @@
+import TelemetryReporter from 'vscode-extension-telemetry';
+import { BaseLanguageClient, ClientCapabilities, StaticFeature } from 'vscode-languageclient';
+
+const TELEMETRY_VERSION = 1;
+
+type TelemetryEvent = {
+  v: number;
+  name: string;
+  properties: { string };
+};
+
+export class TelemetryFeature implements StaticFeature {
+  constructor(private client: BaseLanguageClient, private reporter: TelemetryReporter) {
+    this.client.onTelemetry((event: TelemetryEvent) => {
+      if (event.v != TELEMETRY_VERSION) {
+        console.log(`unsupported telemetry event: ${event}`);
+        return;
+      }
+
+      reporter.sendRawTelemetryEvent(event.name, event.properties);
+    });
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+    if (!capabilities['experimental']) {
+      capabilities['experimental'] = {};
+    }
+    capabilities['experimental']['telemetryVersion'] = TELEMETRY_VERSION;
+  }
+
+  public initialize(): void {
+    return;
+  }
+
+  public dispose(): void {
+    return;
+  }
+}


### PR DESCRIPTION
Depends on https://github.com/hashicorp/terraform-ls/pull/681 but the release does _not_ need to be coordinated. Older versions of LS will just ignore the experimental capability.

Regarding documentation, I believe the existing paragraph already reflects the existing situation which won't really change with this PR: https://github.com/hashicorp/vscode-terraform#telemetry
