### PR TITLE
Fix Warnings

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,12 @@ let reporter: TelemetryReporter;
 let clientHandler: ClientHandler;
 const languageServerUpdater = new SingleInstanceTimeout();
 
-export async function activate(context: vscode.ExtensionContext): Promise<any> {
+export interface TerraformExtension {
+  clientHandler: ClientHandler;
+  moduleCallers(languageClient: TerraformLanguageClient, moduleUri: string): Promise<moduleCallersResponse>;
+}
+
+export async function activate(context: vscode.ExtensionContext): Promise<TerraformExtension> {
   const manifest = context.extension.packageJSON;
   reporter = new TelemetryReporter(context.extension.id, manifest.version, manifest.appInsightsKey);
   context.subscriptions.push(reporter);
@@ -205,6 +210,7 @@ async function updateLanguageServer(extVersion: string, clientHandler: ClientHan
   }
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function execWorkspaceCommand(client: LanguageClient, params: ExecuteCommandParams): Promise<any> {
   reporter.sendTelemetryEvent('execWorkspaceCommand', { command: params.command });
   return client.sendRequest(ExecuteCommandRequest.type, params);
@@ -219,6 +225,7 @@ interface moduleCallersResponse {
   moduleCallers: moduleCaller[];
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function modulesCallersCommand(languageClient: TerraformLanguageClient, moduleUri: string): Promise<any> {
   const requestParams: ExecuteCommandParams = {
     command: `${languageClient.commandPrefix}.terraform-ls.module.callers`,
@@ -241,6 +248,7 @@ async function terraformCommand(
   command: string,
   languageServerExec = true,
   clientHandler: ClientHandler,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
 ): Promise<any> {
   const textEditor = getActiveTextEditor();
   if (textEditor) {

--- a/src/providers/moduleProvider.ts
+++ b/src/providers/moduleProvider.ts
@@ -139,6 +139,7 @@ export class ModuleProvider implements vscode.TreeDataProvider<ModuleCall> {
     sourceType: string,
     docsLink: string,
     terraformIcon: string,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
     dependents: any,
   ): ModuleCall {
     let deps: ModuleCall[] = [];

--- a/src/test/integration/workspaces.test.ts
+++ b/src/test/integration/workspaces.test.ts
@@ -1,9 +1,8 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { Utils } from 'vscode-uri';
+import { TerraformExtension } from '../../extension';
 import { getDocUri, getExtensionId, open, testFolderPath } from '../helper';
-
-
 
 suite('moduleCallers', () => {
   teardown(async () => {
@@ -12,17 +11,24 @@ suite('moduleCallers', () => {
 
 	test('should execute language server command', async () => {
 		const extId = getExtensionId()
-		const ext = vscode.extensions.getExtension(extId);
+		const ext = vscode.extensions.getExtension<TerraformExtension>(extId);
 
 		const documentUri = getDocUri('modules/sample.tf');
 		await open(documentUri);
 
     assert.ok(ext.isActive);
 
-		const client = ext.exports.clientHandler.getClient(documentUri);
+		const api = ext.exports;
+    assert.ok(api.clientHandler);
+    assert.ok(api.moduleCallers);
+
+		const client = await api.clientHandler.getClient();
+    assert.ok(client);
 
 		const moduleUri = Utils.dirname(documentUri).toString();
-		const response = await ext.exports.moduleCallers(client, moduleUri);
+		const response = await api.moduleCallers(client, moduleUri);
+    assert.ok(response);
+
 		assert.strictEqual(response.moduleCallers.length, 1);
 		assert.strictEqual(response.moduleCallers[0].uri, vscode.Uri.file(testFolderPath).toString(true));
 	})

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,6 +21,7 @@ export class SingleInstanceTimeout {
   private timerLock = false;
   private timerId: NodeJS.Timeout;
 
+  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
   public timeout(fn, delay, ...args) {
     if (!this.timerLock) {
       this.timerLock = true;
@@ -35,7 +36,7 @@ export class SingleInstanceTimeout {
     }
   }
 
-  public clear() {
+  public clear(): void {
     if (this.timerId) {
       clearTimeout(this.timerId);
     }


### PR DESCRIPTION
Fixes warnings in extension activation by strongly typing return value. Safely ignores the rest as they rely on untyped responses.
