### PR TITLE
Update list/map syntax highlighting

### DIFF
--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -747,7 +747,7 @@
 				"1": {
 					"patterns": [
 						{
-							"match": "abspath|abs|ceil|floor|log|max|min|pow|signum|chomp|formatlist|indent|join|lower|regexall|regex|replace|split|strrev|substr|title|trimspace|upper|chunklist|coalescelist|coalesce|compact|concat|contains|distinct|element|flatten|index|keys|length|lookup|matchkeys|merge|range|reverse|setintersection|setproduct|setunion|slice|sort|transpose|values|zipmap|base64decode|base64encode|base64gzip|csvdecode|jsondecode|jsonencode|urlencode|yamldecode|yamlencode|dirname|pathexpand|basename|fileexists|fileset|filebase64|templatefile|formatdate|timeadd|timestamp|base64sha256|base64sha512|bcrypt|filebase64sha256|filebase64sha512|filemd5|filemd1|filesha256|filesha512|md5|rsadecrypt|sha1|sha256|sha512|uuidv5|uuid|cidrhost|cidrnetmask|cidrsubnet|tobool|tolist|tomap|tonumber|toset|tostring|file|format",
+							"match": "abspath|abs|ceil|floor|log|max|min|pow|signum|chomp|formatlist|indent|join|lower|regexall|regex|replace|split|strrev|substr|title|trimspace|upper|chunklist|coalescelist|coalesce|compact|concat|contains|distinct|element|flatten|index|keys|length|lookup|matchkeys|merge|range|reverse|setintersection|setproduct|setunion|slice|sort|transpose|values|zipmap|base64decode|base64encode|base64gzip|csvdecode|jsondecode|jsonencode|urlencode|yamldecode|yamlencode|dirname|pathexpand|basename|fileexists|fileset|filebase64|templatefile|formatdate|timeadd|timestamp|base64sha256|base64sha512|bcrypt|filebase64sha256|filebase64sha512|filemd5|filemd1|filesha256|filesha512|md5|rsadecrypt|sha1|sha256|sha512|uuidv5|uuid|cidrhost|cidrnetmask|cidrsubnet|tobool|tolist|tomap|tonumber|toset|tostring|file|format|map|list",
 							"name": "support.function.builtin.terraform"
 						},
 						{

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -751,10 +751,6 @@
 							"name": "support.function.builtin.terraform"
 						},
 						{
-							"match": "list|map",
-							"name": "invalid.deprecated.terraform"
-						},
-						{
 							"match": "\\b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\\b",
 							"name": "variable.function.terraform"
 						}

--- a/tests/snapshot/terraform/variables_input.tf.snap
+++ b/tests/snapshot/terraform/variables_input.tf.snap
@@ -34,7 +34,7 @@
 #      ^^^^ scope.terraform meta.block.terraform variable.declaration.terraform
 #          ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
 #           ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#            ^^^^ scope.terraform meta.block.terraform meta.function-call.terraform variable.function.terraform
+#            ^^^^ scope.terraform meta.block.terraform meta.function-call.terraform support.function.builtin.terraform
 #                ^ scope.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
 #                 ^^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform storage.type.terraform
 #                       ^ scope.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
@@ -66,7 +66,7 @@
 #      ^ scope.terraform meta.block.terraform variable.declaration.terraform
 #       ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
 #        ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#         ^^^^ scope.terraform meta.block.terraform meta.function-call.terraform variable.function.terraform
+#         ^^^^ scope.terraform meta.block.terraform meta.function-call.terraform support.function.builtin.terraform
 #             ^ scope.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
 #              ^^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform support.function.builtin.terraform
 #                    ^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform

--- a/tests/snapshot/terraform/variables_input.tf.snap
+++ b/tests/snapshot/terraform/variables_input.tf.snap
@@ -34,7 +34,7 @@
 #      ^^^^ scope.terraform meta.block.terraform variable.declaration.terraform
 #          ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
 #           ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#            ^^^^ scope.terraform meta.block.terraform meta.function-call.terraform invalid.deprecated.terraform
+#            ^^^^ scope.terraform meta.block.terraform meta.function-call.terraform variable.function.terraform
 #                ^ scope.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
 #                 ^^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform storage.type.terraform
 #                       ^ scope.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
@@ -66,7 +66,7 @@
 #      ^ scope.terraform meta.block.terraform variable.declaration.terraform
 #       ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
 #        ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#         ^^^^ scope.terraform meta.block.terraform meta.function-call.terraform invalid.deprecated.terraform
+#         ^^^^ scope.terraform meta.block.terraform meta.function-call.terraform variable.function.terraform
 #             ^ scope.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
 #              ^^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform support.function.builtin.terraform
 #                    ^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform


### PR DESCRIPTION
This PR updates the syntax highlighting for the deprecated `list()` and `map()` functions.

Closes #610