### PR TITLE
Exclude terraform cache from file watcher

### DIFF
--- a/package.json
+++ b/package.json
@@ -85,6 +85,11 @@
         "path": "./snippets/terraform.json"
       }
     ],
+    "configurationDefaults": {
+      "files.watcherExclude": {
+        "**/.terraform/*/**": true
+      }
+    },
     "configuration": {
       "type": "object",
       "title": "Terraform",


### PR DESCRIPTION
This adds the `.terraform` cache directory to the file watcher exclude list by default. A user can override this by configuring `files.watcherExclude` in their user or workspace settings file.

Closes #405
