### PR TITLE
Terraform TextMate Test Infrastructure

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -23,6 +23,20 @@ jobs:
       - name: lint
         run: npm run lint
 
+  syntax:
+    runs-on: ubuntu-latest
+    timeout-minutes: 3
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
+      - name: npm install
+        run: npm ci
+      - name: syntax
+        run: npm run test:syntax
+
   unit:
     strategy:
       fail-fast: false

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,3 +1,8 @@
 {
-  "recommendations": ["dbaeumer.vscode-eslint", "esbenp.prettier-vscode", "connor4312.esbuild-problem-matchers"]
+  "recommendations": [
+    "dbaeumer.vscode-eslint",
+    "esbenp.prettier-vscode",
+    "connor4312.esbuild-problem-matchers",
+    "redhat.vscode-yaml"
+  ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,5 +40,15 @@
       "source.organizeImports": false
     },
     "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+
+  "json.schemas": [
+    {
+      "fileMatch": ["*.tmGrammar.json"],
+      "url": "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json"
+    }
+  ],
+  "yaml.schemas": {
+    "https://raw.githubusercontent.com/martinring/tmlanguage/master/tmlanguage.json": "*.tmGrammar.yml"
   }
 }

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -106,7 +106,7 @@ The following workflow is recommended to work on Terraform TextMate grammar:
 
 ## Writing Grammar Unit Tests
 
-Unit tests are Terraform files with `vscode-tmgrammar-test` token lines specifying which TextMate grammer should be resolved.
+Unit tests are Terraform files with `vscode-tmgrammar-test` token lines specifying which TextMate grammar should be resolved.
 
 For example:
 
@@ -128,7 +128,7 @@ Snapshot tests comprise of two files: example files and their companion `snap` f
 
 Snapshot test example files are Terraform files without any `vscode-tmgrammar-test` token lines. Each example file is exactly how you would see it used in production. This ensures scope, inheritance, and resolution of tokens happen exactly as they would on a user's machine.
 
-The companion `snap` file is named the same as the example file with the `.snap` extension, and is the tmGrammar represenation of all resolved tokens. This file is commited alongside the example file. If anything changes with regards to how the tokens are resolved, the snapshot test will fail.
+The companion `snap` file is named the same as the example file with the `.snap` extension, and is the tmGrammar representation of all resolved tokens. This file is committed alongside the example file. If anything changes with regards to how the tokens are resolved, the snapshot test will fail.
 
 > Note: If modifying an existing snapshot test, run `npm run test:snap -- -u` to update the snapshot file. This will update the snapshot file with the new modified grammar. Be sure to do this after you've tested using `npm run test:grammar` and are sure that the modified grammar is correct, otherwise you may get false positives.
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -82,6 +82,56 @@ The `terraform init` command runs automatically when tests are executed.
 
 Sample files for tests should be added to the [`./testFixture`](testFixture/) folder, this is the folder vscode will open during tests. Starting from this folder will prevent the language server from walking other folders that typically exist such as `node_modules`.
 
+## Syntax Grammar Tests
+
+Automated TextMate grammar tests can be written using [vscode-tmgrammar-test](https://github.com/PanAeon/vscode-tmgrammar-test) and live inside `./tests`.
+
+To start the test suite from the command-line run:
+
+```bash
+npm test:syntax
+```
+
+## Writing TextMate Grammar
+
+The following workflow is recommended to work on Terraform TextMate grammar:
+
+1. Add or modify grammar in the `terraform.tmGrammar.json` file inside the `syntaxes` directory.
+1. Add a new unit test file or modify existing unit test files inside the test/unit/terraform directory.
+1. Run `npm run test:grammar` until the tests pass
+1. Add a new example Terraform file or modify existing unit test files inside the test/snapshot/terraform directory.
+1. Run `npm run test:snap` until the tests pass. 
+
+> Tip: Running `npm run test:snap -- -u` after modifying the tmGrammar file will give you a quick visual representation of how the tokens are being resolved. This can aid in crafting unit tests.
+
+## Writing Grammar Unit Tests
+
+Unit tests are Terraform files with `vscode-tmgrammar-test` token lines specifying which TextMate grammer should be resolved.
+
+For example:
+
+> Note: This is shortened to demonstrate, actual syntax will vary
+
+```
+resource "example" "thing" {
+;         ^^^^^^^ source.terraform string.quoted.double.terraform
+;                   ^^^^^ source.terraform string.quoted.double.terraform
+;                          ^ source.terraform punctuation.section.block.begin.terraform
+}
+; <- source.terraform punctuation.section.block.end.terraform
+
+```
+
+## Writing Grammar Snapshot Tests
+
+Snapshot tests comprise of two files: example files and their companion `snap` file.
+
+Snapshot test example files are Terraform files without any `vscode-tmgrammar-test` token lines. Each example file is exactly how you would see it used in production. This ensures scope, inheritance, and resolution of tokens happen exactly as they would on a user's machine.
+
+The companion `snap` file is named the same as the example file with the `.snap` extension, and is the tmGrammar represenation of all resolved tokens. This file is commited alongside the example file. If anything changes with regards to how the tokens are resolved, the snapshot test will fail.
+
+> Note: If modifying an existing snapshot test, run `npm run test:snap -- -u` to update the snapshot file. This will update the snapshot file with the new modified grammar. Be sure to do this after you've tested using `npm run test:grammar` and are sure that the modified grammar is correct, otherwise you may get false positives.
+
 ## Packaging
 
 To package the extension into a [`platform specific extension`](https://code.visualstudio.com/api/working-with-extensions/publishing-extension#platformspecific-extensions) VSIX ready for testing run the following command:

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,6 +3,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/src/test/unit/?(*.)+(spec|test).[jt]s?(x)'],
+  testPathIgnorePatterns: ['<rootDir>/tests/'],
   modulePathIgnorePatterns: ['<rootDir>/out/', '<rootDir>/.vscode-test/'],
   resetMocks: true,
   clearMocks: true,

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,7 +3,7 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'node',
   testMatch: ['**/src/test/unit/?(*.)+(spec|test).[jt]s?(x)'],
-  testPathIgnorePatterns: ['<rootDir>/tests/'],
+  testPathIgnorePatterns: ['<rootDir>/tests/', '/node_modules/'],
   modulePathIgnorePatterns: ['<rootDir>/out/', '<rootDir>/.vscode-test/'],
   resetMocks: true,
   clearMocks: true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -39,7 +39,8 @@
         "ts-jest": "^27.1.0",
         "ts-node": "^10.4.0",
         "typescript": "^4.5.4",
-        "vsce": "^2.6.3"
+        "vsce": "^2.6.3",
+        "vscode-tmgrammar-test": "^0.0.11"
       },
       "engines": {
         "node": "~16.X",
@@ -7251,6 +7252,122 @@
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
       "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
     },
+    "node_modules/vscode-oniguruma": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
+      "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
+      "dev": true
+    },
+    "node_modules/vscode-textmate": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.5.0.tgz",
+      "integrity": "sha512-jToQkPGMNKn0eyKyitYeINJF0NoD240aYyKPIWJv5W2jfPt++jIRg0OSergubtGhbw6SoefkvBYEpX7TsfoSUQ==",
+      "dev": true
+    },
+    "node_modules/vscode-tmgrammar-test": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.0.11.tgz",
+      "integrity": "sha512-Bd60x/OeBLAQnIxiR2GhUic1CQZOFfWM8Pd43HjdEUBf/0vcvYAlFQikOXvv+zkItHLznjKaDX7VWKPVYUF9ug==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "commander": "^2.20.3",
+        "diff": "^4.0.2",
+        "glob": "^7.1.6",
+        "vscode-oniguruma": "^1.5.1",
+        "vscode-textmate": "^5.4.0"
+      },
+      "bin": {
+        "vscode-tmgrammar-snap": "dist/src/snapshot.js",
+        "vscode-tmgrammar-test": "dist/src/unit.js"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/commander": {
+      "version": "2.20.3",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+      "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+      "dev": true
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/diff": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.3.1"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true,
+      "engines": {
+        "node": ">=0.8.0"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/vscode-tmgrammar-test/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/vscode-uri": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.0.3.tgz",
@@ -13032,6 +13149,102 @@
       "version": "3.16.0",
       "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.16.0.tgz",
       "integrity": "sha512-k8luDIWJWyenLc5ToFQQMaSrqCHiLwyKPHKPQZ5zz21vM+vIVUSvsRpcbiECH4WR88K2XZqc4ScRcZ7nk/jbeA=="
+    },
+    "vscode-oniguruma": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/vscode-oniguruma/-/vscode-oniguruma-1.6.1.tgz",
+      "integrity": "sha512-vc4WhSIaVpgJ0jJIejjYxPvURJavX6QG41vu0mGhqywMkQqulezEqEQ3cO3gc8GvcOpX6ycmKGqRoROEMBNXTQ==",
+      "dev": true
+    },
+    "vscode-textmate": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/vscode-textmate/-/vscode-textmate-5.5.0.tgz",
+      "integrity": "sha512-jToQkPGMNKn0eyKyitYeINJF0NoD240aYyKPIWJv5W2jfPt++jIRg0OSergubtGhbw6SoefkvBYEpX7TsfoSUQ==",
+      "dev": true
+    },
+    "vscode-tmgrammar-test": {
+      "version": "0.0.11",
+      "resolved": "https://registry.npmjs.org/vscode-tmgrammar-test/-/vscode-tmgrammar-test-0.0.11.tgz",
+      "integrity": "sha512-Bd60x/OeBLAQnIxiR2GhUic1CQZOFfWM8Pd43HjdEUBf/0vcvYAlFQikOXvv+zkItHLznjKaDX7VWKPVYUF9ug==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.4.2",
+        "commander": "^2.20.3",
+        "diff": "^4.0.2",
+        "glob": "^7.1.6",
+        "vscode-oniguruma": "^1.5.1",
+        "vscode-textmate": "^5.4.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "commander": {
+          "version": "2.20.3",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+          "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+          "dev": true
+        },
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+          "dev": true
+        },
+        "escape-string-regexp": {
+          "version": "1.0.5",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+          "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
+      }
     },
     "vscode-uri": {
       "version": "3.0.3",

--- a/package.json
+++ b/package.json
@@ -335,6 +335,9 @@
     "pretest": "npm run download:ls && npm run test-compile && npm run lint",
     "test": "node ./out/test/runTest.js",
     "test:unit": "jest",
+    "test:syntax": "npm run test:grammar && npm run test:snap",
+    "test:grammar": "npx vscode-tmgrammar-test -s scope.terraform -g syntaxes/terraform.tmGrammar.json -t tests/unit/**/*.tf",
+    "test:snap": "npx vscode-tmgrammar-snap -s scope.terraform -g syntaxes/terraform.tmGrammar.json -t tests/snapshot/**/*.tf",
     "lint": "eslint src --ext ts",
     "prettier": "prettier \"**/*.+(js|json|ts)\"",
     "format": "npm run prettier -- --write",
@@ -372,6 +375,7 @@
     "ts-jest": "^27.1.0",
     "ts-node": "^10.4.0",
     "typescript": "^4.5.4",
-    "vsce": "^2.6.3"
+    "vsce": "^2.6.3",
+    "vscode-tmgrammar-test": "^0.0.11"
   }
 }

--- a/tests/snapshot/terraform/basic.tf
+++ b/tests/snapshot/terraform/basic.tf
@@ -1,0 +1,27 @@
+# line comment
+
+// line comment
+
+/*
+  Block comment
+*/
+
+terraform {
+  required_providers {
+    azurerm = {
+      source  = "hashicorp/azurerm"
+      version = "~> 2.65"
+    }
+  }
+
+  required_version = ">= 1.1.0"
+}
+
+provider "azurerm" {
+  features {}
+}
+
+resource "azurerm_resource_group" "rg" {
+  name     = "myTFResourceGroup"
+  location = "westus2"
+}

--- a/tests/snapshot/terraform/basic.tf.snap
+++ b/tests/snapshot/terraform/basic.tf.snap
@@ -1,0 +1,118 @@
+># line comment
+#^ scope.terraform comment.line.terraform punctuation.definition.comment.terraform
+# ^^^^^^^^^^^^^ scope.terraform comment.line.terraform
+>
+>// line comment
+#^^ scope.terraform comment.line.terraform punctuation.definition.comment.terraform
+#  ^^^^^^^^^^^^^ scope.terraform comment.line.terraform
+>
+>/*
+#^^ scope.terraform comment.block.terraform punctuation.definition.comment.terraform
+>  Block comment
+#^^^^^^^^^^^^^^^^ scope.terraform comment.block.terraform
+>*/
+#^^ scope.terraform comment.block.terraform punctuation.definition.comment.terraform
+>
+>terraform {
+#^^^^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
+#         ^ scope.terraform meta.block.terraform
+#          ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+>  required_providers {
+#^^ scope.terraform meta.block.terraform
+#  ^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+#                    ^ scope.terraform meta.block.terraform meta.block.terraform
+#                     ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+>    azurerm = {
+#^^^^ scope.terraform meta.block.terraform meta.block.terraform
+#    ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#           ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#            ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#             ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#              ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
+>      source  = "hashicorp/azurerm"
+#^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+#      ^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+#            ^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+#              ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#               ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+#                ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                 ^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
+#                                  ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+>      version = "~> 2.65"
+#^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+#      ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+#             ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+#              ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#               ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+#                ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                 ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
+#                        ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+>    }
+#^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+#    ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
+>  }
+#^^ scope.terraform meta.block.terraform meta.block.terraform
+#  ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+>
+>  required_version = ">= 1.1.0"
+#^^ scope.terraform meta.block.terraform
+#  ^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#                  ^ scope.terraform meta.block.terraform variable.declaration.terraform
+#                   ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                    ^ scope.terraform meta.block.terraform variable.declaration.terraform
+#                     ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                      ^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
+#                              ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+>}
+#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+>
+>provider "azurerm" {
+#^^^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
+#        ^ scope.terraform meta.block.terraform
+#         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
+#                 ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                  ^ scope.terraform meta.block.terraform
+#                   ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+>  features {}
+#^^ scope.terraform meta.block.terraform
+#  ^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+#          ^ scope.terraform meta.block.terraform meta.block.terraform
+#           ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#            ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+>}
+#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+>
+>resource "azurerm_resource_group" "rg" {
+#^^^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
+#        ^ scope.terraform meta.block.terraform
+#         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
+#                                ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                 ^ scope.terraform meta.block.terraform
+#                                  ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                                   ^^ scope.terraform meta.block.terraform string.quoted.double.terraform
+#                                     ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                      ^ scope.terraform meta.block.terraform
+#                                       ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+>  name     = "myTFResourceGroup"
+#^^ scope.terraform meta.block.terraform
+#  ^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#      ^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform
+#           ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#            ^ scope.terraform meta.block.terraform variable.declaration.terraform
+#             ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#              ^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
+#                               ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+>  location = "westus2"
+#^^ scope.terraform meta.block.terraform
+#  ^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#          ^ scope.terraform meta.block.terraform variable.declaration.terraform
+#           ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#            ^ scope.terraform meta.block.terraform variable.declaration.terraform
+#             ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#              ^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
+#                     ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+>}
+#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+>

--- a/tests/unit/terraform/basic.tf
+++ b/tests/unit/terraform/basic.tf
@@ -1,0 +1,119 @@
+; SYNTAX TEST "scope.terraform" "basic sample"
+
+# line comment
+; <- scope.terraform comment.line.terraform punctuation.definition.comment.terraform
+;  ^^^^^^^^^^^^^ scope.terraform comment.line.terraform
+
+// line comment
+; <-- scope.terraform comment.line.terraform punctuation.definition.comment.terraform
+;   ^^^^^^^^^^^^^ scope.terraform comment.line.terraform
+
+/*
+; <~- scope.terraform comment.block.terraform punctuation.definition.comment.terraform
+  Block comment
+; ^^^^^^^^^^^^^^^^ scope.terraform comment.block.terraform
+*/
+; <~- scope.terraform comment.block.terraform punctuation.definition.comment.terraform
+
+terraform {
+; <--------- scope.terraform meta.block.terraform entity.name.type.terraform
+;        ^ scope.terraform meta.block.terraform
+;         ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+  required_providers {
+; ^^ scope.terraform meta.block.terraform
+; ^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+;                   ^ scope.terraform meta.block.terraform meta.block.terraform
+;                    ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+    azurerm = {
+; ^^^^ scope.terraform meta.block.terraform meta.block.terraform
+;   ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+;          ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+;           ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+;            ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+;             ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
+      source  = "hashicorp/azurerm"
+; ^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+;     ^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+;           ^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+;             ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+;              ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+;               ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;                ^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
+;                                 ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+      version = "~> 2.65"
+; ^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+;     ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+;            ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+;             ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+;              ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+;               ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;                ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
+;                       ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+    }
+; ^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+;   ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
+  }
+; ^^ scope.terraform meta.block.terraform meta.block.terraform
+; ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+
+  required_version = ">= 1.1.0"
+; <-- scope.terraform meta.block.terraform
+; ^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+;                 ^ scope.terraform meta.block.terraform variable.declaration.terraform
+;                  ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+;                   ^ scope.terraform meta.block.terraform variable.declaration.terraform
+;                    ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;                     ^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
+;                             ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+}
+; <- scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+
+provider "azurerm" {
+; <-------- scope.terraform meta.block.terraform entity.name.type.terraform
+;       ^ scope.terraform meta.block.terraform
+;        ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;         ^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
+;                ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+;                 ^ scope.terraform meta.block.terraform
+;                  ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+  features {}
+; <-- scope.terraform meta.block.terraform
+; ^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+;         ^ scope.terraform meta.block.terraform meta.block.terraform
+;          ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+;           ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+}
+; <- scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+
+resource "azurerm_resource_group" "rg" {
+; <-------- scope.terraform meta.block.terraform entity.name.type.terraform
+;       ^ scope.terraform meta.block.terraform
+;        ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;         ^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
+;                               ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+;                                ^ scope.terraform meta.block.terraform
+;                                 ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;                                  ^^ scope.terraform meta.block.terraform string.quoted.double.terraform
+;                                    ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+;                                     ^ scope.terraform meta.block.terraform
+;                                      ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+  name     = "myTFResourceGroup"
+; <-- scope.terraform meta.block.terraform
+; ^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+;     ^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform
+;          ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+;           ^ scope.terraform meta.block.terraform variable.declaration.terraform
+;            ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;             ^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
+;                              ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+  location = "westus2"
+; <-- scope.terraform meta.block.terraform
+; ^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+;         ^ scope.terraform meta.block.terraform variable.declaration.terraform
+;          ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+;           ^ scope.terraform meta.block.terraform variable.declaration.terraform
+;            ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;             ^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
+;                    ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+}
+; <- scope.terraform meta.block.terraform punctuation.section.block.end.terraform


### PR DESCRIPTION
This commit:

- Adds testing infrastructure using vscode-tmgrammar-test to test the Terraform tmGrammar file. A minimal example file is used to demonstrate basic testing. Additional tests will be added as grammar is modified or changed.
- Add tmGrammar schema to project to enable VS Code to provide intellisense and minimal validation of the tmGrammar files, whether they are json or yaml.
- Updates the DEVELOPMENT readme and adds documentation on how to edit and test the Terraform tmGrammar
- Automatically tests the grammar on every pull request
