### PR TITLE
Fix terraform status bar

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { config, getActiveTextEditor } from './vscodeUtils';
 
 const brand = `HashiCorp Terraform`;
 const outputChannel = vscode.window.createOutputChannel(brand);
-export const terraformStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+export let terraformStatus: vscode.StatusBarItem;
 
 let reporter: TelemetryReporter;
 let clientHandler: ClientHandler;
@@ -27,6 +27,7 @@ export interface TerraformExtension {
 
 export async function activate(context: vscode.ExtensionContext): Promise<TerraformExtension> {
   const manifest = context.extension.packageJSON;
+  terraformStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
   reporter = new TelemetryReporter(context.extension.id, manifest.version, manifest.appInsightsKey);
   context.subscriptions.push(reporter);
 
@@ -157,7 +158,7 @@ export async function deactivate(): Promise<void> {
   return clientHandler.stopClient();
 }
 
-async function updateTerraformStatusBar(documentUri: vscode.Uri): Promise<void> {
+export async function updateTerraformStatusBar(documentUri: vscode.Uri): Promise<void> {
   const client = clientHandler.getClient();
   const initSupported = clientHandler.clientSupportsCommand(`${client.commandPrefix}.terraform-ls.terraform.init`);
   if (initSupported) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -14,7 +14,7 @@ import { config, getActiveTextEditor } from './vscodeUtils';
 
 const brand = `HashiCorp Terraform`;
 const outputChannel = vscode.window.createOutputChannel(brand);
-const terraformStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+export const terraformStatus = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
 
 let reporter: TelemetryReporter;
 let clientHandler: ClientHandler;
@@ -158,7 +158,8 @@ export async function deactivate(): Promise<void> {
 }
 
 async function updateTerraformStatusBar(documentUri: vscode.Uri): Promise<void> {
-  const initSupported = clientHandler.clientSupportsCommand('terraform-ls.terraform.init');
+  const client = clientHandler.getClient();
+  const initSupported = clientHandler.clientSupportsCommand(`${client.commandPrefix}.terraform-ls.terraform.init`);
   if (initSupported) {
     const client = clientHandler.getClient();
     const moduleUri = Utils.dirname(documentUri);
@@ -175,6 +176,7 @@ async function updateTerraformStatusBar(documentUri: vscode.Uri): Promise<void> 
           terraformStatus.show();
         } else {
           terraformStatus.hide();
+          terraformStatus.text = '';
         }
       } catch (err) {
         vscode.window.showErrorMessage(err);

--- a/src/test/integration/statusBar.test.ts
+++ b/src/test/integration/statusBar.test.ts
@@ -1,0 +1,32 @@
+import * as assert from 'assert';
+import * as vscode from 'vscode';
+import { expect } from 'chai';
+import { terraformStatus } from '../../extension';
+import { getDocUri, open } from '../helper';
+import { sleep } from '../../utils';
+
+suite('statusBar', () => {
+  teardown(async () => {
+    await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+  });
+
+  test('should create a status bar item', () => {
+    assert.notStrictEqual(terraformStatus, undefined);
+  });
+
+  test('should create a status bar with the root module label', async () => {
+    const documentUri = getDocUri('sample.tf');
+    await open(documentUri);
+    await sleep(500);
+
+    expect(terraformStatus.text).to.equal('$(refresh) testFixture');
+  });
+
+  test('should create an empty status bar inside a child module', async () => {
+    const documentUri = getDocUri('modules/sample.tf');
+    await open(documentUri);
+    await sleep(500);
+
+    expect(terraformStatus.text).to.equal('');
+  });
+});

--- a/src/test/integration/statusBar.test.ts
+++ b/src/test/integration/statusBar.test.ts
@@ -1,31 +1,28 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { expect } from 'chai';
-import { terraformStatus } from '../../extension';
-import { getDocUri, open } from '../helper';
-import { sleep } from '../../utils';
+import { terraformStatus, updateTerraformStatusBar } from '../../extension';
+import { getDocUri } from '../helper';
 
 suite('statusBar', () => {
   teardown(async () => {
     await vscode.commands.executeCommand('workbench.action.closeAllEditors');
   });
 
-  test('should create a status bar item', () => {
+  test('should create a status bar item on activate', () => {
     assert.notStrictEqual(terraformStatus, undefined);
   });
 
   test('should create a status bar with the root module label', async () => {
     const documentUri = getDocUri('sample.tf');
-    await open(documentUri);
-    await sleep(500);
+    await updateTerraformStatusBar(documentUri);
 
     expect(terraformStatus.text).to.equal('$(refresh) testFixture');
   });
 
   test('should create an empty status bar inside a child module', async () => {
     const documentUri = getDocUri('modules/sample.tf');
-    await open(documentUri);
-    await sleep(500);
+    await updateTerraformStatusBar(documentUri);
 
     expect(terraformStatus.text).to.equal('');
   });


### PR DESCRIPTION
VSCode always hid the status bar because we never executed the command for getting the module callers as it was missing the `commandPrefix`.