### PR TITLE
Refactor to Single Language Client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ ENHANCEMENTS:
  - Add new setting which toggles displaying reference counts above top level blocks and attributes ([#837](https://github.com/hashicorp/vscode-terraform/pull/837))
  - Add support for language server side config option `ignoreDirectoryNames` ([#833](https://github.com/hashicorp/vscode-terraform/pull/833))
 
+ INTERNAL:
+
+ - Refactor extension to only use one LanguageClient per workspace (#845)
+
 # 2.16.0 (2021-10-14)
 
 ENHANCEMENTS:

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -26,7 +26,7 @@ export interface TerraformLanguageClient {
 export class ClientHandler {
   private shortUid: ShortUniqueId;
   private tfClient: TerraformLanguageClient;
-  private commands: string[];
+  private commands: string[] = [];
 
   constructor(
     private lsPath: ServerPath,
@@ -66,7 +66,7 @@ export class ClientHandler {
 
     const initializationOptions = this.getInitializationOptions(commandPrefix);
 
-    const serverOptions: ServerOptions = this.getServerOptions();
+    const serverOptions = this.getServerOptions();
     this.outputChannel.appendLine(
       `Launching language server: ${serverOptions.run.command} ${serverOptions.run.args.join(' ')}`,
     );
@@ -107,7 +107,7 @@ export class ClientHandler {
 
   private getServerOptions() {
     const cmd = this.lsPath.resolvedPathToBinary();
-    const serverArgs: string[] = config('terraform').get('languageServer.args');
+    const serverArgs = config('terraform').get<string[]>('languageServer.args');
     const executable: Executable = {
       command: cmd,
       args: serverArgs,
@@ -121,7 +121,7 @@ export class ClientHandler {
   }
 
   private getInitializationOptions(commandPrefix: string) {
-    const rootModulePaths: string[] = config('terraform-ls').get('rootModules');
+    const rootModulePaths = config('terraform-ls').get<string[]>('rootModules', []);
     const terraformExecPath: string = config('terraform-ls').get('terraformExecPath');
     const terraformExecTimeout: string = config('terraform-ls').get('terraformExecTimeout');
     const terraformLogFilePath: string = config('terraform-ls').get('terraformLogFilePath');
@@ -162,7 +162,7 @@ export class ClientHandler {
       return Promise.resolve();
     }
 
-    if (this.tfClient.client === undefined) {
+    if (this.tfClient?.client === undefined) {
       return Promise.resolve();
     }
 

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -63,10 +63,7 @@ export class ClientHandler {
 
     const initializationOptions = this.getInitializationOptions(commandPrefix);
 
-    const serverOptions: ServerOptions = this.getServerOptions();
-    this.outputChannel.appendLine(
-      `Launching language server: ${serverOptions.run.command} ${serverOptions.run.args.join(' ')}`,
-    );
+    const serverOptions = this.getServerOptions();
 
     const documentSelector: DocumentSelector = [
       { scheme: 'file', language: 'terraform' },
@@ -102,7 +99,7 @@ export class ClientHandler {
     return { commandPrefix, client };
   }
 
-  private getServerOptions() {
+  private getServerOptions(): ServerOptions {
     const cmd = this.lsPath.resolvedPathToBinary();
     const serverArgs = config('terraform').get<string[]>('languageServer.args');
     const executable: Executable = {
@@ -114,6 +111,7 @@ export class ClientHandler {
       run: executable,
       debug: executable,
     };
+    this.outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
     return serverOptions;
   }
 

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -1,5 +1,3 @@
-import * as fs from 'fs';
-import * as path from 'path';
 import ShortUniqueId from 'short-unique-id';
 import * as vscode from 'vscode';
 import TelemetryReporter from 'vscode-extension-telemetry';
@@ -12,142 +10,123 @@ import {
   ServerOptions,
   State,
 } from 'vscode-languageclient/node';
-import * as which from 'which';
-import { CUSTOM_BIN_PATH_OPTION_NAME, ServerPath } from './serverPath';
+import { ServerPath } from './serverPath';
 import { ShowReferencesFeature } from './showReferences';
-import { config, getFolderName, getWorkspaceFolder, normalizeFolderName, sortedWorkspaceFolders } from './vscodeUtils';
+import { config } from './vscodeUtils';
 
 export interface TerraformLanguageClient {
   commandPrefix: string;
   client: LanguageClient;
 }
 
-const MULTI_FOLDER_CLIENT = '';
-const clients: Map<string, TerraformLanguageClient> = new Map();
-
 /**
  * ClientHandler maintains lifecycles of language clients
- * based on the server's capabilities (whether multi-folder
- * workspaces are supported).
+ * based on the server's capabilities
  */
 export class ClientHandler {
   private shortUid: ShortUniqueId;
-  private supportsMultiFolders = true;
+  private tfClient: TerraformLanguageClient;
+  private commands: string[];
 
-  constructor(private lsPath: ServerPath, private reporter: TelemetryReporter) {
+  constructor(
+    private lsPath: ServerPath,
+    private outputChannel: vscode.OutputChannel,
+    private reporter: TelemetryReporter,
+  ) {
     this.shortUid = new ShortUniqueId();
+    this.commands = [];
     if (lsPath.hasCustomBinPath()) {
       this.reporter.sendTelemetryEvent('usePathToBinary');
     }
   }
 
-  public async startClients(folders?: string[]): Promise<vscode.Disposable[]> {
+  public async startClient(): Promise<vscode.Disposable[]> {
     const disposables: vscode.Disposable[] = [];
 
-    if (this.supportsMultiFolders) {
-      if (clients.has(MULTI_FOLDER_CLIENT)) {
-        console.log(`No need to start another client for ${folders}`);
-        return disposables;
-      }
+    console.log('Starting client');
 
-      console.log('Starting client');
+    this.tfClient = this.createTerraformClient();
+    const readyClient = this.tfClient.client.onReady().then(async () => {
+      this.reporter.sendTelemetryEvent('startClient');
+      const multiFoldersSupported =
+        this.tfClient.client.initializeResult.capabilities.workspace?.workspaceFolders?.supported;
+      console.log(`Multi-folder support: ${multiFoldersSupported}`);
 
-      const tfClient = this.createTerraformClient();
-      const readyClient = tfClient.client.onReady().then(async () => {
-        this.reporter.sendTelemetryEvent('startClient');
-        const multiFoldersSupported =
-          tfClient.client.initializeResult.capabilities.workspace?.workspaceFolders?.supported;
-        console.log(`Multi-folder support: ${multiFoldersSupported}`);
+      this.commands = this.tfClient.client.initializeResult.capabilities.executeCommandProvider?.commands;
+    });
 
-        if (!multiFoldersSupported) {
-          // restart is needed to launch folder-focused instances
-          console.log('Restarting clients as folder-focused');
-          await this.stopClients(folders);
-          this.supportsMultiFolders = false;
-          await this.startClients(folders);
-        }
-      });
+    disposables.push(this.tfClient.client.start());
+    await readyClient;
 
-      disposables.push(tfClient.client.start());
-      await readyClient;
-      clients.set(MULTI_FOLDER_CLIENT, tfClient);
-
-      return disposables;
-    }
-
-    if (folders && folders.length > 0) {
-      for (const folder of folders) {
-        if (!clients.has(folder)) {
-          console.log(`Starting client for ${folder}`);
-          const folderClient = this.createTerraformClient(folder);
-          const readyClient = folderClient.client.onReady().then(() => {
-            this.reporter.sendTelemetryEvent('startClient');
-          });
-
-          disposables.push(folderClient.client.start());
-          await readyClient;
-          clients.set(folder, folderClient);
-        } else {
-          console.log(`Client for folder: ${folder} already started`);
-        }
-      }
-    }
     return disposables;
   }
 
-  private createTerraformClient(location?: string): TerraformLanguageClient {
-    const cmd = this.resolvedPathToBinary();
-    const binaryName = this.lsPath.binName();
+  private createTerraformClient(): TerraformLanguageClient {
+    const commandPrefix = this.shortUid.seq();
 
-    const serverArgs: string[] = config('terraform').get('languageServer.args');
-    const experimentalFeatures = config('terraform-ls').get('experimentalFeatures');
+    const initializationOptions = this.getInitializationOptions(commandPrefix);
 
-    let channelName = `${binaryName}`;
-    let id = `terraform-ls`;
-    let name = `Terraform LS`;
-    let wsFolder: vscode.WorkspaceFolder;
-    let rootModulePaths: string[];
-    let terraformExecPath: string;
-    let terraformExecTimeout: string;
-    let terraformLogFilePath: string;
-    let excludeModulePaths: string[];
-    let codeLensReferenceCount: boolean;
-    let ignoreDirectoryNames: string[];
-    let documentSelector: DocumentSelector;
-    let outputChannel: vscode.OutputChannel;
-    if (location) {
-      channelName = `${binaryName}: ${location}`;
-      id = `terraform-ls/${location}`;
-      name = `Terraform LS: ${location}`;
-      wsFolder = getWorkspaceFolder(location);
-      documentSelector = [
-        { scheme: 'file', language: 'terraform', pattern: `${wsFolder.uri.fsPath}/**/*` },
-        { scheme: 'file', language: 'terraform-vars', pattern: `${wsFolder.uri.fsPath}/**/*` },
-      ];
-      terraformExecPath = config('terraform-ls', wsFolder).get('terraformExecPath');
-      terraformExecTimeout = config('terraform-ls', wsFolder).get('terraformExecTimeout');
-      terraformLogFilePath = config('terraform-ls', wsFolder).get('terraformLogFilePath');
-      rootModulePaths = config('terraform-ls', wsFolder).get('rootModules');
-      excludeModulePaths = config('terraform-ls', wsFolder).get('excludeRootModules');
-      codeLensReferenceCount = config('terraform', wsFolder).get('codelens.referenceCount');
-      ignoreDirectoryNames = config('terraform-ls', wsFolder).get('ignoreDirectoryNames');
-      outputChannel = vscode.window.createOutputChannel(channelName);
-      outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')} for folder: ${location}`);
-    } else {
-      documentSelector = [
-        { scheme: 'file', language: 'terraform' },
-        { scheme: 'file', language: 'terraform-vars' },
-      ];
-      terraformExecPath = config('terraform-ls').get('terraformExecPath');
-      terraformExecTimeout = config('terraform-ls').get('terraformExecTimeout');
-      terraformLogFilePath = config('terraform-ls').get('terraformLogFilePath');
-      rootModulePaths = config('terraform-ls').get('rootModules');
-      excludeModulePaths = config('terraform-ls').get('excludeRootModules');
-      codeLensReferenceCount = config('terraform').get('codelens.referenceCount');
-      ignoreDirectoryNames = config('terraform-ls').get('ignoreDirectoryNames');
-      outputChannel = vscode.window.createOutputChannel(channelName);
-      outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
+    const serverOptions: ServerOptions = this.getServerOptions();
+    this.outputChannel.appendLine(
+      `Launching language server: ${serverOptions.run.command} ${serverOptions.run.args.join(' ')}`,
+    );
+
+    const documentSelector: DocumentSelector = [
+      { scheme: 'file', language: 'terraform' },
+      { scheme: 'file', language: 'terraform-vars' },
+    ];
+
+    const clientOptions: LanguageClientOptions = {
+      documentSelector: documentSelector,
+      initializationOptions: initializationOptions,
+      initializationFailedHandler: (error) => {
+        this.reporter.sendTelemetryException(error);
+        return false;
+      },
+      outputChannel: this.outputChannel,
+      revealOutputChannelOn: RevealOutputChannelOn.Never,
+    };
+
+    const id = `terraform`;
+    const client = new LanguageClient(id, serverOptions, clientOptions);
+
+    const codeLensReferenceCount = config('terraform').get('codelens.referenceCount');
+    if (codeLensReferenceCount) {
+      client.registerFeature(new ShowReferencesFeature(client));
     }
+
+    client.onDidChangeState((event) => {
+      console.log(`Client: ${State[event.oldState]} --> ${State[event.newState]}`);
+      if (event.newState === State.Stopped) {
+        this.reporter.sendTelemetryEvent('stopClient');
+      }
+    });
+
+    return { commandPrefix, client };
+  }
+
+  private getServerOptions() {
+    const cmd = this.lsPath.resolvedPathToBinary();
+    const serverArgs: string[] = config('terraform').get('languageServer.args');
+    const executable: Executable = {
+      command: cmd,
+      args: serverArgs,
+      options: {},
+    };
+    const serverOptions: ServerOptions = {
+      run: executable,
+      debug: executable,
+    };
+    return serverOptions;
+  }
+
+  private getInitializationOptions(commandPrefix: string) {
+    const rootModulePaths: string[] = config('terraform-ls').get('rootModules');
+    const terraformExecPath: string = config('terraform-ls').get('terraformExecPath');
+    const terraformExecTimeout: string = config('terraform-ls').get('terraformExecTimeout');
+    const terraformLogFilePath: string = config('terraform-ls').get('terraformLogFilePath');
+    const excludeModulePaths: string[] = config('terraform-ls').get('excludeRootModules');
+    const ignoreDirectoryNames: string[] = config('terraform-ls').get('ignoreDirectoryNames');
 
     if (rootModulePaths.length > 0 && excludeModulePaths.length > 0) {
       throw new Error(
@@ -155,7 +134,7 @@ export class ClientHandler {
       );
     }
 
-    const commandPrefix = this.shortUid.seq();
+    const experimentalFeatures = config('terraform-ls').get('experimentalFeatures');
     let initializationOptions = { commandPrefix, experimentalFeatures };
     if (terraformExecPath.length > 0) {
       initializationOptions = Object.assign(initializationOptions, { terraformExecPath });
@@ -175,135 +154,33 @@ export class ClientHandler {
     if (ignoreDirectoryNames.length > 0) {
       initializationOptions = Object.assign(initializationOptions, { ignoreDirectoryNames });
     }
-
-    const executable: Executable = {
-      command: cmd,
-      args: serverArgs,
-      options: {},
-    };
-    const serverOptions: ServerOptions = {
-      run: executable,
-      debug: executable,
-    };
-    const clientOptions: LanguageClientOptions = {
-      documentSelector: documentSelector,
-      workspaceFolder: wsFolder,
-      initializationOptions: initializationOptions,
-      initializationFailedHandler: (error) => {
-        this.reporter.sendTelemetryException(error);
-        return false;
-      },
-      outputChannel: outputChannel,
-      revealOutputChannelOn: RevealOutputChannelOn.Never,
-    };
-
-    const client = new LanguageClient(id, name, serverOptions, clientOptions);
-
-    if (codeLensReferenceCount) {
-      client.registerFeature(new ShowReferencesFeature(client));
-    }
-
-    client.onDidChangeState((event) => {
-      if (event.newState === State.Stopped) {
-        clients.delete(location);
-        this.reporter.sendTelemetryEvent('stopClient');
-      }
-    });
-
-    return { commandPrefix, client };
+    return initializationOptions;
   }
 
-  public async stopClients(folders?: string[]): Promise<void[]> {
-    const promises: Promise<void>[] = [];
-
-    if (this.supportsMultiFolders) {
-      promises.push(this.stopClient(MULTI_FOLDER_CLIENT));
-      return Promise.all(promises);
+  public async stopClient(): Promise<void> {
+    if (this.tfClient === undefined) {
+      return Promise.resolve();
     }
 
-    if (!folders) {
-      folders = [];
-      for (const key of clients.keys()) {
-        folders.push(key);
-      }
+    if (this.tfClient.client === undefined) {
+      return Promise.resolve();
     }
 
-    for (const folder of folders) {
-      promises.push(this.stopClient(folder));
-    }
-    return Promise.all(promises);
-  }
-
-  private async stopClient(folder: string): Promise<void> {
-    if (!clients.has(folder)) {
-      console.log(`Attempted to stop a client for folder: ${folder} but no client exists`);
-      return;
-    }
-
-    return clients
-      .get(folder)
-      .client.stop()
+    return this.tfClient.client
+      .stop()
       .then(() => {
-        if (folder === '') {
-          console.log('Client stopped');
-          return;
-        }
-        console.log(`Client stopped for ${folder}`);
+        console.log('Client stopped');
       })
       .then(() => {
-        const ok = clients.delete(folder);
-        if (ok) {
-          if (folder === '') {
-            console.log('Client deleted');
-            return;
-          }
-          console.log(`Client deleted for ${folder}`);
-        }
+        console.log('Client deleted');
       });
   }
 
-  private resolvedPathToBinary(): string {
-    const pathToBinary = this.lsPath.binPath();
-    let cmd: string;
-    try {
-      if (path.isAbsolute(pathToBinary)) {
-        fs.accessSync(pathToBinary, fs.constants.X_OK);
-        cmd = pathToBinary;
-      } else {
-        cmd = which.sync(pathToBinary);
-      }
-      console.log(`Found server at ${cmd}`);
-    } catch (err) {
-      let extraHint: string;
-      if (this.lsPath.hasCustomBinPath()) {
-        extraHint = `. Check "${CUSTOM_BIN_PATH_OPTION_NAME}" in your settings.`;
-      }
-      throw new Error(`Unable to launch language server: ${err.message}${extraHint}`);
-    }
-
-    return cmd;
+  public getClient(): TerraformLanguageClient {
+    return this.tfClient;
   }
 
-  public getClient(document?: vscode.Uri): TerraformLanguageClient {
-    if (this.supportsMultiFolders) {
-      return clients.get(MULTI_FOLDER_CLIENT);
-    }
-
-    return clients.get(this.clientName(document.toString()));
-  }
-
-  public clientSupportsCommand(cmdName: string, document?: vscode.Uri): boolean {
-    const commands = this.getClient(document).client.initializeResult.capabilities.executeCommandProvider?.commands;
-    return commands.includes(cmdName);
-  }
-
-  private clientName(folderName: string, workspaceFolders: readonly string[] = sortedWorkspaceFolders()): string {
-    folderName = normalizeFolderName(folderName);
-    const outerFolder = workspaceFolders.find((element) => folderName.startsWith(element));
-    // If this folder isn't nested, the found item will be itself
-    if (outerFolder && outerFolder !== folderName) {
-      folderName = getFolderName(getWorkspaceFolder(outerFolder));
-    }
-    return folderName;
+  public clientSupportsCommand(cmdName: string): boolean {
+    return this.commands.includes(cmdName);
   }
 }

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -65,7 +65,7 @@ export class ClientHandler {
 
     const initializationOptions = this.getInitializationOptions(commandPrefix);
 
-    const serverOptions = this.getServerOptions();
+    const serverOptions: ServerOptions = this.getServerOptions();
     this.outputChannel.appendLine(
       `Launching language server: ${serverOptions.run.command} ${serverOptions.run.args.join(' ')}`,
     );
@@ -104,7 +104,7 @@ export class ClientHandler {
     return { commandPrefix, client };
   }
 
-  private getServerOptions(): ServerOptions {
+  private getServerOptions() {
     const cmd = this.lsPath.resolvedPathToBinary();
     const serverArgs = config('terraform').get<string[]>('languageServer.args');
     const executable: Executable = {

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -120,8 +120,8 @@ export class ClientHandler {
     const terraformExecPath = config('terraform-ls').get<string>('terraformExecPath');
     const terraformExecTimeout = config('terraform-ls').get<string>('terraformExecTimeout');
     const terraformLogFilePath = config('terraform-ls').get<string>('terraformLogFilePath');
-    const excludeModulePaths = config('terraform-ls').get<string[]>('excludeRootModules');
-    const ignoreDirectoryNames = config('terraform-ls').get<string[]>('ignoreDirectoryNames');
+    const excludeModulePaths = config('terraform-ls').get<string[]>('excludeRootModules', []);
+    const ignoreDirectoryNames = config('terraform-ls').get<string[]>('ignoreDirectoryNames', []);
 
     if (rootModulePaths.length > 0 && excludeModulePaths.length > 0) {
       throw new Error(

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -39,25 +39,23 @@ export class ClientHandler {
     }
   }
 
-  public async startClient(): Promise<vscode.Disposable[]> {
-    const disposables: vscode.Disposable[] = [];
-
+  public async startClient(): Promise<vscode.Disposable> {
     console.log('Starting client');
 
     this.tfClient = this.createTerraformClient();
-    const readyClient = this.tfClient.client.onReady().then(async () => {
-      this.reporter.sendTelemetryEvent('startClient');
-      const multiFoldersSupported =
-        this.tfClient.client.initializeResult.capabilities.workspace?.workspaceFolders?.supported;
-      console.log(`Multi-folder support: ${multiFoldersSupported}`);
+    const disposable = this.tfClient.client.start();
 
-      this.commands = this.tfClient.client.initializeResult.capabilities.executeCommandProvider?.commands;
-    });
+    await this.tfClient.client.onReady();
 
-    disposables.push(this.tfClient.client.start());
-    await readyClient;
+    this.reporter.sendTelemetryEvent('startClient');
 
-    return disposables;
+    const multiFoldersSupported =
+      this.tfClient.client.initializeResult.capabilities.workspace?.workspaceFolders?.supported;
+    console.log(`Multi-folder support: ${multiFoldersSupported}`);
+
+    this.commands = this.tfClient.client.initializeResult.capabilities.executeCommandProvider?.commands;
+
+    return disposable;
   }
 
   private createTerraformClient(): TerraformLanguageClient {

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -147,7 +147,7 @@ export class ClientHandler {
 
   public async stopClient(): Promise<void> {
     if (this.tfClient?.client === undefined) {
-      return Promise.resolve();
+      return;
     }
 
     await this.tfClient.client.stop();

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -134,25 +134,16 @@ export class ClientHandler {
     }
 
     const experimentalFeatures = config('terraform-ls').get('experimentalFeatures');
-    let initializationOptions = { commandPrefix, experimentalFeatures };
-    if (terraformExecPath.length > 0) {
-      initializationOptions = Object.assign(initializationOptions, { terraformExecPath });
-    }
-    if (terraformExecTimeout.length > 0) {
-      initializationOptions = Object.assign(initializationOptions, { terraformExecTimeout });
-    }
-    if (terraformLogFilePath.length > 0) {
-      initializationOptions = Object.assign(initializationOptions, { terraformLogFilePath });
-    }
-    if (rootModulePaths.length > 0) {
-      initializationOptions = Object.assign(initializationOptions, { rootModulePaths });
-    }
-    if (excludeModulePaths.length > 0) {
-      initializationOptions = Object.assign(initializationOptions, { excludeModulePaths });
-    }
-    if (ignoreDirectoryNames.length > 0) {
-      initializationOptions = Object.assign(initializationOptions, { ignoreDirectoryNames });
-    }
+    const initializationOptions = {
+      commandPrefix,
+      experimentalFeatures,
+      ...(terraformExecPath.length > 0 && { terraformExecPath }),
+      ...(terraformExecTimeout.length > 0 && { terraformExecTimeout }),
+      ...(terraformLogFilePath.length > 0 && { terraformLogFilePath }),
+      ...(rootModulePaths.length > 0 && { rootModulePaths }),
+      ...(excludeModulePaths.length > 0 && { excludeModulePaths }),
+      ...(ignoreDirectoryNames.length > 0 && { ignoreDirectoryNames }),
+    };
     return initializationOptions;
   }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -227,11 +227,8 @@ async function updateLanguageServer(extVersion: string, lsPath: ServerPath, sche
   }
 }
 
-function execWorkspaceCommand(
-  client: LanguageClient,
-  params: ExecuteCommandParams,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Promise<any> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function execWorkspaceCommand(client: LanguageClient, params: ExecuteCommandParams): Promise<any> {
   reporter.sendTelemetryEvent('execWorkspaceCommand', { command: params.command });
   return client.sendRequest(ExecuteCommandRequest.type, params);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -213,7 +213,7 @@ async function updateLanguageServer(extVersion: string, lsPath: ServerPath, sche
       reporter.sendTelemetryException(err);
       throw err;
     } finally {
-      // clean upa fter ourselves and remove zip files
+      // clean up after ourselves and remove zip files
       await installer.cleanupZips();
     }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,7 +80,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Terraf
       return clientHandler.stopClient();
     }),
     vscode.commands.registerCommand('terraform.apply', async () => {
-      await terraformCommand('apply', false, clientHandler);
+      await terraformCommand('apply', false);
     }),
     vscode.commands.registerCommand('terraform.init', async () => {
       const selected = await vscode.window.showOpenDialog({
@@ -101,13 +101,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<Terraf
       }
     }),
     vscode.commands.registerCommand('terraform.initCurrent', async () => {
-      await terraformCommand('init', true, clientHandler);
+      await terraformCommand('init', true);
     }),
     vscode.commands.registerCommand('terraform.plan', async () => {
-      await terraformCommand('plan', false, clientHandler);
+      await terraformCommand('plan', false);
     }),
     vscode.commands.registerCommand('terraform.validate', async () => {
-      await terraformCommand('validate', true, clientHandler);
+      await terraformCommand('validate', true);
     }),
     vscode.window.registerTreeDataProvider('terraform.modules', new ModuleProvider(context, clientHandler)),
     vscode.workspace.onDidChangeConfiguration(async (event: vscode.ConfigurationChangeEvent) => {
@@ -245,11 +245,8 @@ interface moduleCallersResponse {
   moduleCallers: moduleCaller[];
 }
 
-async function modulesCallersCommand(
-  languageClient: TerraformLanguageClient,
-  moduleUri: string,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Promise<any> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function modulesCallersCommand(languageClient: TerraformLanguageClient, moduleUri: string): Promise<any> {
   const requestParams: ExecuteCommandParams = {
     command: `${languageClient.commandPrefix}.terraform-ls.module.callers`,
     arguments: [`uri=${moduleUri}`],
@@ -267,12 +264,8 @@ async function moduleCallers(
   return { version: response.v, moduleCallers };
 }
 
-async function terraformCommand(
-  command: string,
-  languageServerExec = true,
-  clientHandler: ClientHandler,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-): Promise<any> {
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+async function terraformCommand(command: string, languageServerExec = true): Promise<any> {
   const textEditor = getActiveTextEditor();
   if (textEditor) {
     const languageClient = clientHandler.getClient();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,7 +11,7 @@ import { SingleInstanceTimeout } from './utils';
 import { config, getActiveTextEditor } from './vscodeUtils';
 
 const brand = `HashiCorp Terraform`;
-const outputChannel: vscode.OutputChannel = vscode.window.createOutputChannel(brand);
+const outputChannel = vscode.window.createOutputChannel(brand);
 const terraformStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
 
 let reporter: TelemetryReporter;
@@ -127,7 +127,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Terraf
       if (textEditor === undefined) {
         return;
       }
-      if (textEditor.document === undefined) {
+      if (textEditor?.document === undefined) {
         return;
       }
       await updateTerraformStatusBar(terraformStatus, clientHandler, reporter, textEditor.document.uri);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -20,7 +20,11 @@ const languageServerUpdater = new SingleInstanceTimeout();
 
 export interface TerraformExtension {
   clientHandler: ClientHandler;
-  moduleCallers(languageClient: TerraformLanguageClient, moduleUri: string): Promise<moduleCallersResponse>;
+  moduleCallers(
+    languageClient: TerraformLanguageClient,
+    moduleUri: string,
+    reporter: TelemetryReporter,
+  ): Promise<moduleCallersResponse>;
 }
 
 export async function activate(context: vscode.ExtensionContext): Promise<TerraformExtension> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -119,9 +119,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<Terraf
         }
       }
     }),
-    vscode.window.onDidChangeVisibleTextEditors(async () => {
-      const textEditor = getActiveTextEditor();
-      if (textEditor?.document === undefined) {
+    vscode.window.onDidChangeVisibleTextEditors(async (editors: vscode.TextEditor[]) => {
+      const textEditor = editors.find((ed) => !!ed.viewColumn);
+      if (textEditor.document === undefined) {
         return;
       }
       await updateTerraformStatusBar(textEditor.document.uri);

--- a/src/providers/moduleProvider.ts
+++ b/src/providers/moduleProvider.ts
@@ -103,12 +103,14 @@ export class ModuleProvider implements vscode.TreeDataProvider<ModuleCall> {
 
     const editor = document.uri;
     const documentURI = Utils.dirname(editor);
-    const handler = this.handler.getClient(editor);
+    const handler = this.handler.getClient();
+    if (handler === undefined) {
+      return Promise.resolve([]);
+    }
 
     return await handler.client.onReady().then(async () => {
       const moduleCallsSupported = this.handler.clientSupportsCommand(
         `${handler.commandPrefix}.terraform-ls.module.calls`,
-        editor,
       );
       if (!moduleCallsSupported) {
         return Promise.resolve([]);

--- a/src/providers/moduleProvider.ts
+++ b/src/providers/moduleProvider.ts
@@ -105,7 +105,7 @@ export class ModuleProvider implements vscode.TreeDataProvider<ModuleCall> {
     const documentURI = Utils.dirname(editor);
     const handler = this.handler.getClient();
     if (handler === undefined) {
-      return Promise.resolve([]);
+      return [];
     }
 
     return await handler.client.onReady().then(async () => {

--- a/src/serverPath.ts
+++ b/src/serverPath.ts
@@ -59,7 +59,7 @@ export class ServerPath {
       }
       console.log(`Found server at ${cmd}`);
     } catch (err) {
-      let extraHint: string;
+      let extraHint = '';
       if (this.hasCustomBinPath()) {
         extraHint = `. Check "${CUSTOM_BIN_PATH_OPTION_NAME}" in your settings.`;
       }

--- a/src/vscodeUtils.ts
+++ b/src/vscodeUtils.ts
@@ -28,27 +28,6 @@ export function getActiveTextEditor(): vscode.TextEditor {
   return vscode.window.visibleTextEditors.find((textEditor) => !!textEditor.viewColumn);
 }
 
-export function prunedFolderNames(
-  folders: readonly vscode.WorkspaceFolder[] = vscode.workspace.workspaceFolders,
-): string[] {
-  const result = [];
-  // Sort workspace folders so that outer folders (shorter path) go before inner ones
-  const workspaceFolders = sortedWorkspaceFolders();
-  if (folders && workspaceFolders) {
-    const folderNames = folders.map((f) => getFolderName(f));
-    for (let name of folderNames) {
-      const outerFolder = workspaceFolders.find((element) => name.startsWith(element));
-      // If this folder isn't nested, the found item will be itself
-      if (outerFolder && outerFolder !== name) {
-        name = getFolderName(getWorkspaceFolder(outerFolder));
-      }
-      result.push(name);
-    }
-  }
-
-  return result;
-}
-
 export function sortedWorkspaceFolders(): string[] {
   const workspaceFolders = vscode.workspace.workspaceFolders;
   if (workspaceFolders) {


### PR DESCRIPTION
## Refactor Language Client Workflow

- Refactors ClientHandler to only use one `LanguageClient` per extension activation. Removes the Map of `LanguageClients` and ensures that any attempt to use a `LanguageClient` or method happens after the onReady event finishes. The terraform-ls sever implemented multi-folder/workspace support in hashicorp/terraform-ls#502. This means the VS Code extension no longer needs multiple clients to track how many folders are added to the current workspace and which event for which file needs to be sent at certain times.
- Moves the list of supported commands to a private property of the ClientHandler class and populates it when the client and LS are initialized. Previously you could attempt to ask the server what commands were supported before the client and server had finished the initialization process. This would result in an unhandled exception and leave the client in an unknown state.
- Refactors the createTerraformClient method to reduce complexity and verbosity by using language constructs. Move variables closer to usage for future method extraction. We no longer need to track the `location` or `workspaceFolder` to pull settings or display information per folder. This greatly simplifies the code accessing settings and creating the `LanguageClient`.
- Move creation of the OutputChannel to the main flow and only create one outputChannel for the entire extension. Use 'HashiCorp Terraform' as the name the OutputChannel to brand our extension. The `name` is displayed in a drop down in the `Output` pane in the editor, so it should be reconizable and readable.
- Optimizes main execution flow by bringing language server updater to main execution flow, reducing the cases where a restart needs to occur to update, and reducing nesting constucts.
- Extracts `resolvePathToBinary` method to the ServerPath class. The `resolvedPathToBinary` resolves the LS filesystem path and uses methods inside the ServerPath class. The ClientHandler class is only responsible for LanguageClients, and so does not need this private method.


## Testing

- single folder workspace
- multiple folder workspace
- starting editor with no documents open
- starting editor with one or more documents already open
- starting editor with module view expanded

actions for each test:

1. open document, trigger intellisense and complete a resource from a provider
1. hover over a declaration or field and see hover doc info
1. navigate using any of the go to commands
1. navigate using variable reference

--- 

Closes #816