### PR TITLE
Single LanguageClient

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,6 +33,7 @@ jobs:
 
   test:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - windows-latest

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -1,6 +1,5 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import ShortUniqueId from 'short-unique-id';
 import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import {
@@ -15,84 +14,53 @@ import {
 import * as which from 'which';
 import { CUSTOM_BIN_PATH_OPTION_NAME, ServerPath } from './serverPath';
 import { ShowReferencesFeature } from './showReferences';
-import { config, getFolderName, getWorkspaceFolder, normalizeFolderName, sortedWorkspaceFolders } from './vscodeUtils';
+import { config, getWorkspaceFolder } from './vscodeUtils';
 
 export interface TerraformLanguageClient {
-  commandPrefix: string;
   client: LanguageClient;
 }
 
-const MULTI_FOLDER_CLIENT = '';
-const clients: Map<string, TerraformLanguageClient> = new Map();
-
 /**
  * ClientHandler maintains lifecycles of language clients
- * based on the server's capabilities (whether multi-folder
- * workspaces are supported).
+ * based on the server's capabilities
  */
 export class ClientHandler {
-  private shortUid: ShortUniqueId;
-  private supportsMultiFolders = true;
+  private tfClient: TerraformLanguageClient;
 
   constructor(private lsPath: ServerPath, private reporter: TelemetryReporter) {
-    this.shortUid = new ShortUniqueId();
     if (lsPath.hasCustomBinPath()) {
       this.reporter.sendTelemetryEvent('usePathToBinary');
     }
   }
 
-  public async startClients(folders?: string[]): Promise<vscode.Disposable[]> {
+  public async startClients(): Promise<vscode.Disposable[]> {
     const disposables: vscode.Disposable[] = [];
 
-    if (this.supportsMultiFolders) {
-      if (clients.has(MULTI_FOLDER_CLIENT)) {
-        console.log(`No need to start another client for ${folders}`);
-        return disposables;
-      }
+    console.log('Starting client');
 
-      console.log('Starting client');
+    this.tfClient = this.createTerraformClient();
 
-      const tfClient = this.createTerraformClient();
-      const readyClient = tfClient.client.onReady().then(async () => {
-        this.reporter.sendTelemetryEvent('startClient');
-        const multiFoldersSupported =
-          tfClient.client.initializeResult.capabilities.workspace?.workspaceFolders?.supported;
-        console.log(`Multi-folder support: ${multiFoldersSupported}`);
+    disposables.push(this.tfClient.client.start());
 
-        if (!multiFoldersSupported) {
-          // restart is needed to launch folder-focused instances
-          console.log('Restarting clients as folder-focused');
-          await this.stopClients(folders);
-          this.supportsMultiFolders = false;
-          await this.startClients(folders);
-        }
-      });
+    await this.tfClient.client.onReady().then(async () => {
+      this.reporter.sendTelemetryEvent('startClient');
+      const multiFoldersSupported =
+        this.tfClient.client.initializeResult.capabilities.workspace?.workspaceFolders?.supported;
+      console.log(`Multi-folder support: ${multiFoldersSupported}`);
+    });
 
-      disposables.push(tfClient.client.start());
-      await readyClient;
-      clients.set(MULTI_FOLDER_CLIENT, tfClient);
-
-      return disposables;
-    }
-
-    if (folders && folders.length > 0) {
-      for (const folder of folders) {
-        if (!clients.has(folder)) {
-          console.log(`Starting client for ${folder}`);
-          const folderClient = this.createTerraformClient(folder);
-          const readyClient = folderClient.client.onReady().then(() => {
-            this.reporter.sendTelemetryEvent('startClient');
-          });
-
-          disposables.push(folderClient.client.start());
-          await readyClient;
-          clients.set(folder, folderClient);
-        } else {
-          console.log(`Client for folder: ${folder} already started`);
-        }
-      }
-    }
     return disposables;
+  }
+
+  public async stopClients(): Promise<void> {
+    return this.tfClient.client
+      .stop()
+      .then(() => {
+        console.log('Client stopped');
+      })
+      .then(() => {
+        console.log('Client deleted');
+      });
   }
 
   private createTerraformClient(location?: string): TerraformLanguageClient {
@@ -149,8 +117,7 @@ export class ClientHandler {
       );
     }
 
-    const commandPrefix = this.shortUid.seq();
-    let initializationOptions = { commandPrefix, experimentalFeatures };
+    let initializationOptions = { experimentalFeatures };
     if (terraformExecPath.length > 0) {
       initializationOptions = Object.assign(initializationOptions, { terraformExecPath });
     }
@@ -194,61 +161,11 @@ export class ClientHandler {
 
     client.onDidChangeState((event) => {
       if (event.newState === State.Stopped) {
-        clients.delete(location);
         this.reporter.sendTelemetryEvent('stopClient');
       }
     });
 
-    return { commandPrefix, client };
-  }
-
-  public async stopClients(folders?: string[]): Promise<void[]> {
-    const promises: Promise<void>[] = [];
-
-    if (this.supportsMultiFolders) {
-      promises.push(this.stopClient(MULTI_FOLDER_CLIENT));
-      return Promise.all(promises);
-    }
-
-    if (!folders) {
-      folders = [];
-      for (const key of clients.keys()) {
-        folders.push(key);
-      }
-    }
-
-    for (const folder of folders) {
-      promises.push(this.stopClient(folder));
-    }
-    return Promise.all(promises);
-  }
-
-  private async stopClient(folder: string): Promise<void> {
-    if (!clients.has(folder)) {
-      console.log(`Attempted to stop a client for folder: ${folder} but no client exists`);
-      return;
-    }
-
-    return clients
-      .get(folder)
-      .client.stop()
-      .then(() => {
-        if (folder === '') {
-          console.log('Client stopped');
-          return;
-        }
-        console.log(`Client stopped for ${folder}`);
-      })
-      .then(() => {
-        const ok = clients.delete(folder);
-        if (ok) {
-          if (folder === '') {
-            console.log('Client deleted');
-            return;
-          }
-          console.log(`Client deleted for ${folder}`);
-        }
-      });
+    return { client };
   }
 
   private resolvedPathToBinary(): string {
@@ -273,26 +190,12 @@ export class ClientHandler {
     return cmd;
   }
 
-  public getClient(document?: vscode.Uri): TerraformLanguageClient {
-    if (this.supportsMultiFolders) {
-      return clients.get(MULTI_FOLDER_CLIENT);
-    }
-
-    return clients.get(this.clientName(document.toString()));
+  public getClient(): TerraformLanguageClient {
+    return this.tfClient;
   }
 
-  public clientSupportsCommand(cmdName: string, document?: vscode.Uri): boolean {
-    const commands = this.getClient(document).client.initializeResult.capabilities.executeCommandProvider?.commands;
+  public clientSupportsCommand(cmdName: string): boolean {
+    const commands = this.tfClient.client.initializeResult.capabilities.executeCommandProvider?.commands;
     return commands.includes(cmdName);
-  }
-
-  private clientName(folderName: string, workspaceFolders: readonly string[] = sortedWorkspaceFolders()): string {
-    folderName = normalizeFolderName(folderName);
-    const outerFolder = workspaceFolders.find((element) => folderName.startsWith(element));
-    // If this folder isn't nested, the found item will be itself
-    if (outerFolder && outerFolder !== folderName) {
-      folderName = getFolderName(getWorkspaceFolder(outerFolder));
-    }
-    return folderName;
   }
 }

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -1,5 +1,3 @@
-import * as fs from 'fs';
-import * as path from 'path';
 import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
 import {
@@ -11,8 +9,8 @@ import {
   ServerOptions,
   State,
 } from 'vscode-languageclient/node';
-import * as which from 'which';
-import { CUSTOM_BIN_PATH_OPTION_NAME, ServerPath } from './serverPath';
+
+import { ServerPath } from './serverPath';
 import { ShowReferencesFeature } from './showReferences';
 import { config } from './vscodeUtils';
 
@@ -98,7 +96,7 @@ export class ClientHandler {
       excludeModulePaths.length > 0 ? { excludeModulePaths } : null,
     );
 
-    const cmd = this.resolvedPathToBinary();
+    const cmd = this.lsPath.resolvedPathToBinary();
     const serverArgs: string[] = config('terraform').get('languageServer.args');
     const executable: Executable = {
       command: cmd,
@@ -135,28 +133,6 @@ export class ClientHandler {
     });
 
     return { client };
-  }
-
-  private resolvedPathToBinary(): string {
-    const pathToBinary = this.lsPath.binPath();
-    let cmd: string;
-    try {
-      if (path.isAbsolute(pathToBinary)) {
-        fs.accessSync(pathToBinary, fs.constants.X_OK);
-        cmd = pathToBinary;
-      } else {
-        cmd = which.sync(pathToBinary);
-      }
-      console.log(`Found server at ${cmd}`);
-    } catch (err) {
-      let extraHint: string;
-      if (this.lsPath.hasCustomBinPath()) {
-        extraHint = `. Check "${CUSTOM_BIN_PATH_OPTION_NAME}" in your settings.`;
-      }
-      throw new Error(`Unable to launch language server: ${err.message}${extraHint}`);
-    }
-
-    return cmd;
   }
 
   public getClient(): TerraformLanguageClient {

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -26,11 +26,13 @@ export interface TerraformLanguageClient {
  */
 export class ClientHandler {
   private tfClient: TerraformLanguageClient;
+  private supportedCommands: string[];
 
   constructor(private lsPath: ServerPath, private reporter: TelemetryReporter) {
     if (lsPath.hasCustomBinPath()) {
       this.reporter.sendTelemetryEvent('usePathToBinary');
     }
+    this.supportedCommands = [];
   }
 
   public async startClients(): Promise<vscode.Disposable[]> {
@@ -47,6 +49,8 @@ export class ClientHandler {
       const multiFoldersSupported =
         this.tfClient.client.initializeResult.capabilities.workspace?.workspaceFolders?.supported;
       console.log(`Multi-folder support: ${multiFoldersSupported}`);
+
+      this.supportedCommands = this.tfClient.client.initializeResult.capabilities.executeCommandProvider?.commands;
     });
 
     return disposables;
@@ -195,7 +199,6 @@ export class ClientHandler {
   }
 
   public clientSupportsCommand(cmdName: string): boolean {
-    const commands = this.tfClient.client.initializeResult.capabilities.executeCommandProvider?.commands;
-    return commands.includes(cmdName);
+    return this.supportedCommands.includes(cmdName);
   }
 }

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -59,6 +59,10 @@ export class ClientHandler {
   }
 
   public async stopClients(): Promise<void> {
+    if (this.tfClient === undefined || this.tfClient.client === undefined) {
+      return;
+    }
+
     return this.tfClient.client
       .stop()
       .then(() => {
@@ -144,7 +148,8 @@ export class ClientHandler {
     return this.tfClient;
   }
 
-  public clientSupportsCommand(cmdName: string): boolean {
+  public async clientSupportsCommand(cmdName: string): Promise<boolean> {
+    await this.tfClient.client.onReady();
     return this.supportedCommands.includes(cmdName);
   }
 }

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -26,7 +26,11 @@ export class ClientHandler {
   private tfClient: TerraformLanguageClient;
   private supportedCommands: string[];
 
-  constructor(private lsPath: ServerPath, private reporter: TelemetryReporter) {
+  constructor(
+    private lsPath: ServerPath,
+    private outputChannel: vscode.OutputChannel,
+    private reporter: TelemetryReporter,
+  ) {
     if (lsPath.hasCustomBinPath()) {
       this.reporter.sendTelemetryEvent('usePathToBinary');
     }
@@ -36,7 +40,7 @@ export class ClientHandler {
   public async startClients(): Promise<vscode.Disposable[]> {
     const disposables: vscode.Disposable[] = [];
 
-    console.log('Starting client');
+    this.outputChannel.appendLine('Starting client');
 
     this.tfClient = this.createTerraformClient();
 
@@ -46,7 +50,7 @@ export class ClientHandler {
       this.reporter.sendTelemetryEvent('startClient');
       const multiFoldersSupported =
         this.tfClient.client.initializeResult.capabilities.workspace?.workspaceFolders?.supported;
-      console.log(`Multi-folder support: ${multiFoldersSupported}`);
+      this.outputChannel.appendLine(`Multi-folder support: ${multiFoldersSupported}`);
 
       this.supportedCommands = this.tfClient.client.initializeResult.capabilities.executeCommandProvider?.commands;
     });
@@ -58,10 +62,10 @@ export class ClientHandler {
     return this.tfClient.client
       .stop()
       .then(() => {
-        console.log('Client stopped');
+        this.outputChannel.appendLine('Client stopped');
       })
       .then(() => {
-        console.log('Client deleted');
+        this.outputChannel.appendLine('Client deleted');
       });
   }
 

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -139,7 +139,8 @@ export class ClientHandler {
     return { client };
   }
 
-  public getClient(): TerraformLanguageClient {
+  public async getClient(): Promise<TerraformLanguageClient> {
+    await this.tfClient.client.onReady();
     return this.tfClient;
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -90,7 +90,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Terraf
       });
       if (selected) {
         const moduleUri = selected[0];
-        const client = clientHandler.getClient();
+        const client = await clientHandler.getClient();
         const requestParams: ExecuteCommandParams = {
           command: `terraform-ls.terraform.init`,
           arguments: [`uri=${moduleUri}`],
@@ -161,7 +161,7 @@ async function updateTerraformStatusBar(documentUri: vscode.Uri) {
     return;
   }
 
-  const client = clientHandler.getClient();
+  const client = await clientHandler.getClient();
   if (!client) {
     return;
   }
@@ -260,7 +260,7 @@ async function terraformCommand(
 ): Promise<any> {
   const textEditor = getActiveTextEditor();
   if (textEditor) {
-    const languageClient = clientHandler.getClient();
+    const languageClient = await clientHandler.getClient();
 
     const moduleUri = Utils.dirname(textEditor.document.uri);
     const response = await moduleCallers(languageClient, moduleUri.toString());

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -127,7 +127,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
 
   if (enabled()) {
     try {
-      await vscode.commands.executeCommand('terraform.enableLanguageServer');
+      await updateLanguageServer(manifest.version, clientHandler, lsPath);
       vscode.commands.executeCommand('setContext', 'terraform.showModuleView', true);
     } catch (error) {
       reporter.sendTelemetryException(error);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -112,6 +112,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       }
     }),
     vscode.workspace.onDidChangeWorkspaceFolders(async (event: vscode.WorkspaceFoldersChangeEvent) => {
+      // TODO: figure out if this is still necessary
       if (event.removed.length > 0) {
         await clientHandler.stopClients();
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -125,23 +125,49 @@ export async function activate(context: vscode.ExtensionContext): Promise<Terraf
         await clientHandler.startClients();
       }
     }),
-    vscode.window.onDidChangeVisibleTextEditors(async () => {
-      const textEditor = getActiveTextEditor();
-      if (textEditor === undefined) {
-        return;
-      }
-      if (textEditor.document === undefined) {
-        return;
-      }
-      await updateTerraformStatusBar(textEditor.document.uri);
-    }),
+    // vscode.window.onDidChangeVisibleTextEditors(async () => {
+    //   const textEditor = getActiveTextEditor();
+    //   if (textEditor === undefined) {
+    //     return;
+    //   }
+    //   if (textEditor.document === undefined) {
+    //     return;
+    //   }
+    //   await updateTerraformStatusBar(textEditor.document.uri);
+    // }),
     vscode.window.registerTreeDataProvider('terraform.modules', new ModuleProvider(context, clientHandler)),
   );
 
-  if (enabled()) {
+  // if (enabled()) {
+  //   try {
+  //     vscode.commands.executeCommand('setContext', 'terraform.showModuleView', true);
+  //     const ds = await updateLanguageServer(manifest.version, clientHandler, lsPath);
+  //     context.subscriptions.push(...ds);
+  //   } catch (error) {
+  //     reporter.sendTelemetryException(error);
+  //   }
+  // }
+
+  if (config('terraform').get<boolean>('languageServer.external')) {
     try {
+      vscode.commands.executeCommand('setContext', 'terraform.showModuleView', true);
       await updateLanguageServer(manifest.version, clientHandler, lsPath);
       vscode.commands.executeCommand('setContext', 'terraform.showModuleView', true);
+
+      (await clientHandler.getClient()).client.onReady().then(() => {
+        context.subscriptions.push(
+          vscode.window.onDidChangeVisibleTextEditors(async () => {
+            // can't register this until client is ready, otherwise we can't
+            // know if command is supported
+            const textEditor = getActiveTextEditor();
+            if (textEditor === undefined) {
+              return;
+            }
+
+            await updateTerraformStatusBar(textEditor.document.uri);
+          }),
+        );
+      });
     } catch (error) {
       reporter.sendTelemetryException(error);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -122,20 +122,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
       const textEditor = getActiveTextEditor();
       await updateTerraformStatusBar(textEditor.document.uri);
     }),
+    vscode.window.registerTreeDataProvider('terraform.modules', new ModuleProvider(context, clientHandler)),
   );
 
   if (enabled()) {
     try {
       await vscode.commands.executeCommand('terraform.enableLanguageServer');
+      vscode.commands.executeCommand('setContext', 'terraform.showModuleView', true);
     } catch (error) {
       reporter.sendTelemetryException(error);
     }
   }
-
-  vscode.commands.executeCommand('setContext', 'terraform.showModuleView', true);
-  context.subscriptions.push(
-    vscode.window.registerTreeDataProvider('terraform.modules', new ModuleProvider(context, clientHandler)),
-  );
 
   // export public API
   return { clientHandler, moduleCallers };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -146,29 +146,32 @@ export function deactivate(): Promise<void> {
 
 async function updateTerraformStatusBar(documentUri: vscode.Uri) {
   const initSupported = clientHandler.clientSupportsCommand('terraform-ls.terraform.init');
-  if (initSupported) {
-    const client = clientHandler.getClient();
-    const moduleUri = Utils.dirname(documentUri);
+  if (!initSupported) {
+    return;
+  }
 
-    if (client) {
-      try {
-        const response = await moduleCallers(client, moduleUri.toString());
-        if (response.moduleCallers.length === 0) {
-          const dirName = Utils.basename(moduleUri);
-          terraformStatus.text = `$(refresh) ${dirName}`;
-          terraformStatus.color = new vscode.ThemeColor('statusBar.foreground');
-          terraformStatus.tooltip = `Click to run terraform init`;
-          terraformStatus.command = 'terraform.initCurrent';
-          terraformStatus.show();
-        } else {
-          terraformStatus.hide();
-        }
-      } catch (err) {
-        vscode.window.showErrorMessage(err);
-        reporter.sendTelemetryException(err);
-        terraformStatus.hide();
-      }
+  const client = clientHandler.getClient();
+  if (!client) {
+    return;
+  }
+
+  try {
+    const moduleUri = Utils.dirname(documentUri);
+    const response = await moduleCallers(client, moduleUri.toString());
+    if (response.moduleCallers.length === 0) {
+      const dirName = Utils.basename(moduleUri);
+      terraformStatus.text = `$(refresh) ${dirName}`;
+      terraformStatus.color = new vscode.ThemeColor('statusBar.foreground');
+      terraformStatus.tooltip = `Click to run terraform init`;
+      terraformStatus.command = 'terraform.initCurrent';
+      terraformStatus.show();
+    } else {
+      terraformStatus.hide();
     }
+  } catch (err) {
+    vscode.window.showErrorMessage(err);
+    reporter.sendTelemetryException(err);
+    terraformStatus.hide();
   }
 }
 

--- a/src/providers/moduleProvider.ts
+++ b/src/providers/moduleProvider.ts
@@ -103,19 +103,16 @@ export class ModuleProvider implements vscode.TreeDataProvider<ModuleCall> {
 
     const editor = document.uri;
     const documentURI = Utils.dirname(editor);
-    const handler = this.handler.getClient(editor);
+    const handler = this.handler.getClient();
 
     return await handler.client.onReady().then(async () => {
-      const moduleCallsSupported = this.handler.clientSupportsCommand(
-        `${handler.commandPrefix}.terraform-ls.module.calls`,
-        editor,
-      );
+      const moduleCallsSupported = this.handler.clientSupportsCommand(`terraform-ls.module.calls`);
       if (!moduleCallsSupported) {
         return Promise.resolve([]);
       }
 
       const params: ExecuteCommandParams = {
-        command: `${handler.commandPrefix}.terraform-ls.module.calls`,
+        command: `terraform-ls.module.calls`,
         arguments: [`uri=${documentURI}`],
       };
 

--- a/src/providers/moduleProvider.ts
+++ b/src/providers/moduleProvider.ts
@@ -103,7 +103,7 @@ export class ModuleProvider implements vscode.TreeDataProvider<ModuleCall> {
 
     const editor = document.uri;
     const documentURI = Utils.dirname(editor);
-    const handler = this.handler.getClient();
+    const handler = await this.handler.getClient();
 
     return await handler.client.onReady().then(async () => {
       const moduleCallsSupported = this.handler.clientSupportsCommand(`terraform-ls.module.calls`);

--- a/src/test/integration/workspaces.test.ts
+++ b/src/test/integration/workspaces.test.ts
@@ -20,10 +20,17 @@ suite('moduleCallers', () => {
 
     assert.ok(ext.isActive);
 
-		const client = await ext.exports.handler.getClient();
+		const api = ext.exports;
+    assert.ok(api.handler);
+    assert.ok(api.moduleCallers);
+
+		const client = await api.handler.getClient();
+    assert.ok(client);
 
 		const moduleUri = Utils.dirname(documentUri).toString();
-		const response = await ext.exports.moduleCallers(client, moduleUri);
+		const response = await api.moduleCallers(client, moduleUri);
+    assert.ok(response);
+
 		assert.strictEqual(response.moduleCallers.length, 1);
 		assert.strictEqual(response.moduleCallers[0].uri, vscode.Uri.file(testFolderPath).toString(true));
 	})

--- a/src/test/integration/workspaces.test.ts
+++ b/src/test/integration/workspaces.test.ts
@@ -20,7 +20,7 @@ suite('moduleCallers', () => {
 
     assert.ok(ext.isActive);
 
-		const client = ext.exports.handler.getClient();
+		const client = await ext.exports.handler.getClient();
 
 		const moduleUri = Utils.dirname(documentUri).toString();
 		const response = await ext.exports.moduleCallers(client, moduleUri);

--- a/src/test/integration/workspaces.test.ts
+++ b/src/test/integration/workspaces.test.ts
@@ -1,6 +1,7 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { Utils } from 'vscode-uri';
+import { TerraformExtension } from '../../extension';
 import { getDocUri, getExtensionId, open, testFolderPath } from '../helper';
 
 
@@ -12,14 +13,14 @@ suite('moduleCallers', () => {
 
 	test('should execute language server command', async () => {
 		const extId = getExtensionId()
-		const ext = vscode.extensions.getExtension(extId);
+		const ext = vscode.extensions.getExtension<TerraformExtension>(extId);
 
 		const documentUri = getDocUri('modules/sample.tf');
 		await open(documentUri);
 
     assert.ok(ext.isActive);
 
-		const client = ext.exports.clientHandler.getClient(documentUri);
+		const client = ext.exports.handler.getClient();
 
 		const moduleUri = Utils.dirname(documentUri).toString();
 		const response = await ext.exports.moduleCallers(client, moduleUri);


### PR DESCRIPTION
- Update extension tests
- Refactor to Single LanguageClient
- Extract supported commands to class property
- Simplify creating TerraformLanguageClient
- Extract resolvePathToBinary to ServerPath
- Fix ModuleProvider starting before client ready
- Enable LS in main activation flow
- Brand OutputChannel
- figure out if onDidChangeWorkspaceFolders still needed
- simplify creating language clients
- strongly type extension activation


Close #816 

Relies on test fixes in https://github.com/hashicorp/vscode-terraform/pull/828