### PR TITLE
Use vscode.workspace.fs instead of fs package

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,7 +302,6 @@
   "dependencies": {
     "@hashicorp/js-releases": "^1.4.0",
     "@types/semver": "^7.3.4",
-    "del": "^5.1.0",
     "openpgp": "^4.10.10",
     "semver": "^7.3.5",
     "short-unique-id": "^3.2.3",

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -42,7 +42,7 @@ export class ClientHandler {
   public async startClient(): Promise<vscode.Disposable> {
     console.log('Starting client');
 
-    this.tfClient = this.createTerraformClient();
+    this.tfClient = await this.createTerraformClient();
     const disposable = this.tfClient.client.start();
 
     await this.tfClient.client.onReady();
@@ -58,12 +58,12 @@ export class ClientHandler {
     return disposable;
   }
 
-  private createTerraformClient(): TerraformLanguageClient {
+  private async createTerraformClient(): Promise<TerraformLanguageClient> {
     const commandPrefix = this.shortUid.seq();
 
     const initializationOptions = this.getInitializationOptions(commandPrefix);
 
-    const serverOptions = this.getServerOptions();
+    const serverOptions = await this.getServerOptions();
 
     const documentSelector: DocumentSelector = [
       { scheme: 'file', language: 'terraform' },
@@ -99,8 +99,8 @@ export class ClientHandler {
     return { commandPrefix, client };
   }
 
-  private getServerOptions(): ServerOptions {
-    const cmd = this.lsPath.resolvedPathToBinary();
+  private async getServerOptions(): Promise<ServerOptions> {
+    const cmd = await this.lsPath.resolvedPathToBinary();
     const serverArgs = config('terraform').get<string[]>('languageServer.args');
     const executable: Executable = {
       command: cmd,

--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -119,7 +119,7 @@ export class LanguageServerInstaller {
   async installPkg(release: Release): Promise<void> {
     const installDir = this.lsPath.installPath();
     const destination = path.resolve(installDir, `terraform-ls_v${release.version}.zip`);
-    vscode.workspace.fs.createDirectory(vscode.Uri.file(installDir)); // create install directory if missing
+    await vscode.workspace.fs.createDirectory(vscode.Uri.file(installDir)); // create install directory if missing
 
     const os = goOs();
     const arch = goArch();
@@ -129,13 +129,13 @@ export class LanguageServerInstaller {
     }
 
     try {
-      vscode.workspace.fs.delete(vscode.Uri.file(this.lsPath.binPath()));
+      await vscode.workspace.fs.delete(vscode.Uri.file(this.lsPath.binPath()));
     } catch {
       // ignore missing binary (new install)
     }
 
     try {
-      vscode.workspace.fs.delete(vscode.Uri.file(this.lsPath.legacyBinPath()));
+      await vscode.workspace.fs.delete(vscode.Uri.file(this.lsPath.legacyBinPath()));
     } catch {
       // clean up may fail for new installation
       // or in new versions where this path is no longer in use

--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -73,10 +73,10 @@ export class LanguageServerInstaller {
         this.reporter.sendTelemetryException(err);
         throw err;
       }
-      if (err.code !== 'ENOENT') {
-        this.reporter.sendTelemetryException(err);
-        throw err;
-      }
+      // if (err.code !== 'ENOENT') {
+      //   this.reporter.sendTelemetryException(err);
+      //   throw err;
+      // }
       return true; // yes to new install
     }
 

--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -1,5 +1,4 @@
 import { getRelease, Release } from '@hashicorp/js-releases';
-import * as del from 'del';
 import * as path from 'path';
 import * as semver from 'semver';
 import * as vscode from 'vscode';
@@ -158,9 +157,10 @@ export class LanguageServerInstaller {
     );
   }
 
-  public async cleanupZips(): Promise<string[]> {
-    const pattern = path.resolve(this.lsPath.installPath(), 'terraform-ls*.zip');
-    return del(pattern, { force: true });
+  public async cleanupZips(): Promise<void> {
+    const installDir = this.lsPath.installPath();
+    const destination = path.resolve(installDir, `terraform-ls_v${this.release.version}.zip`);
+    return await vscode.workspace.fs.delete(vscode.Uri.file(destination));
   }
 
   showChangelog(version: string): void {

--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -65,7 +65,7 @@ export class LanguageServerInstaller {
       installedVersion = await getLsVersion(this.lsPath);
       console.log(`Currently installed Terraform language server is version '${installedVersion}`);
     } catch (err) {
-      // Most of the time, getLsVersion will produce "ENOENT: no such file or directory"
+      // Most of the time, getLsVersion will produce "FileSystemError: FileNotFound"
       // on a fresh installation (unlike upgrade). It’s also possible that the file or directory
       // is inaccessible for some other reason, but we catch that separately.
       if (err.code !== 'FileNotFound') {

--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -72,10 +72,6 @@ export class LanguageServerInstaller {
         this.reporter.sendTelemetryException(err);
         throw err;
       }
-      // if (err.code !== 'ENOENT') {
-      //   this.reporter.sendTelemetryException(err);
-      //   throw err;
-      // }
       return true; // yes to new install
     }
 

--- a/src/serverPath.ts
+++ b/src/serverPath.ts
@@ -1,4 +1,3 @@
-import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import * as which from 'which';
@@ -52,7 +51,7 @@ export class ServerPath {
     let cmd: string;
     try {
       if (path.isAbsolute(pathToBinary)) {
-        fs.accessSync(pathToBinary, fs.constants.X_OK);
+        vscode.workspace.fs.stat(vscode.Uri.file(pathToBinary));
         cmd = pathToBinary;
       } else {
         cmd = which.sync(pathToBinary);

--- a/src/serverPath.ts
+++ b/src/serverPath.ts
@@ -46,12 +46,12 @@ export class ServerPath {
     return 'terraform-ls';
   }
 
-  public resolvedPathToBinary(): string {
+  public async resolvedPathToBinary(): Promise<string> {
     const pathToBinary = this.binPath();
     let cmd: string;
     try {
       if (path.isAbsolute(pathToBinary)) {
-        vscode.workspace.fs.stat(vscode.Uri.file(pathToBinary));
+        await vscode.workspace.fs.stat(vscode.Uri.file(pathToBinary));
         cmd = pathToBinary;
       } else {
         cmd = which.sync(pathToBinary);


### PR DESCRIPTION
Replaces all usages of the fs package with the vscode.workspace.fs wrapper. This ensures safe usage of the filesystem and allows us in the future to move to remote extension use.

Fix bug where zip is not deleted after extraction. This also helps in the future when we minify the extension and del does not work.

Closes #812 