### PR TITLE
Fix Detecting Terraform files in status calls

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,12 +126,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.window.onDidChangeVisibleTextEditors(async (editors: vscode.TextEditor[]) => {
       const textEditor = editors.find((ed) => !!ed.viewColumn);
-
-      if (!isTerraformFile(textEditor?.document)) {
+      if (textEditor?.document === undefined) {
         return;
       }
 
-      await updateTerraformStatusBar(textEditor?.document.uri);
+      if (!isTerraformFile(textEditor.document)) {
+        return;
+      }
+
+      await updateTerraformStatusBar(textEditor.document.uri);
     }),
   );
 
@@ -156,11 +159,7 @@ export async function deactivate(): Promise<void> {
   return clientHandler.stopClient();
 }
 
-export async function updateTerraformStatusBar(documentUri?: vscode.Uri): Promise<void> {
-  if (documentUri === undefined) {
-    return;
-  }
-
+export async function updateTerraformStatusBar(documentUri: vscode.Uri): Promise<void> {
   const client = clientHandler.getClient();
   if (client === undefined) {
     return;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,7 @@ import { ModuleCallsDataProvider } from './providers/moduleCalls';
 import { ModuleProvidersDataProvider } from './providers/moduleProviders';
 import { ServerPath } from './serverPath';
 import { SingleInstanceTimeout } from './utils';
-import { config, getActiveTextEditor } from './vscodeUtils';
+import { config, getActiveTextEditor, isTerraformFile } from './vscodeUtils';
 
 const brand = `HashiCorp Terraform`;
 const outputChannel = vscode.window.createOutputChannel(brand);
@@ -129,6 +129,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (textEditor?.document === undefined) {
         return;
       }
+
+      if (!isTerraformFile(textEditor?.document)) {
+        return;
+      }
+
       await updateTerraformStatusBar(textEditor.document.uri);
     }),
   );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -126,15 +126,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
     vscode.window.onDidChangeVisibleTextEditors(async (editors: vscode.TextEditor[]) => {
       const textEditor = editors.find((ed) => !!ed.viewColumn);
-      if (textEditor?.document === undefined) {
-        return;
-      }
 
       if (!isTerraformFile(textEditor?.document)) {
         return;
       }
 
-      await updateTerraformStatusBar(textEditor.document.uri);
+      await updateTerraformStatusBar(textEditor?.document.uri);
     }),
   );
 
@@ -159,7 +156,11 @@ export async function deactivate(): Promise<void> {
   return clientHandler.stopClient();
 }
 
-export async function updateTerraformStatusBar(documentUri: vscode.Uri): Promise<void> {
+export async function updateTerraformStatusBar(documentUri?: vscode.Uri): Promise<void> {
+  if (documentUri === undefined) {
+    return;
+  }
+
   const client = clientHandler.getClient();
   if (client === undefined) {
     return;

--- a/src/providers/moduleCalls.ts
+++ b/src/providers/moduleCalls.ts
@@ -85,12 +85,7 @@ export class ModuleCallsDataProvider implements vscode.TreeDataProvider<ModuleCa
       vscode.window.onDidChangeActiveTextEditor(async (event: vscode.TextEditor | undefined) => {
         const activeEditor = getActiveTextEditor();
 
-        const document = activeEditor?.document;
-        if (document === undefined) {
-          return;
-        }
-
-        if (!isTerraformFile(document)) {
+        if (!isTerraformFile(activeEditor?.document)) {
           return;
         }
 

--- a/src/providers/moduleCalls.ts
+++ b/src/providers/moduleCalls.ts
@@ -116,16 +116,15 @@ export class ModuleCallsDataProvider implements vscode.TreeDataProvider<ModuleCa
   async getModules(): Promise<ModuleCallItem[]> {
     const activeEditor = getActiveTextEditor();
 
-    const document = activeEditor?.document;
-    if (document === undefined) {
+    if (activeEditor?.document === undefined) {
       return [];
     }
 
-    if (!isTerraformFile(document)) {
+    if (!isTerraformFile(activeEditor.document)) {
       return [];
     }
 
-    const editor = document.uri;
+    const editor = activeEditor.document.uri;
     const documentURI = Utils.dirname(editor);
     const handler = this.handler.getClient();
     if (handler === undefined) {

--- a/src/providers/moduleProviders.ts
+++ b/src/providers/moduleProviders.ts
@@ -48,12 +48,7 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
       vscode.window.onDidChangeActiveTextEditor(async (event: vscode.TextEditor | undefined) => {
         const activeEditor = getActiveTextEditor();
 
-        const document = activeEditor?.document;
-        if (document === undefined) {
-          return;
-        }
-
-        if (!isTerraformFile(document)) {
+        if (!isTerraformFile(activeEditor?.document)) {
           return;
         }
 
@@ -88,16 +83,15 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
   async getProvider(): Promise<ModuleProviderItem[]> {
     const activeEditor = getActiveTextEditor();
 
-    const document = activeEditor?.document;
-    if (document === undefined) {
+    if (activeEditor?.document === undefined) {
       return [];
     }
 
-    if (!isTerraformFile(document)) {
+    if (!isTerraformFile(activeEditor.document)) {
       return [];
     }
 
-    const editor = document.uri;
+    const editor = activeEditor.document.uri;
     const documentURI = Utils.dirname(editor);
     const handler = this.handler.getClient();
     if (handler === undefined) {

--- a/src/providers/moduleProviders.ts
+++ b/src/providers/moduleProviders.ts
@@ -3,7 +3,7 @@ import { Utils } from 'vscode-uri';
 import { ExecuteCommandParams, ExecuteCommandRequest } from 'vscode-languageclient';
 
 import { ClientHandler } from '../clientHandler';
-import { getActiveTextEditor } from '../vscodeUtils';
+import { getActiveTextEditor, isTerraformFile } from '../vscodeUtils';
 
 interface ModuleProvidersResponse {
   v: number;
@@ -46,7 +46,18 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
   constructor(ctx: vscode.ExtensionContext, private handler: ClientHandler) {
     ctx.subscriptions.push(
       vscode.window.onDidChangeActiveTextEditor(async (event: vscode.TextEditor | undefined) => {
-        if (event && getActiveTextEditor()) {
+        const activeEditor = getActiveTextEditor();
+
+        const document = activeEditor?.document;
+        if (document === undefined) {
+          return;
+        }
+
+        if (!isTerraformFile(document)) {
+          return;
+        }
+
+        if (event && activeEditor) {
           this.refresh();
         }
       }),
@@ -79,6 +90,10 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
 
     const document = activeEditor?.document;
     if (document === undefined) {
+      return [];
+    }
+
+    if (!isTerraformFile(document)) {
       return [];
     }
 

--- a/src/vscodeUtils.ts
+++ b/src/vscodeUtils.ts
@@ -25,7 +25,32 @@ export function getWorkspaceFolder(folderName: string): vscode.WorkspaceFolder |
 // because it also contains Output panes which are considered editors
 // see also https://github.com/microsoft/vscode/issues/58869
 export function getActiveTextEditor(): vscode.TextEditor | undefined {
-  return vscode.window.visibleTextEditors.find((textEditor) => !!textEditor.viewColumn);
+  const activeEditor = vscode.window.visibleTextEditors.find((textEditor) => !!textEditor.viewColumn);
+  return activeEditor;
+}
+
+/*
+  Detects whether this is a Terraform file we can perform operations on
+ */
+export function isTerraformFile(document: vscode.TextDocument): boolean {
+  if (document === undefined) {
+    return false;
+  }
+
+  if (document.isUntitled) {
+    // Untitled files are files which haven't been saved yet, so we don't know if they
+    // are terraform so we return false
+    return false;
+  }
+
+  if (document.fileName.endsWith('tf')) {
+    // For the purposes of this extension, anything with the tf file
+    // extension is a Terraform file
+    return true;
+  }
+
+  // be safe and default to false
+  return false;
 }
 
 export function sortedWorkspaceFolders(): string[] {

--- a/src/vscodeUtils.ts
+++ b/src/vscodeUtils.ts
@@ -25,14 +25,13 @@ export function getWorkspaceFolder(folderName: string): vscode.WorkspaceFolder |
 // because it also contains Output panes which are considered editors
 // see also https://github.com/microsoft/vscode/issues/58869
 export function getActiveTextEditor(): vscode.TextEditor | undefined {
-  const activeEditor = vscode.window.visibleTextEditors.find((textEditor) => !!textEditor.viewColumn);
-  return activeEditor;
+  return vscode.window.visibleTextEditors.find((textEditor) => !!textEditor.viewColumn);
 }
 
 /*
   Detects whether this is a Terraform file we can perform operations on
  */
-export function isTerraformFile(document: vscode.TextDocument): boolean {
+export function isTerraformFile(document?: vscode.TextDocument): boolean {
   if (document === undefined) {
     return false;
   }


### PR DESCRIPTION
This modifies the moduleCalls and moduleProviders views and the updateTerraformStatusBar function to detect if the open file is an `Untitled` file or other type of file and return early instead of trying to determine Terraform module information.

Previously the editor would attempt to determine terraform module status whenever a file was opened. This worked well if a Terraform file was opened, but would throw exceptions if a file was opened that did not contain Terraform code. This includes `Untitled` files which are open files that are not saved yet and don't exist on the filesystem yet. The fix is to ignore any non Terraform file.

This contains a naive check to determine if a file is a Terraform file, which checks the file extension for `tf`. This suits for now but possibly might need to be expanded in the future if the extension supports more Terraform file types.
