### PR TITLE
Make reference count code lens opt-in

### DIFF
--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
         "terraform.codelens.referenceCount": {
           "scope": "resource",
           "type": "boolean",
-          "default": true,
+          "default": false,
           "description": "Display reference counts above top level blocks and attributes."
         },
         "terraform-ls.rootModules": {


### PR DESCRIPTION
After recent changes there's an increased overhead of pre-calculating the number of references for the code lens.

We can therefore make this code lens opt-in to avoid the extra lookups which are likely causing the excessive CPU consumption as code lens get refresh upon editor focus and generally very often.

This should help address https://github.com/hashicorp/terraform-ls/issues/733