### PR TITLE
Fix creating process with environment variables

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,6 +71,7 @@ jobs:
 
   test:
     strategy:
+      fail-fast: false
       matrix:
         os:
           - windows-latest

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -128,8 +128,8 @@ export class ClientHandler {
   }
 
   private getProcessEnvironment() {
-    // deep object clone without the bother of custom traversal
-    const procEnv = JSON.parse(JSON.stringify(process.env));
+    // shallow copy environment variables
+    const procEnv = { ...process.env };
 
     // It's unlilely but possible that there is no PATH set. Object property
     // names can be case sensitive depending on the OS, so we cannot rely on
@@ -148,7 +148,7 @@ export class ClientHandler {
       procEnv.PATH = envPath;
     }
 
-    // Child spawn environment variables can have undefined or null value
+    // Environment variables can have undefined or null values
     // In our case we can remove these elements from the Object directly and not
     // worry about them
     try {


### PR DESCRIPTION
This ensures the child process we create for the Language Server contains the process environment variables needed to find other binaries on the host.

When creating the process for the Language Server, we relied on process.spawn to copy the environment variables to the child process. This works in most cases, but fails to contain the host environment variables in certain scenarios. For example, opening VS Code from the macOS Launcher. This leaves our process with important environment variables like PATH, and results in failures down the line attempting to use other binaries like terraform.

These errors are mostly silent, leaving the user confused why something isn't working. It's also hard to debug, because the correct variables (especially PATH) are present and work outside our app.
