### PR TITLE
Update actions/setup-node to v2

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,21 +12,13 @@ jobs:
       - name: checkout repo
         uses: actions/checkout@v2
 
-      - name: Read NodeJS version
-        id: nodejs-version
-        run: |
-          content=`cat ./.nvmrc`
-          echo "::set-output name=content::$content"
-
-      - name: setup node
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          # See https://github.com/actions/setup-node/issues/32
-          node-version: ${{ steps.nodejs-version.outputs.content }}
+          node-version-file: '.nvmrc'
 
       - name: clean install dependencies
-        run: npm ci    
-      
+        run: npm ci
+
       - name: compile and create vsix
         run: npm run package -- -o extension.vsix
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -24,18 +24,9 @@ jobs:
           content=`cat ./package.json | jq -r .version`
           echo "::set-output name=content::$content"
 
-      - name: Read Node.js version
-        id: nodejs-version
-        run: |
-          content=`cat ./.nvmrc`
-          echo "::set-output name=content::$content"
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v2
+      - uses: actions/setup-node@v2
         with:
-          # See https://github.com/actions/setup-node/issues/32
-          node-version: ${{ steps.nodejs-version.outputs.content }}
-          cache: 'npm'
+          node-version-file: '.nvmrc'
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -24,16 +24,9 @@ jobs:
           echo "Received ref: ${{ github.ref }}"
           echo "Expected ref: refs/tags/v${{ steps.ext-version.outputs.content }}"
           exit 1
-      - name: Read Node.js version
-        id: nodejs-version
-        run: |
-          content=`cat ./.nvmrc`
-          echo "::set-output name=content::$content"
-      - name: Set up Node.js
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          # See https://github.com/actions/setup-node/issues/32
-          node-version: ${{ steps.nodejs-version.outputs.content }}
+          node-version-file: '.nvmrc'
       - name: Install dependencies
         run: npm ci
       - name: vsce package

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,17 +15,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      -
-        name: Read Node.js version (Unix)
-        id: nodejs-version
-        run: |
-          content=`cat ./.nvmrc`
-          echo "::set-output name=content::$content"
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          # See https://github.com/actions/setup-node/issues/32
-          node-version: ${{ steps.nodejs-version.outputs.content }}
+          node-version-file: '.nvmrc'
       - name: npm install
         run: npm install
       - name: lint
@@ -45,25 +37,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      -
-        name: Read Node.js version (Unix)
-        if: ${{ runner.os != 'Windows' }}
-        id: nodejs-version-unix
-        run: |
-          content=`cat ./.nvmrc`
-          echo "::set-output name=content::$content"
-      -
-        name: Read Node.js version (Windows)
-        if: ${{ runner.os == 'Windows' }}
-        id: nodejs-version-win
-        run: |
-          $content = Get-Content .\.nvmrc -Raw
-          echo "::set-output name=content::$content"
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          # See https://github.com/actions/setup-node/issues/32
-          node-version: ${{ steps.nodejs-version-unix.outputs.content || steps.nodejs-version-win.outputs.content }}
+          node-version-file: '.nvmrc'
       - name: npm install
         run: npm ci
       - name: unit test
@@ -83,25 +59,9 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v2
-      -
-        name: Read Node.js version (Unix)
-        if: ${{ runner.os != 'Windows' }}
-        id: nodejs-version-unix
-        run: |
-          content=`cat ./.nvmrc`
-          echo "::set-output name=content::$content"
-      -
-        name: Read Node.js version (Windows)
-        if: ${{ runner.os == 'Windows' }}
-        id: nodejs-version-win
-        run: |
-          $content = Get-Content .\.nvmrc -Raw
-          echo "::set-output name=content::$content"
-      - name: Setup Node.js
-        uses: actions/setup-node@v1
+      - uses: actions/setup-node@v2
         with:
-          # See https://github.com/actions/setup-node/issues/32
-          node-version: ${{ steps.nodejs-version-unix.outputs.content || steps.nodejs-version-win.outputs.content }}
+          node-version-file: '.nvmrc'
       - name: Set up Xvfb (Ubuntu)
         run: |
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
@@ -111,7 +71,7 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           terraform_wrapper: false
-          terraform_version: "~1.0"
+          terraform_version: '~1.0'
       - name: Clean Install Dependencies
         run: npm ci
       - name: Run Tests


### PR DESCRIPTION
I’ve seen multiple canceled test runs on macos-latest in the setup-node step over the last couple of days. Upgrading to `actions/setup-node@v2` should make things more reliable.

Additionally, https://github.com/actions/setup-node/pull/338 added support for fetching the node version from a `.npmrc` file, so I was able to simplify most workflows.