### PR TITLE
Remove public api

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -26,7 +26,7 @@
         "panel": "dedicated",
         "reveal": "never"
       },
-      "dependsOn": "npm: watch"
+      "dependsOn": "npm: compile"
     }
   ]
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,30 +152,33 @@ export async function deactivate(): Promise<void> {
 
 export async function updateTerraformStatusBar(documentUri: vscode.Uri): Promise<void> {
   const client = clientHandler.getClient();
-  const initSupported = clientHandler.clientSupportsCommand(`${client.commandPrefix}.terraform-ls.terraform.init`);
 
-  if (initSupported) {
-    const moduleUri = Utils.dirname(documentUri);
+  if (client) {
+    const initSupported = clientHandler.clientSupportsCommand(`${client.commandPrefix}.terraform-ls.terraform.init`);
 
-    try {
-      const response = await moduleCallers(moduleUri.toString());
+    if (initSupported) {
+      const moduleUri = Utils.dirname(documentUri);
 
-      if (response.moduleCallers.length === 0) {
-        const dirName = Utils.basename(moduleUri);
+      try {
+        const response = await moduleCallers(moduleUri.toString());
 
-        terraformStatus.text = `$(refresh) ${dirName}`;
-        terraformStatus.color = new vscode.ThemeColor('statusBar.foreground');
-        terraformStatus.tooltip = `Click to run terraform init`;
-        terraformStatus.command = 'terraform.initCurrent';
-        terraformStatus.show();
-      } else {
+        if (response.moduleCallers.length === 0) {
+          const dirName = Utils.basename(moduleUri);
+
+          terraformStatus.text = `$(refresh) ${dirName}`;
+          terraformStatus.color = new vscode.ThemeColor('statusBar.foreground');
+          terraformStatus.tooltip = `Click to run terraform init`;
+          terraformStatus.command = 'terraform.initCurrent';
+          terraformStatus.show();
+        } else {
+          terraformStatus.hide();
+          terraformStatus.text = '';
+        }
+      } catch (err) {
+        vscode.window.showErrorMessage(err);
+        reporter.sendTelemetryException(err);
         terraformStatus.hide();
-        terraformStatus.text = '';
       }
-    } catch (err) {
-      vscode.window.showErrorMessage(err);
-      reporter.sendTelemetryException(err);
-      terraformStatus.hide();
     }
   }
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -259,6 +259,13 @@ async function modulesCallersCommand(languageClient: TerraformLanguageClient, mo
 
 export async function moduleCallers(moduleUri: string): Promise<moduleCallersResponse> {
   const client = clientHandler.getClient();
+  if (client === undefined) {
+    return {
+      version: 0,
+      moduleCallers: [],
+    };
+  }
+
   const response = await modulesCallersCommand(client, moduleUri);
   const moduleCallers: moduleCaller[] = response.callers;
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -152,34 +152,35 @@ export async function deactivate(): Promise<void> {
 
 export async function updateTerraformStatusBar(documentUri: vscode.Uri): Promise<void> {
   const client = clientHandler.getClient();
+  if (client === undefined) {
+    return;
+  }
 
-  if (client) {
-    const initSupported = clientHandler.clientSupportsCommand(`${client.commandPrefix}.terraform-ls.terraform.init`);
+  const initSupported = clientHandler.clientSupportsCommand(`${client.commandPrefix}.terraform-ls.terraform.init`);
+  if (!initSupported) {
+    return;
+  }
 
-    if (initSupported) {
-      const moduleUri = Utils.dirname(documentUri);
+  try {
+    const moduleUri = Utils.dirname(documentUri);
+    const response = await moduleCallers(moduleUri.toString());
 
-      try {
-        const response = await moduleCallers(moduleUri.toString());
+    if (response.moduleCallers.length === 0) {
+      const dirName = Utils.basename(moduleUri);
 
-        if (response.moduleCallers.length === 0) {
-          const dirName = Utils.basename(moduleUri);
-
-          terraformStatus.text = `$(refresh) ${dirName}`;
-          terraformStatus.color = new vscode.ThemeColor('statusBar.foreground');
-          terraformStatus.tooltip = `Click to run terraform init`;
-          terraformStatus.command = 'terraform.initCurrent';
-          terraformStatus.show();
-        } else {
-          terraformStatus.hide();
-          terraformStatus.text = '';
-        }
-      } catch (err) {
-        vscode.window.showErrorMessage(err);
-        reporter.sendTelemetryException(err);
-        terraformStatus.hide();
-      }
+      terraformStatus.text = `$(refresh) ${dirName}`;
+      terraformStatus.color = new vscode.ThemeColor('statusBar.foreground');
+      terraformStatus.tooltip = `Click to run terraform init`;
+      terraformStatus.command = 'terraform.initCurrent';
+      terraformStatus.show();
+    } else {
+      terraformStatus.hide();
+      terraformStatus.text = '';
     }
+  } catch (err) {
+    vscode.window.showErrorMessage(err);
+    reporter.sendTelemetryException(err);
+    terraformStatus.hide();
   }
 }
 

--- a/src/test/integration/workspaces.test.ts
+++ b/src/test/integration/workspaces.test.ts
@@ -1,8 +1,8 @@
 import * as assert from 'assert';
 import * as vscode from 'vscode';
 import { Utils } from 'vscode-uri';
-import { TerraformExtension } from '../../extension';
-import { getDocUri, getExtensionId, open, testFolderPath } from '../helper';
+import { moduleCallers } from '../../extension';
+import { getDocUri, open, testFolderPath } from '../helper';
 
 suite('moduleCallers', () => {
   teardown(async () => {
@@ -10,23 +10,11 @@ suite('moduleCallers', () => {
   });
 
   test('should execute language server command', async () => {
-    const extId = getExtensionId();
-    const ext = vscode.extensions.getExtension<TerraformExtension>(extId);
-
     const documentUri = getDocUri('modules/sample.tf');
     await open(documentUri);
 
-    assert.ok(ext.isActive);
-
-    const api = ext.exports;
-    assert.ok(api.clientHandler);
-    assert.ok(api.moduleCallers);
-
-    const client = await api.clientHandler.getClient();
-    assert.ok(client);
-
     const moduleUri = Utils.dirname(documentUri).toString();
-    const response = await api.moduleCallers(client, moduleUri);
+    const response = await moduleCallers(moduleUri);
     assert.ok(response);
 
     assert.strictEqual(response.moduleCallers.length, 1);


### PR DESCRIPTION
This PR depends on #857, which needs to be merged first.

Our `activate` function returned `moduleCallers` and `clientHandler` which enabled other extensions to use them. We didn't intend this behavior and don't want to expose any public API yet.

See:
> https://code.visualstudio.com/api/references/vscode-api#extensions
> Extension writers can provide APIs to other extensions by returning their API public surface from the `activate` call.

This PR removes the return value from `activate` and refactors the `workspaces.spec.ts` test, which used this API.