### PR TITLE
Manual Preview release workflow dispatch

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -4,6 +4,7 @@ on:
   schedule:
     # run every day at 00:15 UTC to avoid high load times at the start of every hour
     - cron: "15 0 * * *"
+  workflow_dispatch:
 
 jobs:
   build:


### PR DESCRIPTION
This adds a workflow_dispatch event to the preview workflow so that we can publish the extension manually.
