### PR TITLE
use jest.mocked instead of ts-jest mocked

### DIFF
--- a/src/test/unit/detector.test.ts
+++ b/src/test/unit/detector.test.ts
@@ -1,4 +1,3 @@
-import { mocked } from 'ts-jest/utils';
 import { exec as execOrg } from '../../utils';
 import { getRelease as getReleaseOrg } from '@hashicorp/js-releases';
 import { getLsVersion, isValidVersionString, getRequiredVersionRelease } from '../../installer/detector';
@@ -6,8 +5,8 @@ import { getLsVersion, isValidVersionString, getRequiredVersionRelease } from '.
 jest.mock('../../utils');
 jest.mock('@hashicorp/js-releases');
 
-const exec = mocked(execOrg);
-const getRelease = mocked(getReleaseOrg);
+const exec = jest.mocked(execOrg);
+const getRelease = jest.mocked(getReleaseOrg);
 
 describe('terraform release detector', () => {
   test('returns valid release', async () => {

--- a/src/test/unit/installer.test.ts
+++ b/src/test/unit/installer.test.ts
@@ -1,4 +1,3 @@
-import { mocked } from 'ts-jest/utils';
 import { pathExists as pathExistsOrig } from '../../installer/detector';
 import { installTerraformLS } from '../../installer/installer';
 import { reporter } from './mocks/reporter';
@@ -6,8 +5,8 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { Release } from '@hashicorp/js-releases';
 
-const pathExists = mocked(pathExistsOrig);
-const withProgress = mocked(vscode.window.withProgress);
+const pathExists = jest.mocked(pathExistsOrig);
+const withProgress = jest.mocked(vscode.window.withProgress);
 
 jest.mock('../../installer/detector');
 describe('terraform-ls installer', () => {

--- a/src/test/unit/updater.test.ts
+++ b/src/test/unit/updater.test.ts
@@ -1,5 +1,4 @@
 import * as vscode from 'vscode';
-import { mocked } from 'ts-jest/utils';
 import { updateOrInstall } from '../../installer/updater';
 import { reporter } from './mocks/reporter';
 import { installTerraformLS } from '../../installer/installer';
@@ -15,11 +14,11 @@ import { lsPathMock } from './mocks/serverPath';
 jest.mock('../../installer/detector');
 jest.mock('../../installer/installer');
 
-const getConfiguration = mocked(vscode.workspace.getConfiguration);
-const pathExists = mocked(pathExistsOrig);
-const isValidVersionString = mocked(isValidVersionStringOrig);
-const getRequiredVersionRelease = mocked(getRequiredVersionReleaseOrig);
-const getLsVersion = mocked(getLsVersionOrig);
+const getConfiguration = jest.mocked(vscode.workspace.getConfiguration);
+const pathExists = jest.mocked(pathExistsOrig);
+const isValidVersionString = jest.mocked(isValidVersionStringOrig);
+const getRequiredVersionRelease = jest.mocked(getRequiredVersionReleaseOrig);
+const getLsVersion = jest.mocked(getLsVersionOrig);
 // eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
 const lsPath: ServerPath & typeof lsPathMock = lsPathMock;


### PR DESCRIPTION
The `mocked` helper function is deprecated and will be removed in `ts-jest` 28.0.0. It has been integrated into jest-mock package as a part of Jest 27.4.0.

Closes #885 