### PR TITLE
Fix ModuleProvider starting before client ready

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -101,6 +101,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
     vscode.commands.registerCommand('terraform.validate', async () => {
       await terraformCommand('validate', true, clientHandler);
     }),
+    vscode.window.registerTreeDataProvider('terraform.modules', new ModuleProvider(context, clientHandler)),
     vscode.workspace.onDidChangeConfiguration(async (event: vscode.ConfigurationChangeEvent) => {
       if (event.affectsConfiguration('terraform') || event.affectsConfiguration('terraform-ls')) {
         const reloadMsg = 'Reload VSCode window to apply language server changes';
@@ -127,15 +128,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<any> {
   if (enabled()) {
     try {
       await vscode.commands.executeCommand('terraform.enableLanguageServer');
+      vscode.commands.executeCommand('setContext', 'terraform.showModuleView', true);
     } catch (error) {
       reporter.sendTelemetryException(error);
     }
   }
-
-  vscode.commands.executeCommand('setContext', 'terraform.showModuleView', true);
-  context.subscriptions.push(
-    vscode.window.registerTreeDataProvider('terraform.modules', new ModuleProvider(context, clientHandler)),
-  );
 
   // export public API
   return { clientHandler, moduleCallers };


### PR DESCRIPTION
Delays enabling the ModuleProvider until the client has started to avoid the case where the user has the view pane open on editor start but the language client or server has not fully initialized yet.
