### PR TITLE
Test VS Code Version Matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -74,7 +74,7 @@ jobs:
       fail-fast: false
       matrix:
         vscode:
-          - '1.55.0'
+          - '1.58.2'
           - 'insiders'
           - 'stable'
         os:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,7 +71,12 @@ jobs:
 
   test:
     strategy:
+      fail-fast: false
       matrix:
+        vscode:
+          - '1.55.0'
+          - 'insiders'
+          - 'stable'
         os:
           - windows-latest
           - macos-latest
@@ -119,3 +124,4 @@ jobs:
         env:
           CI: true
           DISPLAY: ':99.0'
+          VSCODE_VERSION: ${{ matrix.vscode }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1105,6 +1105,18 @@
       "integrity": "sha512-sL/cEvJWAnClXw0wHk85/2L0G6Sj8UB0Ctc1TEMbKSsmpRosqhwj9gWgFRZSrBr2f9tiXISwNhCPmlfqUqyb9Q==",
       "dev": true
     },
+    "@vscode/test-electron": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@vscode/test-electron/-/test-electron-2.0.1.tgz",
+      "integrity": "sha512-4I+vejOy02G1aFDqxi2Bof1ODorWuXtZAHwXzYeHbTi3zEd1DCtdiClvaoD7H2gjLb/yFxyisr1jLN0ae8nnLQ==",
+      "dev": true,
+      "requires": {
+        "http-proxy-agent": "^4.0.1",
+        "https-proxy-agent": "^5.0.0",
+        "rimraf": "^3.0.2",
+        "unzipper": "^0.10.11"
+      }
+    },
     "abab": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/abab/-/abab-2.0.5.tgz",
@@ -5388,18 +5400,6 @@
       "version": "3.16.0",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
       "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
-    },
-    "vscode-test": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/vscode-test/-/vscode-test-1.6.1.tgz",
-      "integrity": "sha512-086q88T2ca1k95mUzffvbzb7esqQNvJgiwY4h29ukPhFo8u+vXOOmelUoU5EQUHs3Of8+JuQ3oGdbVCqaxuTXA==",
-      "dev": true,
-      "requires": {
-        "http-proxy-agent": "^4.0.1",
-        "https-proxy-agent": "^5.0.0",
-        "rimraf": "^3.0.2",
-        "unzipper": "^0.10.11"
-      }
     },
     "vscode-uri": {
       "version": "3.0.2",

--- a/package.json
+++ b/package.json
@@ -367,6 +367,6 @@
     "ts-jest": "^27.1.0",
     "typescript": "^3.9.7",
     "vsce": "^1.93.0",
-    "vscode-test": "^1.5.2"
+    "@vscode/test-electron": "^2.0.1"
   }
 }

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -1,6 +1,6 @@
 import * as path from 'path';
-import { runTests } from 'vscode-test';
-import { TestOptions } from 'vscode-test/out/runTest';
+import { runTests } from '@vscode/test-electron';
+import { TestOptions } from '@vscode/test-electron/out/runTest';
 import { exec } from '../utils';
 
 async function terraformInit() {

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -32,6 +32,7 @@ async function main(): Promise<void> {
 
   // common options for all runners
   const options: TestOptions = {
+    version: process.env['VSCODE_VERSION'] ?? 'stable',
     extensionDevelopmentPath,
     extensionTestsPath,
     launchArgs: ['testFixture', '--disable-extensions', '--disable-workspace-trust'],
@@ -41,24 +42,7 @@ async function main(): Promise<void> {
     // Download VS Code, unzip it and run the integration test
     // start in the fixtures folder to prevent the language server from walking all the
     // project root folders, like node_modules
-    const vscodeVersion = process.env['VSCODE_VERSION'];
-    switch (vscodeVersion) {
-      case undefined:
-        console.log('_______________LATEST_____________________');
-        break;
-      case 'stable':
-        console.log('_______________LATEST_____________________');
-        break;
-      case 'insiders':
-        console.log('_______________INSIDERS_____________________');
-        options.version = vscodeVersion;
-        break;
-      default:
-        console.log(`_______________${vscodeVersion}_____________________`);
-        options.version = vscodeVersion;
-        break;
-    }
-
+    console.log(`_______________${options.version}_____________________`);
     await runTests(options);
   } catch (err) {
     console.error(err);

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -41,15 +41,24 @@ async function main(): Promise<void> {
     // Download VS Code, unzip it and run the integration test
     // start in the fixtures folder to prevent the language server from walking all the
     // project root folders, like node_modules
-    console.log('_______________LATEST_____________________');
-    await runTests(options);
+    const vscodeVersion = process.env['VSCODE_VERSION'];
+    switch (vscodeVersion) {
+      case undefined:
+        console.log('_______________LATEST_____________________');
+        break;
+      case 'stable':
+        console.log('_______________LATEST_____________________');
+        break;
+      case 'insiders':
+        console.log('_______________INSIDERS_____________________');
+        options.version = vscodeVersion;
+        break;
+      default:
+        console.log(`_______________${vscodeVersion}_____________________`);
+        options.version = vscodeVersion;
+        break;
+    }
 
-    console.log('_______________INSIDERS___________________');
-    options.version = 'insiders';
-    await runTests(options);
-
-    console.log('________________1.55.0____________________');
-    options.version = '1.55.0';
     await runTests(options);
   } catch (err) {
     console.error(err);


### PR DESCRIPTION
Change default `npm test` behavior to use the version of VS Code specified in the `VSCODE_VER` environment variable, instead of testing hardcoded versions inside `runtest.ts`.

`VSCODE_VER` supports latest, insiders and version numbers lik 1.55.0.

If the `VSCODE_VER` environment variable is not specified, then the latest stable version of VS Code is automatically used.
