### PR TITLE
Enable eslint for tests

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,4 +1,3 @@
 node_modules
 out
-src/test
 testFixture

--- a/jest.config.js
+++ b/jest.config.js
@@ -8,5 +8,4 @@ module.exports = {
   clearMocks: true,
   verbose: true,
   silent: true,
-  // automock: true,
 };

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -1,6 +1,5 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import { sleep } from '../utils';
 
 export let doc: vscode.TextDocument;
 export let editor: vscode.TextEditor;
@@ -18,7 +17,8 @@ export async function open(docUri: vscode.Uri): Promise<void> {
 }
 
 export function getExtensionId(): string {
-  var pjson = require('../../package.json');
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const pjson = require('../../package.json');
   return `${pjson.publisher}.${pjson.name}`;
 }
 

--- a/src/test/unit/detector.test.ts
+++ b/src/test/unit/detector.test.ts
@@ -1,6 +1,6 @@
 import { mocked } from 'ts-jest/utils';
 import { exec as execOrg } from '../../utils';
-import { getRelease as getReleaseOrg, Release } from '@hashicorp/js-releases';
+import { getRelease as getReleaseOrg } from '@hashicorp/js-releases';
 import { getLsVersion, isValidVersionString, getRequiredVersionRelease } from '../../installer/detector';
 
 jest.mock('../../utils');

--- a/src/test/unit/updater.test.ts
+++ b/src/test/unit/updater.test.ts
@@ -20,6 +20,7 @@ const pathExists = mocked(pathExistsOrig);
 const isValidVersionString = mocked(isValidVersionStringOrig);
 const getRequiredVersionRelease = mocked(getRequiredVersionReleaseOrig);
 const getLsVersion = mocked(getLsVersionOrig);
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 const lsPath: ServerPath & typeof lsPathMock = lsPathMock;
 


### PR DESCRIPTION
This PR updates the `.eslintignore` to not exclude the `test/` directory. The change enables eslint to check the tests, too.