### PR TITLE
Use more strict TypeScript configuration

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -9,5 +9,8 @@
     "plugin:@typescript-eslint/recommended",
     "plugin:prettier/recommended",
     "prettier"
-  ]
+  ],
+  "rules": {
+    "@typescript-eslint/no-explicit-any": ["warn", { "ignoreRestArgs": true }]
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -214,6 +214,12 @@
       "integrity": "sha512-wZt3VTmzYrgZ0l/3QmEbCq4KAJ71K3/hmMQ/nfpv84oH8e81KKwPEoQ5v8dNCxfHFVJ1JabHKmCvqdYOoVm1Ow==",
       "dev": true
     },
+    "@types/which": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/which/-/which-2.0.1.tgz",
+      "integrity": "sha512-Jjakcv8Roqtio6w1gr0D7y6twbhx6gGgFGF5BLwajPpnOIOxFkakFhCq+LmyyeAz7BX6ULrjBOxdKaCDy+4+dQ==",
+      "dev": true
+    },
     "@types/yauzl": {
       "version": "2.9.2",
       "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.9.2.tgz",

--- a/package.json
+++ b/package.json
@@ -349,6 +349,7 @@
     "@types/node": "^12.12.54",
     "@types/openpgp": "^4.4.15",
     "@types/vscode": "^1.52.0",
+    "@types/which": "^2.0.1",
     "@types/yauzl": "^2.9.1",
     "@typescript-eslint/eslint-plugin": "^3.9.0",
     "@typescript-eslint/parser": "^3.9.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -298,7 +298,11 @@ async function terraformCommand(command: string, languageServerExec = true): Pro
         response.moduleCallers.map((m) => m.uri),
         { canPickMany: false },
       );
-      selectedModule = selected ?? moduleUri.toString();
+      if (!selected) {
+        return;
+      }
+
+      selectedModule = selected;
     } else if (response.moduleCallers.length == 1) {
       selectedModule = response.moduleCallers[0].uri;
     } else {

--- a/src/languageServerInstaller.ts
+++ b/src/languageServerInstaller.ts
@@ -1,3 +1,5 @@
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+// @ts-nocheck will be refactored by the silent installer
 import { getRelease, Release } from '@hashicorp/js-releases';
 import * as path from 'path';
 import * as semver from 'semver';

--- a/src/serverPath.ts
+++ b/src/serverPath.ts
@@ -6,7 +6,7 @@ const INSTALL_FOLDER_NAME = 'bin';
 export const CUSTOM_BIN_PATH_OPTION_NAME = 'languageServer.pathToBinary';
 
 export class ServerPath {
-  private customBinPath: string;
+  private customBinPath: string | undefined;
 
   constructor(private context: vscode.ExtensionContext) {
     this.customBinPath = vscode.workspace.getConfiguration('terraform').get(CUSTOM_BIN_PATH_OPTION_NAME);
@@ -28,7 +28,7 @@ export class ServerPath {
   }
 
   public binPath(): string {
-    if (this.hasCustomBinPath()) {
+    if (this.customBinPath) {
       return this.customBinPath;
     }
 
@@ -36,7 +36,7 @@ export class ServerPath {
   }
 
   public binName(): string {
-    if (this.hasCustomBinPath()) {
+    if (this.customBinPath) {
       return path.basename(this.customBinPath);
     }
 
@@ -59,10 +59,10 @@ export class ServerPath {
       console.log(`Found server at ${cmd}`);
     } catch (err) {
       let extraHint = '';
-      if (this.hasCustomBinPath()) {
+      if (this.customBinPath) {
         extraHint = `. Check "${CUSTOM_BIN_PATH_OPTION_NAME}" in your settings.`;
       }
-      throw new Error(`Unable to launch language server: ${err.message}${extraHint}`);
+      throw new Error(`Unable to launch language server: ${err instanceof Error ? err.message : err}${extraHint}`);
     }
 
     return cmd;

--- a/src/telemetry.ts
+++ b/src/telemetry.ts
@@ -1,6 +1,8 @@
 import TelemetryReporter from 'vscode-extension-telemetry';
 import { BaseLanguageClient, ClientCapabilities, StaticFeature } from 'vscode-languageclient';
 
+import { ExperimentalClientCapabilities } from './types';
+
 const TELEMETRY_VERSION = 1;
 
 type TelemetryEvent = {
@@ -21,7 +23,7 @@ export class TelemetryFeature implements StaticFeature {
     });
   }
 
-  public fillClientCapabilities(capabilities: ClientCapabilities): void {
+  public fillClientCapabilities(capabilities: ClientCapabilities & ExperimentalClientCapabilities): void {
     if (!capabilities['experimental']) {
       capabilities['experimental'] = {};
     }

--- a/src/test/integration/codeAction.test.ts
+++ b/src/test/integration/codeAction.test.ts
@@ -25,9 +25,9 @@ suite('code actions', () => {
 
     for (let index = 0; index < supported.length; index++) {
       const wanted = supported[index];
-      const requested = wanted.kind.value.toString();
+      const requested = wanted.kind?.value.toString();
 
-      const actions: vscode.CodeAction[] = await vscode.commands.executeCommand<vscode.CodeAction[]>(
+      const actions = await vscode.commands.executeCommand<vscode.CodeAction[]>(
         'vscode.executeCodeActionProvider',
         docUri,
         new vscode.Range(new vscode.Position(0, 0), new vscode.Position(0, 0)),
@@ -36,10 +36,11 @@ suite('code actions', () => {
 
       assert.ok(actions);
       expect(actions).not.to.be.undefined;
+      expect(wanted.kind?.value).not.to.be.undefined;
 
       assert.strictEqual(actions.length, 1);
       assert.strictEqual(actions[0].title, wanted.title);
-      assert.strictEqual(actions[0].kind.value, wanted.kind.value);
+      assert.strictEqual(actions[0].kind?.value, wanted.kind?.value);
     }
   });
 });

--- a/src/test/integration/completion.test.ts
+++ b/src/test/integration/completion.test.ts
@@ -32,7 +32,7 @@ suite('completion', () => {
     const docUri = getDocUri('actions.tf');
     await open(docUri);
 
-    const list: vscode.CompletionList = await vscode.commands.executeCommand<vscode.CompletionList>(
+    const list = await vscode.commands.executeCommand<vscode.CompletionList>(
       'vscode.executeCompletionItemProvider',
       docUri,
       new vscode.Position(0, 0),
@@ -44,7 +44,7 @@ suite('completion', () => {
     expect(list.items.length).to.be.greaterThanOrEqual(1);
 
     for (let index = 0; index < list.items.length; index++) {
-      const element = list.items[index];
+      const element: vscode.CompletionItem = list.items[index];
       assert.ok(element);
       expect(element).not.to.be.undefined;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+/**
+ * Defines our experimental capabilities provided by the client.
+ */
+export interface ExperimentalClientCapabilities {
+  experimental: {
+    telemetryVersion?: number;
+    showReferencesCommandId?: string;
+  };
+}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -19,14 +19,13 @@ export async function sleep(ms: number): Promise<void> {
 // timer can be running at a time. Attempts to add a new timeout silently fail.
 export class SingleInstanceTimeout {
   private timerLock = false;
-  private timerId: NodeJS.Timeout;
+  private timerId: NodeJS.Timeout | null = null;
 
-  // eslint-disable-next-line @typescript-eslint/explicit-module-boundary-types
-  public timeout(fn, delay, ...args) {
+  public timeout(fn: (...args: any[]) => void, delay: number, ...args: any[]): void {
     if (!this.timerLock) {
       this.timerLock = true;
       this.timerId = setTimeout(
-        function () {
+        () => {
           this.timerLock = false;
           fn();
         },

--- a/src/vscodeUtils.ts
+++ b/src/vscodeUtils.ts
@@ -16,7 +16,7 @@ export function normalizeFolderName(folderName: string): string {
   return folderName;
 }
 
-export function getWorkspaceFolder(folderName: string): vscode.WorkspaceFolder {
+export function getWorkspaceFolder(folderName: string): vscode.WorkspaceFolder | undefined {
   return vscode.workspace.getWorkspaceFolder(vscode.Uri.parse(folderName));
 }
 
@@ -24,14 +24,14 @@ export function getWorkspaceFolder(folderName: string): vscode.WorkspaceFolder {
 // We intentionally do *not* use vscode.window.activeTextEditor here
 // because it also contains Output panes which are considered editors
 // see also https://github.com/microsoft/vscode/issues/58869
-export function getActiveTextEditor(): vscode.TextEditor {
+export function getActiveTextEditor(): vscode.TextEditor | undefined {
   return vscode.window.visibleTextEditors.find((textEditor) => !!textEditor.viewColumn);
 }
 
 export function sortedWorkspaceFolders(): string[] {
   const workspaceFolders = vscode.workspace.workspaceFolders;
   if (workspaceFolders) {
-    return vscode.workspace.workspaceFolders
+    return workspaceFolders
       .map((f) => getFolderName(f))
       .sort((a, b) => {
         return a.length - b.length;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,7 +4,8 @@
     "target": "es6",
     "outDir": "out",
     "rootDir": "src",
-    "sourceMap": true
+    "sourceMap": true,
+    "strict": true
   },
   "include": ["src"],
   "exclude": ["node_modules", ".vscode-test"]


### PR DESCRIPTION
This PR enables strict mode for TypeScript, resulting in a wide range of type checking behavior that guarantees program correctness.

I tried to do one commit per file, sometimes explaining my choices.