### PR TITLE
Deprecate terraform.languageServer.requiredVersion

### DIFF
--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
             "requiredVersion": {
               "type": "string",
               "description": "The required version of the Language Server described as a semantic version string, for example '^2.0.1' or '> 1.0'. Defaults to latest available version.",
-              "deprecationMessage": "Deprecated: A platform specific Language Server binary will be bundled with the extension in a future release. Users who wish to use a different version than the one shipped with the extension will use terraform.languageServer.pathToBinary"
+              "deprecationMessage": "Deprecated: A platform specific Language Server binary will be bundled with the extension in a future release. If you wish to use a different version than the one shipped with the extension, use terraform.languageServer.pathToBinary"
             }
           },
           "default": {

--- a/package.json
+++ b/package.json
@@ -131,7 +131,8 @@
             },
             "requiredVersion": {
               "type": "string",
-              "description": "The required version of the Language Server described as a semantic version string, for example '^2.0.1' or '> 1.0'. Defaults to latest available version."
+              "description": "The required version of the Language Server described as a semantic version string, for example '^2.0.1' or '> 1.0'. Defaults to latest available version.",
+              "deprecationMessage": "Deprecated: A platform specific Language Server binary will be bundled with the extension in a future release. Users who wish to use a different version than the one shipped with the extension will use terraform.languageServer.pathToBinary"
             }
           },
           "default": {


### PR DESCRIPTION
This adds a deprecation message to the `terraform.languageServer.requiredVersion` setting.

This setting will be removed in a future release when this extension adopts platform specific extension publishing.

In a future release, the extension will bundle the terraform-ls binary inside the published VSIX. This eliminates the need to download the binary at runtime, but also means the user cannot change the terraform-ls version used. Since they cannot change the version, this setting will no longer be needed.

Users who wish to use a different version than the one shipped with the extension will use `terraform.languageServer.pathToBinary` instead and install the terraform-ls binary using one of the release artifacts or through a package manager.

More detailed documentation on this process will be added when platform specific extension support is added.
