### PR TITLE
Ignore jest config when packaging

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -20,4 +20,5 @@ testFixture/
 .vscodeignore
 DEVELOPMENT.md
 ROADMAP.md
+jest.config.js
 tsconfig.json


### PR DESCRIPTION
This ignores the jest config file when packaging the extension.
