### PR TITLE
Fix preview publish trigger

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -74,7 +74,7 @@ jobs:
     name: Publish All
     runs-on: ubuntu-latest
     needs: build
-    if: success() && startsWith( github.ref, 'refs/tags/v')
+    if: success()
     steps:
       - uses: actions/download-artifact@v2
       - name: Publish Preview Extension


### PR DESCRIPTION
Preview builds do not use git tags, so remove the GitHub Action filter checking for them.
