### PR TITLE
Add panel for module providers

### DIFF
--- a/package.json
+++ b/package.json
@@ -279,6 +279,13 @@
     "views": {
       "explorer": [
         {
+          "id": "terraform.providers",
+          "name": "Terraform Provides",
+          "icon": "assets/icons/terraform.svg",
+          "visibility": "collapsed",
+          "when": "terraform.showProviderView"
+        },
+        {
           "id": "terraform.modules",
           "name": "Terraform Module Calls",
           "icon": "assets/icons/terraform.svg",
@@ -288,6 +295,10 @@
       ]
     },
     "viewsWelcome": [
+      {
+        "view": "terraform.providers",
+        "contents": "The active editor cannot provide information about installed providers."
+      },
       {
         "view": "terraform.modules",
         "contents": "The active editor cannot provide information about installed modules. [Learn more about modules](https://www.terraform.io/docs/language/modules/develop/index.html) You may need to run 'terraform get' or update your language server version."

--- a/package.json
+++ b/package.json
@@ -249,6 +249,11 @@
         "command": "terraform.modules.openDocumentation",
         "title": "Open Documentation",
         "icon": "$(book)"
+      },
+      {
+        "command": "terraform.providers.openDocumentation",
+        "title": "Open Documentation",
+        "icon": "$(book)"
       }
     ],
     "menus": {
@@ -259,6 +264,10 @@
         },
         {
           "command": "terraform.modules.openDocumentation",
+          "when": "false"
+        },
+        {
+          "command": "terraform.providers.openDocumentation",
           "when": "false"
         }
       ],
@@ -273,6 +282,10 @@
         {
           "command": "terraform.modules.openDocumentation",
           "when": "view == terraform.modules"
+        },
+        {
+          "command": "terraform.providers.openDocumentation",
+          "when": "view == terraform.providers"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -293,17 +293,17 @@
       "explorer": [
         {
           "id": "terraform.providers",
-          "name": "Terraform Provides",
+          "name": "Terraform Providers",
           "icon": "assets/icons/terraform.svg",
           "visibility": "collapsed",
-          "when": "terraform.showProviderView"
+          "when": "terraform.showTreeViews"
         },
         {
           "id": "terraform.modules",
           "name": "Terraform Module Calls",
           "icon": "assets/icons/terraform.svg",
           "visibility": "collapsed",
-          "when": "terraform.showModuleView"
+          "when": "terraform.showTreeViews"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -310,7 +310,7 @@
     "viewsWelcome": [
       {
         "view": "terraform.providers",
-        "contents": "The active editor cannot provide information about installed providers."
+        "contents": "The active editor cannot provide information about installed providers. [Learn more about providers](https://www.terraform.io/docs/language/providers/index.html). You may need to update your language server version."
       },
       {
         "view": "terraform.modules",

--- a/package.json
+++ b/package.json
@@ -285,7 +285,7 @@
         },
         {
           "command": "terraform.providers.openDocumentation",
-          "when": "view == terraform.providers"
+          "when": "view == terraform.providers && viewItem == moduleProviderHasDocs"
         }
       ]
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -128,7 +128,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Terraf
     }),
     vscode.window.onDidChangeVisibleTextEditors(async (editors: vscode.TextEditor[]) => {
       const textEditor = editors.find((ed) => !!ed.viewColumn);
-      if (textEditor.document === undefined) {
+      if (textEditor?.document === undefined) {
         return;
       }
       await updateTerraformStatusBar(textEditor.document.uri);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -136,8 +136,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Terraf
     try {
       await updateLanguageServer(manifest.version, lsPath);
       await clientHandler.startClient();
-      vscode.commands.executeCommand('setContext', 'terraform.showModuleView', true);
-      vscode.commands.executeCommand('setContext', 'terraform.showProviderView', true);
+      vscode.commands.executeCommand('setContext', 'terraform.showTreeViews', true);
     } catch (error) {
       reporter.sendTelemetryException(error);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,7 +7,7 @@ import { ClientHandler, TerraformLanguageClient } from './clientHandler';
 import { GenerateBugReportCommand } from './commands/generateBugReport';
 import { defaultVersionString, isValidVersionString, LanguageServerInstaller } from './languageServerInstaller';
 import { ModuleProvider } from './providers/moduleProvider';
-import { ProviderProvider } from './providers/providerProvider';
+import { ModuleProviderProvider } from './providers/providerProvider';
 import { ServerPath } from './serverPath';
 import { SingleInstanceTimeout } from './utils';
 import { config, getActiveTextEditor } from './vscodeUtils';
@@ -113,7 +113,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Terraf
     }),
     new GenerateBugReportCommand(context),
     vscode.window.registerTreeDataProvider('terraform.modules', new ModuleProvider(context, clientHandler)),
-    vscode.window.registerTreeDataProvider('terraform.providers', new ProviderProvider(context, clientHandler)),
+    vscode.window.registerTreeDataProvider('terraform.providers', new ModuleProviderProvider(context, clientHandler)),
     vscode.workspace.onDidChangeConfiguration(async (event: vscode.ConfigurationChangeEvent) => {
       if (event.affectsConfiguration('terraform') || event.affectsConfiguration('terraform-ls')) {
         const reloadMsg = 'Reload VSCode window to apply language server changes';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -7,6 +7,7 @@ import { ClientHandler, TerraformLanguageClient } from './clientHandler';
 import { GenerateBugReportCommand } from './commands/generateBugReport';
 import { defaultVersionString, isValidVersionString, LanguageServerInstaller } from './languageServerInstaller';
 import { ModuleProvider } from './providers/moduleProvider';
+import { ProviderProvider } from './providers/providerProvider';
 import { ServerPath } from './serverPath';
 import { SingleInstanceTimeout } from './utils';
 import { config, getActiveTextEditor } from './vscodeUtils';
@@ -112,6 +113,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Terraf
     }),
     new GenerateBugReportCommand(context),
     vscode.window.registerTreeDataProvider('terraform.modules', new ModuleProvider(context, clientHandler)),
+    vscode.window.registerTreeDataProvider('terraform.providers', new ProviderProvider(context, clientHandler)),
     vscode.workspace.onDidChangeConfiguration(async (event: vscode.ConfigurationChangeEvent) => {
       if (event.affectsConfiguration('terraform') || event.affectsConfiguration('terraform-ls')) {
         const reloadMsg = 'Reload VSCode window to apply language server changes';
@@ -135,6 +137,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<Terraf
       await updateLanguageServer(manifest.version, lsPath);
       await clientHandler.startClient();
       vscode.commands.executeCommand('setContext', 'terraform.showModuleView', true);
+      vscode.commands.executeCommand('setContext', 'terraform.showProviderView', true);
     } catch (error) {
       reporter.sendTelemetryException(error);
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,8 +6,8 @@ import { Utils } from 'vscode-uri';
 import { ClientHandler, TerraformLanguageClient } from './clientHandler';
 import { GenerateBugReportCommand } from './commands/generateBugReport';
 import { defaultVersionString, isValidVersionString, LanguageServerInstaller } from './languageServerInstaller';
-import { ModuleProvider } from './providers/moduleProvider';
-import { ModuleProviderProvider } from './providers/providerProvider';
+import { ModuleCallsDataProvider } from './providers/moduleCalls';
+import { ModuleProvidersDataProvider } from './providers/moduleProviders';
 import { ServerPath } from './serverPath';
 import { SingleInstanceTimeout } from './utils';
 import { config, getActiveTextEditor } from './vscodeUtils';
@@ -112,8 +112,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<Terraf
       await terraformCommand('validate', true);
     }),
     new GenerateBugReportCommand(context),
-    vscode.window.registerTreeDataProvider('terraform.modules', new ModuleProvider(context, clientHandler)),
-    vscode.window.registerTreeDataProvider('terraform.providers', new ModuleProviderProvider(context, clientHandler)),
+    vscode.window.registerTreeDataProvider('terraform.modules', new ModuleCallsDataProvider(context, clientHandler)),
+    vscode.window.registerTreeDataProvider(
+      'terraform.providers',
+      new ModuleProvidersDataProvider(context, clientHandler),
+    ),
     vscode.workspace.onDidChangeConfiguration(async (event: vscode.ConfigurationChangeEvent) => {
       if (event.affectsConfiguration('terraform') || event.affectsConfiguration('terraform-ls')) {
         const reloadMsg = 'Reload VSCode window to apply language server changes';

--- a/src/providers/moduleCalls.ts
+++ b/src/providers/moduleCalls.ts
@@ -5,7 +5,7 @@ import { Utils } from 'vscode-uri';
 import { ClientHandler } from '../clientHandler';
 import { getActiveTextEditor } from '../vscodeUtils';
 
-class ModuleCall extends vscode.TreeItem {
+class ModuleCallItem extends vscode.TreeItem {
   constructor(
     public label: string,
     public sourceAddr: string,
@@ -13,7 +13,7 @@ class ModuleCall extends vscode.TreeItem {
     public sourceType: string,
     public docsLink: string,
     public terraformIcon: string,
-    public readonly children: ModuleCall[],
+    public readonly children: ModuleCallItem[],
   ) {
     super(
       label,
@@ -50,11 +50,12 @@ class ModuleCall extends vscode.TreeItem {
   }
 }
 
-export class ModuleProvider implements vscode.TreeDataProvider<ModuleCall> {
-  private _onDidChangeTreeData: vscode.EventEmitter<ModuleCall | undefined | null | void> = new vscode.EventEmitter<
-    ModuleCall | undefined | null | void
+export class ModuleCallsDataProvider implements vscode.TreeDataProvider<ModuleCallItem> {
+  private _onDidChangeTreeData: vscode.EventEmitter<ModuleCallItem | undefined | null | void> = new vscode.EventEmitter<
+    ModuleCallItem | undefined | null | void
   >();
-  readonly onDidChangeTreeData: vscode.Event<ModuleCall | undefined | null | void> = this._onDidChangeTreeData.event;
+  readonly onDidChangeTreeData: vscode.Event<ModuleCallItem | undefined | null | void> =
+    this._onDidChangeTreeData.event;
 
   private svg = '';
 
@@ -62,7 +63,7 @@ export class ModuleProvider implements vscode.TreeDataProvider<ModuleCall> {
     this.svg = ctx.asAbsolutePath(path.join('assets', 'icons', 'terraform.svg'));
     ctx.subscriptions.push(
       vscode.commands.registerCommand('terraform.modules.refreshList', () => this.refresh()),
-      vscode.commands.registerCommand('terraform.modules.openDocumentation', (module: ModuleCall) => {
+      vscode.commands.registerCommand('terraform.modules.openDocumentation', (module: ModuleCallItem) => {
         vscode.env.openExternal(vscode.Uri.parse(module.docsLink));
       }),
       vscode.window.onDidChangeActiveTextEditor(async (event: vscode.TextEditor | undefined) => {
@@ -77,11 +78,11 @@ export class ModuleProvider implements vscode.TreeDataProvider<ModuleCall> {
     this._onDidChangeTreeData.fire();
   }
 
-  getTreeItem(element: ModuleCall): ModuleCall | Thenable<ModuleCall> {
+  getTreeItem(element: ModuleCallItem): ModuleCallItem | Thenable<ModuleCallItem> {
     return element;
   }
 
-  getChildren(element?: ModuleCall): vscode.ProviderResult<ModuleCall[]> {
+  getChildren(element?: ModuleCallItem): vscode.ProviderResult<ModuleCallItem[]> {
     if (element) {
       return Promise.resolve(element.children);
     } else {
@@ -90,7 +91,7 @@ export class ModuleProvider implements vscode.TreeDataProvider<ModuleCall> {
     }
   }
 
-  async getModules(): Promise<ModuleCall[]> {
+  async getModules(): Promise<ModuleCallItem[]> {
     const activeEditor = getActiveTextEditor();
     if (activeEditor === undefined) {
       return Promise.resolve([]);
@@ -143,8 +144,8 @@ export class ModuleProvider implements vscode.TreeDataProvider<ModuleCall> {
     terraformIcon: string,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/explicit-module-boundary-types
     dependents: any,
-  ): ModuleCall {
-    let deps: ModuleCall[] = [];
+  ): ModuleCallItem {
+    let deps: ModuleCallItem[] = [];
     if (dependents.length != 0) {
       deps = dependents.map((dp) =>
         this.toModuleCall(
@@ -159,6 +160,6 @@ export class ModuleProvider implements vscode.TreeDataProvider<ModuleCall> {
       );
     }
 
-    return new ModuleCall(name, sourceAddr, version, sourceType, docsLink, terraformIcon, deps);
+    return new ModuleCallItem(name, sourceAddr, version, sourceType, docsLink, terraformIcon, deps);
   }
 }

--- a/src/providers/moduleProviders.ts
+++ b/src/providers/moduleProviders.ts
@@ -19,7 +19,7 @@ interface ModuleProvidersResponse {
   };
 }
 
-class ModuleProvider extends vscode.TreeItem {
+class ModuleProviderItem extends vscode.TreeItem {
   constructor(
     public fullName: string,
     public displayName: string,
@@ -39,18 +39,18 @@ class ModuleProvider extends vscode.TreeItem {
   }
 }
 
-export class ModuleProviderProvider implements vscode.TreeDataProvider<ModuleProvider> {
-  private readonly didChangeTreeData = new vscode.EventEmitter<void | ModuleProvider>();
+export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<ModuleProviderItem> {
+  private readonly didChangeTreeData = new vscode.EventEmitter<void | ModuleProviderItem>();
   public readonly onDidChangeTreeData = this.didChangeTreeData.event;
 
   constructor(ctx: vscode.ExtensionContext, private handler: ClientHandler) {
     ctx.subscriptions.push(
-      vscode.window.onDidChangeActiveTextEditor(async (event: vscode.TextEditor) => {
+      vscode.window.onDidChangeActiveTextEditor(async (event: vscode.TextEditor | undefined) => {
         if (event && getActiveTextEditor()) {
           this.refresh();
         }
       }),
-      vscode.commands.registerCommand('terraform.providers.openDocumentation', (module: ModuleProvider) => {
+      vscode.commands.registerCommand('terraform.providers.openDocumentation', (module: ModuleProviderItem) => {
         if (module.docsLink) {
           vscode.env.openExternal(vscode.Uri.parse(module.docsLink));
         }
@@ -62,11 +62,11 @@ export class ModuleProviderProvider implements vscode.TreeDataProvider<ModulePro
     this.didChangeTreeData.fire();
   }
 
-  getTreeItem(element: ModuleProvider): vscode.TreeItem | Thenable<vscode.TreeItem> {
+  getTreeItem(element: ModuleProviderItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
     return element;
   }
 
-  getChildren(element?: ModuleProvider): vscode.ProviderResult<ModuleProvider[]> {
+  getChildren(element?: ModuleProviderItem): vscode.ProviderResult<ModuleProviderItem[]> {
     if (element) {
       return [];
     } else {
@@ -74,7 +74,7 @@ export class ModuleProviderProvider implements vscode.TreeDataProvider<ModulePro
     }
   }
 
-  async getProvider(): Promise<ModuleProvider[]> {
+  async getProvider(): Promise<ModuleProviderItem[]> {
     const activeEditor = getActiveTextEditor();
 
     const document = activeEditor?.document;
@@ -113,7 +113,7 @@ export class ModuleProviderProvider implements vscode.TreeDataProvider<ModulePro
     return Object.entries(response.provider_requirements)
       .map(
         ([provider, details]) =>
-          new ModuleProvider(
+          new ModuleProviderItem(
             provider,
             details.display_name,
             details.version_constraint,

--- a/src/providers/providerProvider.ts
+++ b/src/providers/providerProvider.ts
@@ -10,7 +10,8 @@ interface ModuleProvidersResponse {
   provider_requirements: {
     [provider: string]: {
       display_name: string;
-      version_constraint: string;
+      version_constraint?: string;
+      docs_link?: string;
     };
   };
   installed_providers: {
@@ -24,6 +25,7 @@ class ModuleProvider extends vscode.TreeItem {
     public displayName: string,
     public requiredVersion: string,
     public installedVersion: string | undefined,
+    public docsLink: string | undefined,
   ) {
     super(`${displayName} ${requiredVersion}`, vscode.TreeItemCollapsibleState.None);
 
@@ -42,6 +44,11 @@ export class ModuleProviderProvider implements vscode.TreeDataProvider<ModulePro
       vscode.window.onDidChangeActiveTextEditor(async (event: vscode.TextEditor) => {
         if (event && getActiveTextEditor()) {
           this.refresh();
+        }
+      }),
+      vscode.commands.registerCommand('terraform.providers.openDocumentation', (module: ModuleProvider) => {
+        if (module.docsLink) {
+          vscode.env.openExternal(vscode.Uri.parse(module.docsLink));
         }
       }),
     );
@@ -107,6 +114,7 @@ export class ModuleProviderProvider implements vscode.TreeDataProvider<ModulePro
             details.display_name,
             details.version_constraint,
             response.installed_providers[provider],
+            details.docs_link,
           ),
       )
       .filter((m) => Boolean(m.requiredVersion));

--- a/src/providers/providerProvider.ts
+++ b/src/providers/providerProvider.ts
@@ -23,15 +23,15 @@ class ModuleProvider extends vscode.TreeItem {
   constructor(
     public fullName: string,
     public displayName: string,
-    public requiredVersion: string,
+    public requiredVersion: string | undefined,
     public installedVersion: string | undefined,
     public docsLink: string | undefined,
   ) {
-    super(`${displayName} ${requiredVersion}`, vscode.TreeItemCollapsibleState.None);
+    super(displayName, vscode.TreeItemCollapsibleState.None);
 
-    this.description = installedVersion ?? 'n.a.';
+    this.description = installedVersion ?? '';
     this.iconPath = new vscode.ThemeIcon('package');
-    this.tooltip = fullName;
+    this.tooltip = `${fullName} ${requiredVersion ?? ''}`;
 
     if (docsLink) {
       this.contextValue = 'moduleProviderHasDocs';

--- a/src/providers/providerProvider.ts
+++ b/src/providers/providerProvider.ts
@@ -1,0 +1,30 @@
+import * as vscode from 'vscode';
+import { ClientHandler } from '../clientHandler';
+
+class Provider extends vscode.TreeItem {}
+
+export class ProviderProvider implements vscode.TreeDataProvider<Provider> {
+  onDidChangeTreeData?: vscode.Event<void | Provider>;
+
+  constructor(ctx: vscode.ExtensionContext, public handler: ClientHandler) {}
+
+  getTreeItem(element: Provider): vscode.TreeItem | Thenable<vscode.TreeItem> {
+    throw new Error('Method not implemented.');
+  }
+
+  getChildren(element?: Provider): vscode.ProviderResult<Provider[]> {
+    throw new Error('Method not implemented.');
+  }
+
+  getParent?(element: Provider): vscode.ProviderResult<Provider> {
+    throw new Error('Method not implemented.');
+  }
+
+  resolveTreeItem?(
+    item: vscode.TreeItem,
+    element: Provider,
+    token: vscode.CancellationToken,
+  ): vscode.ProviderResult<vscode.TreeItem> {
+    throw new Error('Method not implemented.');
+  }
+}

--- a/src/providers/providerProvider.ts
+++ b/src/providers/providerProvider.ts
@@ -32,6 +32,10 @@ class ModuleProvider extends vscode.TreeItem {
     this.description = installedVersion ?? 'n.a.';
     this.iconPath = new vscode.ThemeIcon('package');
     this.tooltip = fullName;
+
+    if (docsLink) {
+      this.contextValue = 'moduleProviderHasDocs';
+    }
   }
 }
 


### PR DESCRIPTION
This PR adds a new tree view panel in the explorer menu with the installed providers in the current module.

It depends on the language server PR https://github.com/hashicorp/terraform-ls/pull/712

New panel, listing providers with the installed version:

<img width="310" alt="CleanShot 2021-11-17 at 16 37 01@2x" src="https://user-images.githubusercontent.com/45985/142231702-f96c011c-4c3c-4353-ad72-8e0d1b9958cf.png">

No providers detected:

<img width="321" alt="CleanShot 2021-11-17 at 16 35 20@2x" src="https://user-images.githubusercontent.com/45985/142231756-b28645ca-d5cf-4f23-9800-7b0fc5e839ca.png">

Providers not installed (yet):

<img width="322" alt="CleanShot 2021-11-17 at 16 34 58@2x" src="https://user-images.githubusercontent.com/45985/142231807-6e183686-5fa6-4a65-ada8-27bfe10c585f.png">

Tooltip showing the required version:

<img width="421" alt="CleanShot 2021-11-17 at 16 37 54@2x" src="https://user-images.githubusercontent.com/45985/142231970-091f4a1d-ab4a-46cc-a983-23dac54c9472.png">

Closes #701