### PR TITLE
Implement opt out config option for ref count code lens

### DIFF
--- a/package.json
+++ b/package.json
@@ -143,6 +143,12 @@
             "trace.server": "off"
           }
         },
+        "terraform.enableReferenceCountCodeLens": {
+          "scope": "resource",
+          "type": "boolean",
+          "default": true,
+          "description": "Display reference counts above top level blocks and attributes."
+        },
         "terraform-ls.rootModules": {
           "scope": "resource",
           "type": "array",

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -111,6 +111,7 @@ export class ClientHandler {
     let terraformExecTimeout: string;
     let terraformLogFilePath: string;
     let excludeModulePaths: string[];
+    let enableReferenceCountCodeLens: boolean;
     let documentSelector: DocumentSelector;
     let outputChannel: vscode.OutputChannel;
     if (location) {
@@ -127,6 +128,7 @@ export class ClientHandler {
       terraformLogFilePath = config('terraform-ls', wsFolder).get('terraformLogFilePath');
       rootModulePaths = config('terraform-ls', wsFolder).get('rootModules');
       excludeModulePaths = config('terraform-ls', wsFolder).get('excludeRootModules');
+      enableReferenceCountCodeLens = config('terraform', wsFolder).get('enableReferenceCountCodeLens');
       outputChannel = vscode.window.createOutputChannel(channelName);
       outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')} for folder: ${location}`);
     } else {
@@ -139,6 +141,7 @@ export class ClientHandler {
       terraformLogFilePath = config('terraform-ls').get('terraformLogFilePath');
       rootModulePaths = config('terraform-ls').get('rootModules');
       excludeModulePaths = config('terraform-ls').get('excludeRootModules');
+      enableReferenceCountCodeLens = config('terraform').get('enableReferenceCountCodeLens');
       outputChannel = vscode.window.createOutputChannel(channelName);
       outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
     }
@@ -190,7 +193,9 @@ export class ClientHandler {
 
     const client = new LanguageClient(id, name, serverOptions, clientOptions);
 
-    client.registerFeature(new ShowReferencesFeature(client));
+    if (enableReferenceCountCodeLens) {
+      client.registerFeature(new ShowReferencesFeature(client));
+    }
 
     client.onDidChangeState((event) => {
       if (event.newState === State.Stopped) {


### PR DESCRIPTION
This PR adds a new setting called `enableReferenceCountCodeLens` which toggles displaying reference counts above top level blocks and attributes.

Closes #713.