### PR TITLE
Use a scheduler for publishing preview releases

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,9 +1,9 @@
 name: Publish Preview release
 
 on:
-  push:
-    branches:
-      - main
+  schedule:
+    # run every day at 00:15 UTC to avoid high load times at the start of every hour
+    - cron: '15 0 * * *'
 
 jobs:
   publish:


### PR DESCRIPTION
This PR updates the workflow for preview releases to publish each night at 00:15 UTC instead of on each push to `main`.