### PR TITLE
Move TextMate scope.terraform to source.terraform

### DIFF
--- a/package.json
+++ b/package.json
@@ -73,12 +73,12 @@
     "grammars": [
       {
         "language": "terraform",
-        "scopeName": "scope.terraform",
+        "scopeName": "source.terraform",
         "path": "./syntaxes/terraform.tmGrammar.json"
       },
       {
         "language": "terraform-vars",
-        "scopeName": "scope.terraform",
+        "scopeName": "source.terraform",
         "path": "./syntaxes/terraform.tmGrammar.json"
       }
     ],
@@ -336,8 +336,8 @@
     "test": "node ./out/test/runTest.js",
     "test:unit": "jest",
     "test:syntax": "npm run test:grammar && npm run test:snap",
-    "test:grammar": "npx vscode-tmgrammar-test -s scope.terraform -g syntaxes/terraform.tmGrammar.json -t 'tests/unit/**/*.tf'",
-    "test:snap": "npx vscode-tmgrammar-snap -s scope.terraform -g syntaxes/terraform.tmGrammar.json -t 'tests/snapshot/**/*.tf'",
+    "test:grammar": "npx vscode-tmgrammar-test -s source.terraform -g syntaxes/terraform.tmGrammar.json -t 'tests/unit/**/*.tf'",
+    "test:snap": "npx vscode-tmgrammar-snap -s source.terraform -g syntaxes/terraform.tmGrammar.json -t 'tests/snapshot/**/*.tf'",
     "lint": "eslint src --ext ts",
     "prettier": "prettier \"**/*.+(js|json|ts)\"",
     "format": "npm run prettier -- --write",

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -1,5 +1,5 @@
 {
-	"scopeName": "scope.terraform",
+	"scopeName": "source.terraform",
 	"fileTypes": [
 		"tf",
 		"tfvars",

--- a/tests/snapshot/terraform/basic.tf.snap
+++ b/tests/snapshot/terraform/basic.tf.snap
@@ -1,118 +1,118 @@
 ># line comment
-#^ scope.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^^^^^^ scope.terraform comment.line.terraform
+#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
+# ^^^^^^^^^^^^^ source.terraform comment.line.terraform
 >
 >// line comment
-#^^ scope.terraform comment.line.terraform punctuation.definition.comment.terraform
-#  ^^^^^^^^^^^^^ scope.terraform comment.line.terraform
+#^^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
+#  ^^^^^^^^^^^^^ source.terraform comment.line.terraform
 >
 >/*
-#^^ scope.terraform comment.block.terraform punctuation.definition.comment.terraform
+#^^ source.terraform comment.block.terraform punctuation.definition.comment.terraform
 >  Block comment
-#^^^^^^^^^^^^^^^^ scope.terraform comment.block.terraform
+#^^^^^^^^^^^^^^^^ source.terraform comment.block.terraform
 >*/
-#^^ scope.terraform comment.block.terraform punctuation.definition.comment.terraform
+#^^ source.terraform comment.block.terraform punctuation.definition.comment.terraform
 >
 >terraform {
-#^^^^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#         ^ scope.terraform meta.block.terraform
-#          ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#         ^ source.terraform meta.block.terraform
+#          ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  required_providers {
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
-#                    ^ scope.terraform meta.block.terraform meta.block.terraform
-#                     ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+#                    ^ source.terraform meta.block.terraform meta.block.terraform
+#                     ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >    azurerm = {
-#^^^^ scope.terraform meta.block.terraform meta.block.terraform
-#    ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#           ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#            ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#             ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#              ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
+#^^^^ source.terraform meta.block.terraform meta.block.terraform
+#    ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#           ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#            ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#             ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#              ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
 >      source  = "hashicorp/azurerm"
-#^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
-#      ^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
-#            ^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
-#              ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-#               ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
-#                ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                 ^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
-#                                  ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+#      ^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+#            ^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+#              ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#               ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+#                ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                 ^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
+#                                  ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >      version = "~> 2.65"
-#^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
-#      ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
-#             ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
-#              ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-#               ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
-#                ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                 ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
-#                        ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+#      ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+#             ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+#              ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#               ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+#                ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                 ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
+#                        ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >    }
-#^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
-#    ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
+#^^^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+#    ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
 >  }
-#^^ scope.terraform meta.block.terraform meta.block.terraform
-#  ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^^ source.terraform meta.block.terraform meta.block.terraform
+#  ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >  required_version = ">= 1.1.0"
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#                  ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                   ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#                    ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                     ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                      ^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                              ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#                  ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                   ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                    ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                     ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                      ^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                              ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >provider "azurerm" {
-#^^^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#        ^ scope.terraform meta.block.terraform
-#         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                 ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                  ^ scope.terraform meta.block.terraform
-#                   ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#        ^ source.terraform meta.block.terraform
+#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                  ^ source.terraform meta.block.terraform
+#                   ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  features {}
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
-#          ^ scope.terraform meta.block.terraform meta.block.terraform
-#           ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
-#            ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+#          ^ source.terraform meta.block.terraform meta.block.terraform
+#           ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#            ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >resource "azurerm_resource_group" "rg" {
-#^^^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#        ^ scope.terraform meta.block.terraform
-#         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                                ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                 ^ scope.terraform meta.block.terraform
-#                                  ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                                   ^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                                     ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                      ^ scope.terraform meta.block.terraform
-#                                       ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#        ^ source.terraform meta.block.terraform
+#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                                ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                 ^ source.terraform meta.block.terraform
+#                                  ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                                   ^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                                     ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                      ^ source.terraform meta.block.terraform
+#                                       ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  name     = "myTFResourceGroup"
-#^^ scope.terraform meta.block.terraform
-#  ^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#      ^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform
-#           ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#            ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#             ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#              ^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                               ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#      ^^^^^ source.terraform meta.block.terraform variable.declaration.terraform
+#           ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#            ^ source.terraform meta.block.terraform variable.declaration.terraform
+#             ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#              ^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                               ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >  location = "westus2"
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#          ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#           ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#            ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#             ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#              ^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                     ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#          ^ source.terraform meta.block.terraform variable.declaration.terraform
+#           ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#            ^ source.terraform meta.block.terraform variable.declaration.terraform
+#             ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#              ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                     ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >

--- a/tests/snapshot/terraform/blocks.tf.snap
+++ b/tests/snapshot/terraform/blocks.tf.snap
@@ -1,59 +1,59 @@
 >resource "aws_instance" "web" {
-#^^^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#        ^ scope.terraform meta.block.terraform
-#         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                      ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                       ^ scope.terraform meta.block.terraform
-#                        ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                         ^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                            ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                             ^ scope.terraform meta.block.terraform
-#                              ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#        ^ source.terraform meta.block.terraform
+#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                      ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                       ^ source.terraform meta.block.terraform
+#                        ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                         ^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                            ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                             ^ source.terraform meta.block.terraform
+#                              ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  ami           = "ami-a1b2c3d4"
-#^^ scope.terraform meta.block.terraform
-#  ^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#     ^^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#                 ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                  ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                   ^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                               ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#     ^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform
+#                ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                 ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                  ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                   ^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                               ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >  instance_type = "t2.micro"
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#               ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#                 ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                  ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                   ^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                           ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#               ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                 ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                  ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                   ^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                           ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >  timeouts {
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
-#          ^ scope.terraform meta.block.terraform meta.block.terraform
-#           ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+#          ^ source.terraform meta.block.terraform meta.block.terraform
+#           ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >    create = "60m"
-#^^^^ scope.terraform meta.block.terraform meta.block.terraform
-#    ^^^^^^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#          ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#           ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#            ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#             ^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#              ^^^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                 ^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^^^ source.terraform meta.block.terraform meta.block.terraform
+#    ^^^^^^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#          ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#           ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#            ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#             ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#              ^^^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
+#                 ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >    delete = "2h"
-#^^^^ scope.terraform meta.block.terraform meta.block.terraform
-#    ^^^^^^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#          ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#           ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#            ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#             ^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#              ^^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                ^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^^^ source.terraform meta.block.terraform meta.block.terraform
+#    ^^^^^^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#          ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#           ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#            ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#             ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#              ^^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
+#                ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >  }
-#^^ scope.terraform meta.block.terraform meta.block.terraform
-#  ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^^ source.terraform meta.block.terraform meta.block.terraform
+#  ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >

--- a/tests/snapshot/terraform/comments.tf.snap
+++ b/tests/snapshot/terraform/comments.tf.snap
@@ -1,15 +1,15 @@
 ># line comment
-#^ scope.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^^^^^^ scope.terraform comment.line.terraform
+#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
+# ^^^^^^^^^^^^^ source.terraform comment.line.terraform
 >
 >// line comment
-#^^ scope.terraform comment.line.terraform punctuation.definition.comment.terraform
-#  ^^^^^^^^^^^^^ scope.terraform comment.line.terraform
+#^^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
+#  ^^^^^^^^^^^^^ source.terraform comment.line.terraform
 >
 >/*
-#^^ scope.terraform comment.block.terraform punctuation.definition.comment.terraform
+#^^ source.terraform comment.block.terraform punctuation.definition.comment.terraform
 >  Block comment
-#^^^^^^^^^^^^^^^^ scope.terraform comment.block.terraform
+#^^^^^^^^^^^^^^^^ source.terraform comment.block.terraform
 >*/
-#^^ scope.terraform comment.block.terraform punctuation.definition.comment.terraform
+#^^ source.terraform comment.block.terraform punctuation.definition.comment.terraform
 >

--- a/tests/snapshot/terraform/data_sources.tf.snap
+++ b/tests/snapshot/terraform/data_sources.tf.snap
@@ -1,62 +1,62 @@
 >data "aws_ami" "example" {
-#^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#    ^ scope.terraform meta.block.terraform
-#     ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#      ^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#             ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#              ^ scope.terraform meta.block.terraform
-#               ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                ^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                       ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                        ^ scope.terraform meta.block.terraform
-#                         ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#    ^ source.terraform meta.block.terraform
+#     ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#      ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#             ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#              ^ source.terraform meta.block.terraform
+#               ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                       ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                        ^ source.terraform meta.block.terraform
+#                         ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  most_recent = true
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#             ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#              ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#               ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                ^^^^ scope.terraform meta.block.terraform constant.language.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#             ^ source.terraform meta.block.terraform variable.declaration.terraform
+#              ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#               ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                ^^^^ source.terraform meta.block.terraform constant.language.terraform
 >
 >  owners = ["self"]
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#        ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#         ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#          ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#           ^ scope.terraform meta.block.terraform punctuation.section.brackets.begin.terraform
-#            ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#             ^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                 ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                  ^ scope.terraform meta.block.terraform punctuation.section.brackets.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#        ^ source.terraform meta.block.terraform variable.declaration.terraform
+#         ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#          ^ source.terraform meta.block.terraform variable.declaration.terraform
+#           ^ source.terraform meta.block.terraform punctuation.section.brackets.begin.terraform
+#            ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#             ^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                  ^ source.terraform meta.block.terraform punctuation.section.brackets.end.terraform
 >  tags = {
-#^^ scope.terraform meta.block.terraform
-#  ^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#      ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#       ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#        ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#         ^ scope.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#      ^ source.terraform meta.block.terraform variable.declaration.terraform
+#       ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#        ^ source.terraform meta.block.terraform variable.declaration.terraform
+#         ^ source.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
 >    Name   = "app-server"
-#^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#    ^^^^ scope.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
-#        ^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#           ^ scope.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-#            ^ scope.terraform meta.block.terraform meta.braces.terraform
-#             ^ scope.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#              ^^^^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
-#                        ^ scope.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#    ^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+#        ^^^ source.terraform meta.block.terraform meta.braces.terraform
+#           ^ source.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#            ^ source.terraform meta.block.terraform meta.braces.terraform
+#             ^ source.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#              ^^^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
+#                        ^ source.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >    Tested = "true"
-#^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#    ^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
-#          ^ scope.terraform meta.block.terraform meta.braces.terraform
-#           ^ scope.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-#            ^ scope.terraform meta.block.terraform meta.braces.terraform
-#             ^ scope.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#              ^^^^ scope.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
-#                  ^ scope.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#    ^^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+#          ^ source.terraform meta.block.terraform meta.braces.terraform
+#           ^ source.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#            ^ source.terraform meta.block.terraform meta.braces.terraform
+#             ^ source.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#              ^^^^ source.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
+#                  ^ source.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >  }
-#^^ scope.terraform meta.block.terraform meta.braces.terraform
-#  ^ scope.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
+#^^ source.terraform meta.block.terraform meta.braces.terraform
+#  ^ source.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >

--- a/tests/snapshot/terraform/expressions_conditional.tf.snap
+++ b/tests/snapshot/terraform/expressions_conditional.tf.snap
@@ -1,53 +1,53 @@
 >var.a != "" ? var.a : "default-a"
-#^^^ scope.terraform support.constant.terraform
-#   ^ scope.terraform keyword.operator.accessor.terraform
-#    ^ scope.terraform variable.other.member.terraform
-#     ^ scope.terraform
-#      ^^ scope.terraform keyword.operator.terraform
-#        ^ scope.terraform
-#         ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#           ^ scope.terraform
-#            ^ scope.terraform keyword.operator.terraform
-#             ^ scope.terraform
-#              ^^^ scope.terraform support.constant.terraform
-#                 ^ scope.terraform keyword.operator.accessor.terraform
-#                  ^ scope.terraform variable.other.member.terraform
-#                   ^ scope.terraform
-#                    ^ scope.terraform
-#                     ^ scope.terraform
-#                      ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                       ^^^^^^^^^ scope.terraform string.quoted.double.terraform
-#                                ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^^ source.terraform support.constant.terraform
+#   ^ source.terraform keyword.operator.accessor.terraform
+#    ^ source.terraform variable.other.member.terraform
+#     ^ source.terraform
+#      ^^ source.terraform keyword.operator.terraform
+#        ^ source.terraform
+#         ^ source.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^ source.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#           ^ source.terraform
+#            ^ source.terraform keyword.operator.terraform
+#             ^ source.terraform
+#              ^^^ source.terraform support.constant.terraform
+#                 ^ source.terraform keyword.operator.accessor.terraform
+#                  ^ source.terraform variable.other.member.terraform
+#                   ^ source.terraform
+#                    ^ source.terraform
+#                     ^ source.terraform
+#                      ^ source.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                       ^^^^^^^^^ source.terraform string.quoted.double.terraform
+#                                ^ source.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >var.example ? tostring(12) : "hello"
-#^^^ scope.terraform support.constant.terraform
-#   ^ scope.terraform keyword.operator.accessor.terraform
-#    ^^^^^^^ scope.terraform variable.other.member.terraform
-#           ^ scope.terraform
-#            ^ scope.terraform keyword.operator.terraform
-#             ^ scope.terraform
-#              ^^^^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#                      ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#                       ^^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#                         ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
-#                          ^ scope.terraform
-#                           ^ scope.terraform
-#                            ^ scope.terraform
-#                             ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                              ^^^^^ scope.terraform string.quoted.double.terraform
-#                                   ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^^ source.terraform support.constant.terraform
+#   ^ source.terraform keyword.operator.accessor.terraform
+#    ^^^^^^^ source.terraform variable.other.member.terraform
+#           ^ source.terraform
+#            ^ source.terraform keyword.operator.terraform
+#             ^ source.terraform
+#              ^^^^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#                      ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#                       ^^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#                         ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#                          ^ source.terraform
+#                           ^ source.terraform
+#                            ^ source.terraform
+#                             ^ source.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                              ^^^^^ source.terraform string.quoted.double.terraform
+#                                   ^ source.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >var.example ? 12 : "hello"
-#^^^ scope.terraform support.constant.terraform
-#   ^ scope.terraform keyword.operator.accessor.terraform
-#    ^^^^^^^ scope.terraform variable.other.member.terraform
-#           ^ scope.terraform
-#            ^ scope.terraform keyword.operator.terraform
-#             ^ scope.terraform
-#              ^^ scope.terraform constant.numeric.integer.terraform
-#                ^ scope.terraform
-#                 ^ scope.terraform
-#                  ^ scope.terraform
-#                   ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                    ^^^^^ scope.terraform string.quoted.double.terraform
-#                         ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^^ source.terraform support.constant.terraform
+#   ^ source.terraform keyword.operator.accessor.terraform
+#    ^^^^^^^ source.terraform variable.other.member.terraform
+#           ^ source.terraform
+#            ^ source.terraform keyword.operator.terraform
+#             ^ source.terraform
+#              ^^ source.terraform constant.numeric.integer.terraform
+#                ^ source.terraform
+#                 ^ source.terraform
+#                  ^ source.terraform
+#                   ^ source.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                    ^^^^^ source.terraform string.quoted.double.terraform
+#                         ^ source.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >

--- a/tests/snapshot/terraform/expressions_dynamic.tf.snap
+++ b/tests/snapshot/terraform/expressions_dynamic.tf.snap
@@ -1,178 +1,178 @@
 >resource "thing" "name" {
-#^^^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#        ^ scope.terraform meta.block.terraform
-#         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#               ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                ^ scope.terraform meta.block.terraform
-#                 ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                  ^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                      ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                       ^ scope.terraform meta.block.terraform
-#                        ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#        ^ source.terraform meta.block.terraform
+#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#               ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                ^ source.terraform meta.block.terraform
+#                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                  ^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                      ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                       ^ source.terraform meta.block.terraform
+#                        ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  name = "tf-test-name"
-#^^ scope.terraform meta.block.terraform
-#  ^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#      ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#       ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#        ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                      ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#      ^ source.terraform meta.block.terraform variable.declaration.terraform
+#       ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#        ^ source.terraform meta.block.terraform variable.declaration.terraform
+#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                      ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >
 >  dynamic "setting" {
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
-#         ^ scope.terraform meta.block.terraform meta.block.terraform
-#          ^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#           ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                  ^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                   ^ scope.terraform meta.block.terraform meta.block.terraform
-#                    ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+#         ^ source.terraform meta.block.terraform meta.block.terraform
+#          ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#           ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
+#                  ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                   ^ source.terraform meta.block.terraform meta.block.terraform
+#                    ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >    for_each = var.settings
-#^^^^ scope.terraform meta.block.terraform meta.block.terraform
-#    ^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#            ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#             ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#              ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#               ^^^ scope.terraform meta.block.terraform meta.block.terraform support.constant.terraform
-#                  ^ scope.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                   ^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
+#^^^^ source.terraform meta.block.terraform meta.block.terraform
+#    ^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#            ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#             ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#              ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#               ^^^ source.terraform meta.block.terraform meta.block.terraform support.constant.terraform
+#                  ^ source.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                   ^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
 >    content {
-#^^^^ scope.terraform meta.block.terraform meta.block.terraform
-#    ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
-#           ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#            ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^ source.terraform meta.block.terraform meta.block.terraform
+#    ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+#           ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#            ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >      namespace = setting.value["namespace"]
-#^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#      ^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#               ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#                ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#                 ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#                  ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#                         ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                          ^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
-#                               ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.brackets.begin.terraform
-#                                ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                                 ^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                                          ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                           ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.brackets.end.terraform
+#^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#      ^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#               ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#                ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                 ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#                  ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#                         ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                          ^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
+#                               ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.brackets.begin.terraform
+#                                ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                                 ^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
+#                                          ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                           ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.brackets.end.terraform
 >      name = setting.value["name"]
-#^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#      ^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#          ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#           ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#            ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#             ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#                    ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                     ^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
-#                          ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.brackets.begin.terraform
-#                           ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                            ^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                                ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                 ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.brackets.end.terraform
+#^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#      ^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#          ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#           ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#            ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#             ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#                    ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                     ^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
+#                          ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.brackets.begin.terraform
+#                           ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                            ^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
+#                                ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                 ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.brackets.end.terraform
 >      value = setting.value["value"]
-#^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#      ^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#           ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#            ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#             ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#              ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#                     ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                      ^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
-#                           ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.brackets.begin.terraform
-#                            ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                             ^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                                  ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                   ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.brackets.end.terraform
+#^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#      ^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#           ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#            ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#             ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#              ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#                     ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                      ^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
+#                           ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.brackets.begin.terraform
+#                            ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                             ^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
+#                                  ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                   ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.brackets.end.terraform
 >    }
-#^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#    ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#    ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
 >  }
-#^^ scope.terraform meta.block.terraform meta.block.terraform
-#  ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^^ source.terraform meta.block.terraform meta.block.terraform
+#  ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >  dynamic "origin_group" {
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
-#         ^ scope.terraform meta.block.terraform meta.block.terraform
-#          ^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#           ^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                       ^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                        ^ scope.terraform meta.block.terraform meta.block.terraform
-#                         ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+#         ^ source.terraform meta.block.terraform meta.block.terraform
+#          ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#           ^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
+#                       ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                        ^ source.terraform meta.block.terraform meta.block.terraform
+#                         ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >    for_each = var.load_balancer_origin_groups
-#^^^^ scope.terraform meta.block.terraform meta.block.terraform
-#    ^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#            ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#             ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#              ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#               ^^^ scope.terraform meta.block.terraform meta.block.terraform support.constant.terraform
-#                  ^ scope.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
+#^^^^ source.terraform meta.block.terraform meta.block.terraform
+#    ^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#            ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#             ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#              ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#               ^^^ source.terraform meta.block.terraform meta.block.terraform support.constant.terraform
+#                  ^ source.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
 >    content {
-#^^^^ scope.terraform meta.block.terraform meta.block.terraform
-#    ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
-#           ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#            ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^ source.terraform meta.block.terraform meta.block.terraform
+#    ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+#           ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#            ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >      name = origin_group.key
-#^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#      ^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#          ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#           ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#            ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#             ^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#                         ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                          ^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
+#^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#      ^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#          ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#           ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#            ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#             ^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#                         ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                          ^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
 >
 >      dynamic "origin" {
-#^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#      ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
-#             ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#              ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#               ^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                     ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                      ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#                       ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#      ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+#             ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#              ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#               ^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
+#                     ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                      ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#                       ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >        for_each = origin_group.value.origins
-#^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#        ^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#                ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#                 ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#                  ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#                   ^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#                               ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                                ^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
-#                                     ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                                      ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
+#^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#        ^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#                ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#                 ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                  ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#                   ^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#                               ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                                ^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
+#                                     ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                                      ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
 >        content {
-#^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#        ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
-#               ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#                ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#        ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+#               ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#                ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >          hostname = origin.value.hostname
-#^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#          ^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#                  ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#                   ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#                    ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#                     ^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#                           ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                            ^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
-#                                 ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                                  ^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
+#^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#          ^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#                  ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#                   ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                    ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#                     ^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#                           ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                            ^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
+#                                 ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                                  ^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.member.terraform
 >        }
-#^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#        ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#        ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
 >      }
-#^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#      ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#      ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
 >    }
-#^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#    ^ scope.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
+#    ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
 >  }
-#^^ scope.terraform meta.block.terraform meta.block.terraform
-#  ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^^ source.terraform meta.block.terraform meta.block.terraform
+#  ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >

--- a/tests/snapshot/terraform/expressions_for.tf.snap
+++ b/tests/snapshot/terraform/expressions_for.tf.snap
@@ -1,217 +1,217 @@
 >[for s in var.list : upper(s)]
-#^ scope.terraform punctuation.section.brackets.begin.terraform
-# ^^^ scope.terraform keyword.control.terraform
-#    ^ scope.terraform
-#     ^ scope.terraform variable.other.readwrite.terraform
-#      ^ scope.terraform
-#       ^^ scope.terraform keyword.operator.word.terraform
-#         ^ scope.terraform
-#          ^^^ scope.terraform support.constant.terraform
-#             ^ scope.terraform keyword.operator.accessor.terraform
-#              ^^^^ scope.terraform variable.other.member.terraform
-#                  ^ scope.terraform
-#                   ^ scope.terraform keyword.operator.terraform
-#                    ^ scope.terraform
-#                     ^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#                          ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#                           ^ scope.terraform meta.function-call.terraform
-#                            ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
-#                             ^ scope.terraform punctuation.section.brackets.end.terraform
+#^ source.terraform punctuation.section.brackets.begin.terraform
+# ^^^ source.terraform keyword.control.terraform
+#    ^ source.terraform
+#     ^ source.terraform variable.other.readwrite.terraform
+#      ^ source.terraform
+#       ^^ source.terraform keyword.operator.word.terraform
+#         ^ source.terraform
+#          ^^^ source.terraform support.constant.terraform
+#             ^ source.terraform keyword.operator.accessor.terraform
+#              ^^^^ source.terraform variable.other.member.terraform
+#                  ^ source.terraform
+#                   ^ source.terraform keyword.operator.terraform
+#                    ^ source.terraform
+#                     ^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#                          ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#                           ^ source.terraform meta.function-call.terraform
+#                            ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#                             ^ source.terraform punctuation.section.brackets.end.terraform
 >
 >[for k, v in var.map : length(k) + length(v)]
-#^ scope.terraform punctuation.section.brackets.begin.terraform
-# ^^^ scope.terraform keyword.control.terraform
-#    ^ scope.terraform
-#     ^ scope.terraform variable.other.readwrite.terraform
-#      ^ scope.terraform punctuation.separator.terraform
-#       ^ scope.terraform
-#        ^ scope.terraform variable.other.readwrite.terraform
-#         ^ scope.terraform
-#          ^^ scope.terraform keyword.operator.word.terraform
-#            ^ scope.terraform
-#             ^^^ scope.terraform support.constant.terraform
-#                ^ scope.terraform keyword.operator.accessor.terraform
-#                 ^^^ scope.terraform variable.other.member.terraform
-#                    ^ scope.terraform
-#                     ^ scope.terraform keyword.operator.terraform
-#                      ^ scope.terraform
-#                       ^^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#                             ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#                              ^ scope.terraform meta.function-call.terraform
-#                               ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
-#                                ^ scope.terraform
-#                                 ^ scope.terraform keyword.operator.arithmetic.terraform
-#                                  ^ scope.terraform
-#                                   ^^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#                                         ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#                                          ^ scope.terraform meta.function-call.terraform
-#                                           ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
-#                                            ^ scope.terraform punctuation.section.brackets.end.terraform
+#^ source.terraform punctuation.section.brackets.begin.terraform
+# ^^^ source.terraform keyword.control.terraform
+#    ^ source.terraform
+#     ^ source.terraform variable.other.readwrite.terraform
+#      ^ source.terraform punctuation.separator.terraform
+#       ^ source.terraform
+#        ^ source.terraform variable.other.readwrite.terraform
+#         ^ source.terraform
+#          ^^ source.terraform keyword.operator.word.terraform
+#            ^ source.terraform
+#             ^^^ source.terraform support.constant.terraform
+#                ^ source.terraform keyword.operator.accessor.terraform
+#                 ^^^ source.terraform variable.other.member.terraform
+#                    ^ source.terraform
+#                     ^ source.terraform keyword.operator.terraform
+#                      ^ source.terraform
+#                       ^^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#                             ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#                              ^ source.terraform meta.function-call.terraform
+#                               ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#                                ^ source.terraform
+#                                 ^ source.terraform keyword.operator.arithmetic.terraform
+#                                  ^ source.terraform
+#                                   ^^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#                                         ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#                                          ^ source.terraform meta.function-call.terraform
+#                                           ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#                                            ^ source.terraform punctuation.section.brackets.end.terraform
 >
 >[for i, v in var.list : "${i} is ${v}"]
-#^ scope.terraform punctuation.section.brackets.begin.terraform
-# ^^^ scope.terraform keyword.control.terraform
-#    ^ scope.terraform
-#     ^ scope.terraform variable.other.readwrite.terraform
-#      ^ scope.terraform punctuation.separator.terraform
-#       ^ scope.terraform
-#        ^ scope.terraform variable.other.readwrite.terraform
-#         ^ scope.terraform
-#          ^^ scope.terraform keyword.operator.word.terraform
-#            ^ scope.terraform
-#             ^^^ scope.terraform support.constant.terraform
-#                ^ scope.terraform keyword.operator.accessor.terraform
-#                 ^^^^ scope.terraform variable.other.member.terraform
-#                     ^ scope.terraform
-#                      ^ scope.terraform keyword.operator.terraform
-#                       ^ scope.terraform
-#                        ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                         ^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
-#                           ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform variable.other.readwrite.terraform
-#                            ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
-#                             ^^^ scope.terraform string.quoted.double.terraform
-#                                ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform
-#                                 ^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
-#                                   ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform variable.other.readwrite.terraform
-#                                    ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
-#                                     ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                      ^ scope.terraform punctuation.section.brackets.end.terraform
+#^ source.terraform punctuation.section.brackets.begin.terraform
+# ^^^ source.terraform keyword.control.terraform
+#    ^ source.terraform
+#     ^ source.terraform variable.other.readwrite.terraform
+#      ^ source.terraform punctuation.separator.terraform
+#       ^ source.terraform
+#        ^ source.terraform variable.other.readwrite.terraform
+#         ^ source.terraform
+#          ^^ source.terraform keyword.operator.word.terraform
+#            ^ source.terraform
+#             ^^^ source.terraform support.constant.terraform
+#                ^ source.terraform keyword.operator.accessor.terraform
+#                 ^^^^ source.terraform variable.other.member.terraform
+#                     ^ source.terraform
+#                      ^ source.terraform keyword.operator.terraform
+#                       ^ source.terraform
+#                        ^ source.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                         ^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
+#                           ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform variable.other.readwrite.terraform
+#                            ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
+#                             ^^^ source.terraform string.quoted.double.terraform
+#                                ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform
+#                                 ^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
+#                                   ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform variable.other.readwrite.terraform
+#                                    ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
+#                                     ^ source.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                      ^ source.terraform punctuation.section.brackets.end.terraform
 >
 >{for s in var.list : s => upper(s)}
-#^ scope.terraform punctuation.section.braces.begin.terraform
-# ^^^ scope.terraform keyword.control.terraform
-#    ^ scope.terraform
-#     ^ scope.terraform variable.other.readwrite.terraform
-#      ^ scope.terraform
-#       ^^ scope.terraform keyword.operator.word.terraform
-#         ^ scope.terraform
-#          ^^^ scope.terraform support.constant.terraform
-#             ^ scope.terraform keyword.operator.accessor.terraform
-#              ^^^^ scope.terraform variable.other.member.terraform
-#                  ^ scope.terraform
-#                   ^ scope.terraform keyword.operator.terraform
-#                    ^ scope.terraform
-#                     ^ scope.terraform variable.other.readwrite.terraform
-#                      ^ scope.terraform
-#                       ^^ scope.terraform storage.type.function.terraform
-#                         ^ scope.terraform
-#                          ^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#                               ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#                                ^ scope.terraform meta.function-call.terraform
-#                                 ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
-#                                  ^ scope.terraform punctuation.section.braces.end.terraform
+#^ source.terraform punctuation.section.braces.begin.terraform
+# ^^^ source.terraform keyword.control.terraform
+#    ^ source.terraform
+#     ^ source.terraform variable.other.readwrite.terraform
+#      ^ source.terraform
+#       ^^ source.terraform keyword.operator.word.terraform
+#         ^ source.terraform
+#          ^^^ source.terraform support.constant.terraform
+#             ^ source.terraform keyword.operator.accessor.terraform
+#              ^^^^ source.terraform variable.other.member.terraform
+#                  ^ source.terraform
+#                   ^ source.terraform keyword.operator.terraform
+#                    ^ source.terraform
+#                     ^ source.terraform variable.other.readwrite.terraform
+#                      ^ source.terraform
+#                       ^^ source.terraform storage.type.function.terraform
+#                         ^ source.terraform
+#                          ^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#                               ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#                                ^ source.terraform meta.function-call.terraform
+#                                 ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#                                  ^ source.terraform punctuation.section.braces.end.terraform
 >
 >[for s in var.list : upper(s) if s != ""]
-#^ scope.terraform punctuation.section.brackets.begin.terraform
-# ^^^ scope.terraform keyword.control.terraform
-#    ^ scope.terraform
-#     ^ scope.terraform variable.other.readwrite.terraform
-#      ^ scope.terraform
-#       ^^ scope.terraform keyword.operator.word.terraform
-#         ^ scope.terraform
-#          ^^^ scope.terraform support.constant.terraform
-#             ^ scope.terraform keyword.operator.accessor.terraform
-#              ^^^^ scope.terraform variable.other.member.terraform
-#                  ^ scope.terraform
-#                   ^ scope.terraform keyword.operator.terraform
-#                    ^ scope.terraform
-#                     ^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#                          ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#                           ^ scope.terraform meta.function-call.terraform
-#                            ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
-#                             ^ scope.terraform
-#                              ^^ scope.terraform keyword.control.conditional.terraform
-#                                ^ scope.terraform
-#                                 ^ scope.terraform variable.other.readwrite.terraform
-#                                  ^ scope.terraform
-#                                   ^^ scope.terraform keyword.operator.terraform
-#                                     ^ scope.terraform
-#                                      ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                                       ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                        ^ scope.terraform punctuation.section.brackets.end.terraform
+#^ source.terraform punctuation.section.brackets.begin.terraform
+# ^^^ source.terraform keyword.control.terraform
+#    ^ source.terraform
+#     ^ source.terraform variable.other.readwrite.terraform
+#      ^ source.terraform
+#       ^^ source.terraform keyword.operator.word.terraform
+#         ^ source.terraform
+#          ^^^ source.terraform support.constant.terraform
+#             ^ source.terraform keyword.operator.accessor.terraform
+#              ^^^^ source.terraform variable.other.member.terraform
+#                  ^ source.terraform
+#                   ^ source.terraform keyword.operator.terraform
+#                    ^ source.terraform
+#                     ^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#                          ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#                           ^ source.terraform meta.function-call.terraform
+#                            ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#                             ^ source.terraform
+#                              ^^ source.terraform keyword.control.conditional.terraform
+#                                ^ source.terraform
+#                                 ^ source.terraform variable.other.readwrite.terraform
+#                                  ^ source.terraform
+#                                   ^^ source.terraform keyword.operator.terraform
+#                                     ^ source.terraform
+#                                      ^ source.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                                       ^ source.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                        ^ source.terraform punctuation.section.brackets.end.terraform
 >
 >locals {
-#^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#      ^ scope.terraform meta.block.terraform
-#       ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#      ^ source.terraform meta.block.terraform
+#       ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  admin_users = {
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#             ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#              ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#               ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                ^ scope.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#             ^ source.terraform meta.block.terraform variable.declaration.terraform
+#              ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#               ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                ^ source.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
 >    for name, user in var.users : name => user
-#^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#                      ^^^ scope.terraform meta.block.terraform meta.braces.terraform support.constant.terraform
-#                         ^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#                                ^ scope.terraform meta.block.terraform meta.braces.terraform
-#                                 ^ scope.terraform meta.block.terraform meta.braces.terraform
-#                                  ^^^^ scope.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
-#                                      ^ scope.terraform meta.block.terraform meta.braces.terraform
-#                                       ^ scope.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-#                                        ^ scope.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-#                                         ^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
+#^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#                      ^^^ source.terraform meta.block.terraform meta.braces.terraform support.constant.terraform
+#                         ^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#                                ^ source.terraform meta.block.terraform meta.braces.terraform
+#                                 ^ source.terraform meta.block.terraform meta.braces.terraform
+#                                  ^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+#                                      ^ source.terraform meta.block.terraform meta.braces.terraform
+#                                       ^ source.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#                                        ^ source.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#                                         ^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
 >    if user.is_admin
-#^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
+#^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
 >  }
-#^^ scope.terraform meta.block.terraform meta.braces.terraform
-#  ^ scope.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
+#^^ source.terraform meta.block.terraform meta.braces.terraform
+#  ^ source.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
 >  regular_users = {
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#               ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#                 ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                  ^ scope.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#               ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                 ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                  ^ source.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
 >    for name, user in var.users : name => user
-#^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#                      ^^^ scope.terraform meta.block.terraform meta.braces.terraform support.constant.terraform
-#                         ^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#                                ^ scope.terraform meta.block.terraform meta.braces.terraform
-#                                 ^ scope.terraform meta.block.terraform meta.braces.terraform
-#                                  ^^^^ scope.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
-#                                      ^ scope.terraform meta.block.terraform meta.braces.terraform
-#                                       ^ scope.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-#                                        ^ scope.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-#                                         ^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
+#^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#                      ^^^ source.terraform meta.block.terraform meta.braces.terraform support.constant.terraform
+#                         ^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#                                ^ source.terraform meta.block.terraform meta.braces.terraform
+#                                 ^ source.terraform meta.block.terraform meta.braces.terraform
+#                                  ^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+#                                      ^ source.terraform meta.block.terraform meta.braces.terraform
+#                                       ^ source.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#                                        ^ source.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#                                         ^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
 >    if !user.is_admin
-#^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#       ^ scope.terraform meta.block.terraform meta.braces.terraform keyword.operator.logical.terraform
-#        ^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
+#^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#       ^ source.terraform meta.block.terraform meta.braces.terraform keyword.operator.logical.terraform
+#        ^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
 >  }
-#^^ scope.terraform meta.block.terraform meta.braces.terraform
-#  ^ scope.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
+#^^ source.terraform meta.block.terraform meta.braces.terraform
+#  ^ source.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >locals {
-#^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#      ^ scope.terraform meta.block.terraform
-#       ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#      ^ source.terraform meta.block.terraform
+#       ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  users_by_role = {
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#               ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#                 ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                  ^ scope.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#               ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                 ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                  ^ source.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
 >    for name, user in var.users : user.role => name...
-#^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#                      ^^^ scope.terraform meta.block.terraform meta.braces.terraform support.constant.terraform
-#                         ^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#                                ^ scope.terraform meta.block.terraform meta.braces.terraform
-#                                 ^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#                                       ^^^^ scope.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
-#                                           ^ scope.terraform meta.block.terraform meta.braces.terraform
-#                                            ^ scope.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-#                                             ^ scope.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-#                                              ^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#                                                   ^^^ scope.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#                      ^^^ source.terraform meta.block.terraform meta.braces.terraform support.constant.terraform
+#                         ^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#                                ^ source.terraform meta.block.terraform meta.braces.terraform
+#                                 ^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#                                       ^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+#                                           ^ source.terraform meta.block.terraform meta.braces.terraform
+#                                            ^ source.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#                                             ^ source.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#                                              ^^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#                                                   ^^^ source.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
 >  }
-#^^ scope.terraform meta.block.terraform meta.braces.terraform
-#  ^ scope.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
+#^^ source.terraform meta.block.terraform meta.braces.terraform
+#  ^ source.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >

--- a/tests/snapshot/terraform/expressions_functions.tf.snap
+++ b/tests/snapshot/terraform/expressions_functions.tf.snap
@@ -1,348 +1,348 @@
 ># numeric
-#^ scope.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^ scope.terraform comment.line.terraform
+#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
+# ^^^^^^^^ source.terraform comment.line.terraform
 >
 >abs(23)
-#^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#   ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#    ^^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#      ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#   ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#    ^^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#      ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >ceil(5)
-#^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#    ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#     ^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#      ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#    ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#     ^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#      ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >floor(5)
-#^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#     ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#      ^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#       ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#     ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#      ^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#       ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >log(50, 10)
-#^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#   ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#    ^^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#      ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#       ^ scope.terraform meta.function-call.terraform
-#        ^^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#          ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#   ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#    ^^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#      ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#       ^ source.terraform meta.function-call.terraform
+#        ^^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#          ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >max(12, 54, 3)
-#^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#   ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#    ^^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#      ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#       ^ scope.terraform meta.function-call.terraform
-#        ^^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#          ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#           ^ scope.terraform meta.function-call.terraform
-#            ^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#             ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#   ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#    ^^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#      ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#       ^ source.terraform meta.function-call.terraform
+#        ^^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#          ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#           ^ source.terraform meta.function-call.terraform
+#            ^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#             ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >min(12, 54, 3)
-#^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#   ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#    ^^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#      ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#       ^ scope.terraform meta.function-call.terraform
-#        ^^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#          ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#           ^ scope.terraform meta.function-call.terraform
-#            ^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#             ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#   ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#    ^^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#      ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#       ^ source.terraform meta.function-call.terraform
+#        ^^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#          ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#           ^ source.terraform meta.function-call.terraform
+#            ^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#             ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >parseint("100", 10)
-#^^^^^^^^ scope.terraform meta.function-call.terraform variable.function.terraform
-#        ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#         ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#             ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#              ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#               ^ scope.terraform meta.function-call.terraform
-#                ^^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#                  ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^^^^ source.terraform meta.function-call.terraform variable.function.terraform
+#        ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#         ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#             ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#              ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#               ^ source.terraform meta.function-call.terraform
+#                ^^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#                  ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >pow(3, 2)
-#^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#   ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#    ^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#     ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#      ^ scope.terraform meta.function-call.terraform
-#       ^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#        ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#   ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#    ^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#     ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#      ^ source.terraform meta.function-call.terraform
+#       ^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#        ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >signum(-13)
-#^^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#      ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#       ^ scope.terraform meta.function-call.terraform keyword.operator.arithmetic.terraform
-#        ^^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#          ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#      ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#       ^ source.terraform meta.function-call.terraform keyword.operator.arithmetic.terraform
+#        ^^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#          ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >
 ># string
-#^ scope.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^ scope.terraform comment.line.terraform
+#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
+# ^^^^^^^ source.terraform comment.line.terraform
 >
 >chomp("hello\n")
-#^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#     ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#      ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#       ^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#            ^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform constant.character.escape.terraform
-#              ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#               ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#     ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#      ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#       ^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#            ^^ source.terraform meta.function-call.terraform string.quoted.double.terraform constant.character.escape.terraform
+#              ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#               ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >format("Hello, %s!", "Ander")
-#^^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#      ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#       ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#        ^^^^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                  ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                   ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                    ^ scope.terraform meta.function-call.terraform
-#                     ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                      ^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                           ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                            ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#      ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#       ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#        ^^^^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                  ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                   ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                    ^ source.terraform meta.function-call.terraform
+#                     ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                      ^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                           ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                            ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >formatlist("Hello, %s!", ["Valentina", "Ander", "Olivia", "Sam"])
-#^^^^^^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#          ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#           ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#            ^^^^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                      ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                       ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                        ^ scope.terraform meta.function-call.terraform
-#                         ^ scope.terraform meta.function-call.terraform punctuation.section.brackets.begin.terraform
-#                          ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                           ^^^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                                    ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                     ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                                      ^ scope.terraform meta.function-call.terraform
-#                                       ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                                        ^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                                             ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                              ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                                               ^ scope.terraform meta.function-call.terraform
-#                                                ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                                                 ^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                                                       ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                                        ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                                                         ^ scope.terraform meta.function-call.terraform
-#                                                          ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                                                           ^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                                                              ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                                               ^ scope.terraform meta.function-call.terraform punctuation.section.brackets.end.terraform
-#                                                                ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#          ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#           ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#            ^^^^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                      ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                       ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                        ^ source.terraform meta.function-call.terraform
+#                         ^ source.terraform meta.function-call.terraform punctuation.section.brackets.begin.terraform
+#                          ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                           ^^^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                                    ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                     ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                                      ^ source.terraform meta.function-call.terraform
+#                                       ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                                        ^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                                             ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                              ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                                               ^ source.terraform meta.function-call.terraform
+#                                                ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                                                 ^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                                                       ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                                        ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                                                         ^ source.terraform meta.function-call.terraform
+#                                                          ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                                                           ^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                                                              ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                                               ^ source.terraform meta.function-call.terraform punctuation.section.brackets.end.terraform
+#                                                                ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >formatlist("%s, %s!", "Salutations", ["Valentina", "Ander", "Olivia", "Sam"])
-#^^^^^^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#          ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#           ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#            ^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                   ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                    ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                     ^ scope.terraform meta.function-call.terraform
-#                      ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                       ^^^^^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                                  ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                   ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                                    ^ scope.terraform meta.function-call.terraform
-#                                     ^ scope.terraform meta.function-call.terraform punctuation.section.brackets.begin.terraform
-#                                      ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                                       ^^^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                                                ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                                 ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                                                  ^ scope.terraform meta.function-call.terraform
-#                                                   ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                                                    ^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                                                         ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                                          ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                                                           ^ scope.terraform meta.function-call.terraform
-#                                                            ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                                                             ^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                                                                   ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                                                    ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                                                                     ^ scope.terraform meta.function-call.terraform
-#                                                                      ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                                                                       ^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                                                                          ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                                                           ^ scope.terraform meta.function-call.terraform punctuation.section.brackets.end.terraform
-#                                                                            ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#          ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#           ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#            ^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                   ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                    ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                     ^ source.terraform meta.function-call.terraform
+#                      ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                       ^^^^^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                                  ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                   ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                                    ^ source.terraform meta.function-call.terraform
+#                                     ^ source.terraform meta.function-call.terraform punctuation.section.brackets.begin.terraform
+#                                      ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                                       ^^^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                                                ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                                 ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                                                  ^ source.terraform meta.function-call.terraform
+#                                                   ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                                                    ^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                                                         ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                                          ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                                                           ^ source.terraform meta.function-call.terraform
+#                                                            ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                                                             ^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                                                                   ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                                                    ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                                                                     ^ source.terraform meta.function-call.terraform
+#                                                                      ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                                                                       ^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                                                                          ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                                                           ^ source.terraform meta.function-call.terraform punctuation.section.brackets.end.terraform
+#                                                                            ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >"  items: ${indent(2, "[\n  foo,\n  bar,\n]\n")}"
-#^ scope.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-# ^^^^^^^^ scope.terraform string.quoted.double.terraform
-#         ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform
-#          ^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
-#            ^^^^^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform support.function.builtin.terraform
-#                  ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#                   ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#                    ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform punctuation.separator.terraform
-#                     ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform
-#                      ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                       ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform
-#                        ^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform constant.character.escape.terraform
-#                          ^^^^^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform
-#                                ^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform constant.character.escape.terraform
-#                                  ^^^^^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform
-#                                        ^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform constant.character.escape.terraform
-#                                          ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform
-#                                           ^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform constant.character.escape.terraform
-#                                             ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                              ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
-#                                               ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
-#                                                ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^ source.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+# ^^^^^^^^ source.terraform string.quoted.double.terraform
+#         ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform
+#          ^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
+#            ^^^^^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform support.function.builtin.terraform
+#                  ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#                   ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#                    ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform punctuation.separator.terraform
+#                     ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform
+#                      ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                       ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform
+#                        ^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform constant.character.escape.terraform
+#                          ^^^^^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform
+#                                ^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform constant.character.escape.terraform
+#                                  ^^^^^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform
+#                                        ^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform constant.character.escape.terraform
+#                                          ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform
+#                                           ^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform constant.character.escape.terraform
+#                                             ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                              ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#                                               ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
+#                                                ^ source.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >join(", ", ["foo", "bar", "baz"])
-#^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#    ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#     ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#      ^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#        ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#         ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#          ^ scope.terraform meta.function-call.terraform
-#           ^ scope.terraform meta.function-call.terraform punctuation.section.brackets.begin.terraform
-#            ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#             ^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                 ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                  ^ scope.terraform meta.function-call.terraform
-#                   ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                    ^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                       ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                        ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                         ^ scope.terraform meta.function-call.terraform
-#                          ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                           ^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                              ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                               ^ scope.terraform meta.function-call.terraform punctuation.section.brackets.end.terraform
-#                                ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#    ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#     ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#      ^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#        ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#         ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#          ^ source.terraform meta.function-call.terraform
+#           ^ source.terraform meta.function-call.terraform punctuation.section.brackets.begin.terraform
+#            ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#             ^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                 ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                  ^ source.terraform meta.function-call.terraform
+#                   ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                    ^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                       ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                        ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                         ^ source.terraform meta.function-call.terraform
+#                          ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                           ^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                              ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                               ^ source.terraform meta.function-call.terraform punctuation.section.brackets.end.terraform
+#                                ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >lower("HELLO")
-#^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#     ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#      ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#       ^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#            ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#             ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#     ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#      ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#       ^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#            ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#             ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >regex("[a-z]+", "53453453.345345aaabbbccc23454")
-#^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#     ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#      ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#       ^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#             ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#              ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#               ^ scope.terraform meta.function-call.terraform
-#                ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                                              ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                               ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#     ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#      ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#       ^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#             ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#              ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#               ^ source.terraform meta.function-call.terraform
+#                ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                                              ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                               ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >regexall("[a-z]+", "1234abcd5678efgh9")
-#^^^^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#        ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#         ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                 ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                  ^ scope.terraform meta.function-call.terraform
-#                   ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                    ^^^^^^^^^^^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                                     ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                      ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#        ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#         ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                 ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                  ^ source.terraform meta.function-call.terraform
+#                   ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                    ^^^^^^^^^^^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                                     ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                      ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >replace("1 + 2 + 3", "+", "-")
-#^^^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#       ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#        ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#         ^^^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                  ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                   ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                    ^ scope.terraform meta.function-call.terraform
-#                     ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                      ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                       ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                        ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                         ^ scope.terraform meta.function-call.terraform
-#                          ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                           ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                            ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                             ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#       ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#        ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#         ^^^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                  ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                   ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                    ^ source.terraform meta.function-call.terraform
+#                     ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                      ^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                       ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                        ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                         ^ source.terraform meta.function-call.terraform
+#                          ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                           ^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                            ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                             ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >split(",", "foo,bar,baz")
-#^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#     ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#      ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#       ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#        ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#         ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#          ^ scope.terraform meta.function-call.terraform
-#           ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#            ^^^^^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                       ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                        ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#     ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#      ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#       ^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#        ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#         ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#          ^ source.terraform meta.function-call.terraform
+#           ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#            ^^^^^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                       ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                        ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >strrev("hello")
-#^^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#      ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#       ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#        ^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#             ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#              ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#      ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#       ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#        ^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#             ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#              ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >substr("hello world", 1, 4)
-#^^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#      ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#       ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#        ^^^^^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                   ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                    ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                     ^ scope.terraform meta.function-call.terraform
-#                      ^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#                       ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                        ^ scope.terraform meta.function-call.terraform
-#                         ^ scope.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#                          ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#      ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#       ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#        ^^^^^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                   ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                    ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                     ^ source.terraform meta.function-call.terraform
+#                      ^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#                       ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                        ^ source.terraform meta.function-call.terraform
+#                         ^ source.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#                          ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >title("hello world")
-#^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#     ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#      ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#       ^^^^^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                  ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                   ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#     ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#      ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#       ^^^^^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                  ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                   ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >trim("?!hello?!", "!?")
-#^^^^ scope.terraform meta.function-call.terraform variable.function.terraform
-#    ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#     ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#      ^^^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#               ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                 ^ scope.terraform meta.function-call.terraform
-#                  ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                   ^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                     ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                      ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^ source.terraform meta.function-call.terraform variable.function.terraform
+#    ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#     ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#      ^^^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#               ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                 ^ source.terraform meta.function-call.terraform
+#                  ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                   ^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                     ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                      ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >trimprefix("helloworld", "hello")
-#^^^^^^^^^^ scope.terraform meta.function-call.terraform variable.function.terraform
-#          ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#           ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#            ^^^^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                      ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                       ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                        ^ scope.terraform meta.function-call.terraform
-#                         ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                          ^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                               ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^^^^^^ source.terraform meta.function-call.terraform variable.function.terraform
+#          ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#           ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#            ^^^^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                      ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                       ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                        ^ source.terraform meta.function-call.terraform
+#                         ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                          ^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                               ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >trimsuffix("helloworld", "world")
-#^^^^^^^^^^ scope.terraform meta.function-call.terraform variable.function.terraform
-#          ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#           ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#            ^^^^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                      ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                       ^ scope.terraform meta.function-call.terraform punctuation.separator.terraform
-#                        ^ scope.terraform meta.function-call.terraform
-#                         ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                          ^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                               ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^^^^^^ source.terraform meta.function-call.terraform variable.function.terraform
+#          ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#           ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#            ^^^^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                      ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                       ^ source.terraform meta.function-call.terraform punctuation.separator.terraform
+#                        ^ source.terraform meta.function-call.terraform
+#                         ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                          ^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                               ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >trimspace("  hello\n\n")
-#^^^^^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#         ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#          ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#           ^^^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#                  ^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform constant.character.escape.terraform
-#                    ^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform constant.character.escape.terraform
-#                      ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                       ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#         ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#          ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#           ^^^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#                  ^^ source.terraform meta.function-call.terraform string.quoted.double.terraform constant.character.escape.terraform
+#                    ^^ source.terraform meta.function-call.terraform string.quoted.double.terraform constant.character.escape.terraform
+#                      ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                       ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >upper("hello")
-#^^^^^ scope.terraform meta.function-call.terraform support.function.builtin.terraform
-#     ^ scope.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#      ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#       ^^^^^ scope.terraform meta.function-call.terraform string.quoted.double.terraform
-#            ^ scope.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#             ^ scope.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
+#     ^ source.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#      ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#       ^^^^^ source.terraform meta.function-call.terraform string.quoted.double.terraform
+#            ^ source.terraform meta.function-call.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#             ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >

--- a/tests/snapshot/terraform/expressions_operators.tf.snap
+++ b/tests/snapshot/terraform/expressions_operators.tf.snap
@@ -1,80 +1,80 @@
 ># arithmetic
-#^ scope.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^^^^ scope.terraform comment.line.terraform
+#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
+# ^^^^^^^^^^^ source.terraform comment.line.terraform
 >
 >1 + 2 * 3 / 4
-#^ scope.terraform constant.numeric.integer.terraform
-# ^ scope.terraform
-#  ^ scope.terraform keyword.operator.arithmetic.terraform
-#   ^ scope.terraform
-#    ^ scope.terraform constant.numeric.integer.terraform
-#     ^ scope.terraform
-#      ^ scope.terraform keyword.operator.arithmetic.terraform
-#       ^ scope.terraform
-#        ^ scope.terraform constant.numeric.integer.terraform
-#         ^ scope.terraform
-#          ^ scope.terraform keyword.operator.arithmetic.terraform
-#           ^ scope.terraform
-#            ^ scope.terraform constant.numeric.integer.terraform
+#^ source.terraform constant.numeric.integer.terraform
+# ^ source.terraform
+#  ^ source.terraform keyword.operator.arithmetic.terraform
+#   ^ source.terraform
+#    ^ source.terraform constant.numeric.integer.terraform
+#     ^ source.terraform
+#      ^ source.terraform keyword.operator.arithmetic.terraform
+#       ^ source.terraform
+#        ^ source.terraform constant.numeric.integer.terraform
+#         ^ source.terraform
+#          ^ source.terraform keyword.operator.arithmetic.terraform
+#           ^ source.terraform
+#            ^ source.terraform constant.numeric.integer.terraform
 >
 >5 % 6
-#^ scope.terraform constant.numeric.integer.terraform
-# ^ scope.terraform
-#  ^ scope.terraform keyword.operator.arithmetic.terraform
-#   ^ scope.terraform
-#    ^ scope.terraform constant.numeric.integer.terraform
+#^ source.terraform constant.numeric.integer.terraform
+# ^ source.terraform
+#  ^ source.terraform keyword.operator.arithmetic.terraform
+#   ^ source.terraform
+#    ^ source.terraform constant.numeric.integer.terraform
 >
 >-thing
-#^ scope.terraform keyword.operator.arithmetic.terraform
-# ^^^^^^ scope.terraform
+#^ source.terraform keyword.operator.arithmetic.terraform
+# ^^^^^^ source.terraform
 >
 ># equality
-#^ scope.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^^ scope.terraform comment.line.terraform
+#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
+# ^^^^^^^^^ source.terraform comment.line.terraform
 >
 >thing1 == thing2
-#^^^^^^^ scope.terraform
-#       ^^ scope.terraform keyword.operator.terraform
-#         ^^^^^^^^ scope.terraform
+#^^^^^^^ source.terraform
+#       ^^ source.terraform keyword.operator.terraform
+#         ^^^^^^^^ source.terraform
 >thing1 != thing2
-#^^^^^^^ scope.terraform
-#       ^^ scope.terraform keyword.operator.terraform
-#         ^^^^^^^^ scope.terraform
+#^^^^^^^ source.terraform
+#       ^^ source.terraform keyword.operator.terraform
+#         ^^^^^^^^ source.terraform
 >
 ># comparison
-#^ scope.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^^^^ scope.terraform comment.line.terraform
+#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
+# ^^^^^^^^^^^ source.terraform comment.line.terraform
 >
 >thing1 > thing2
-#^^^^^^^ scope.terraform
-#       ^ scope.terraform keyword.operator.terraform
-#        ^^^^^^^^ scope.terraform
+#^^^^^^^ source.terraform
+#       ^ source.terraform keyword.operator.terraform
+#        ^^^^^^^^ source.terraform
 >thing1 >= thing2
-#^^^^^^^ scope.terraform
-#       ^^ scope.terraform keyword.operator.terraform
-#         ^^^^^^^^ scope.terraform
+#^^^^^^^ source.terraform
+#       ^^ source.terraform keyword.operator.terraform
+#         ^^^^^^^^ source.terraform
 >thing1 < thing2
-#^^^^^^^ scope.terraform
-#       ^ scope.terraform keyword.operator.terraform
-#        ^^^^^^^^ scope.terraform
+#^^^^^^^ source.terraform
+#       ^ source.terraform keyword.operator.terraform
+#        ^^^^^^^^ source.terraform
 >thing1 <= thing2
-#^^^^^^^ scope.terraform
-#       ^^ scope.terraform keyword.operator.terraform
-#         ^^^^^^^^ scope.terraform
+#^^^^^^^ source.terraform
+#       ^^ source.terraform keyword.operator.terraform
+#         ^^^^^^^^ source.terraform
 >
 ># logical
-#^ scope.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^ scope.terraform comment.line.terraform
+#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
+# ^^^^^^^^ source.terraform comment.line.terraform
 >
 >thing1 || thing2
-#^^^^^^^ scope.terraform
-#       ^^ scope.terraform keyword.operator.logical.terraform
-#         ^^^^^^^^ scope.terraform
+#^^^^^^^ source.terraform
+#       ^^ source.terraform keyword.operator.logical.terraform
+#         ^^^^^^^^ source.terraform
 >thing1 && thing2
-#^^^^^^^ scope.terraform
-#       ^^ scope.terraform keyword.operator.logical.terraform
-#         ^^^^^^^^ scope.terraform
+#^^^^^^^ source.terraform
+#       ^^ source.terraform keyword.operator.logical.terraform
+#         ^^^^^^^^ source.terraform
 >!thing1
-#^ scope.terraform keyword.operator.logical.terraform
-# ^^^^^^^ scope.terraform
+#^ source.terraform keyword.operator.logical.terraform
+# ^^^^^^^ source.terraform
 >

--- a/tests/snapshot/terraform/expressions_splat.tf.snap
+++ b/tests/snapshot/terraform/expressions_splat.tf.snap
@@ -1,38 +1,38 @@
 >[for o in var.list : o.id]
-#^ scope.terraform punctuation.section.brackets.begin.terraform
-# ^^^ scope.terraform keyword.control.terraform
-#    ^ scope.terraform
-#     ^ scope.terraform variable.other.readwrite.terraform
-#      ^ scope.terraform
-#       ^^ scope.terraform keyword.operator.word.terraform
-#         ^ scope.terraform
-#          ^^^ scope.terraform support.constant.terraform
-#             ^ scope.terraform keyword.operator.accessor.terraform
-#              ^^^^ scope.terraform variable.other.member.terraform
-#                  ^ scope.terraform
-#                   ^ scope.terraform keyword.operator.terraform
-#                    ^ scope.terraform
-#                     ^ scope.terraform variable.other.readwrite.terraform
-#                      ^ scope.terraform keyword.operator.accessor.terraform
-#                       ^^ scope.terraform variable.other.member.terraform
-#                         ^ scope.terraform punctuation.section.brackets.end.terraform
+#^ source.terraform punctuation.section.brackets.begin.terraform
+# ^^^ source.terraform keyword.control.terraform
+#    ^ source.terraform
+#     ^ source.terraform variable.other.readwrite.terraform
+#      ^ source.terraform
+#       ^^ source.terraform keyword.operator.word.terraform
+#         ^ source.terraform
+#          ^^^ source.terraform support.constant.terraform
+#             ^ source.terraform keyword.operator.accessor.terraform
+#              ^^^^ source.terraform variable.other.member.terraform
+#                  ^ source.terraform
+#                   ^ source.terraform keyword.operator.terraform
+#                    ^ source.terraform
+#                     ^ source.terraform variable.other.readwrite.terraform
+#                      ^ source.terraform keyword.operator.accessor.terraform
+#                       ^^ source.terraform variable.other.member.terraform
+#                         ^ source.terraform punctuation.section.brackets.end.terraform
 >
 >var.list[*].id
-#^^^ scope.terraform support.constant.terraform
-#   ^ scope.terraform keyword.operator.accessor.terraform
-#    ^^^^ scope.terraform variable.other.member.terraform
-#        ^^^ scope.terraform
-#           ^ scope.terraform keyword.operator.accessor.terraform
-#            ^^ scope.terraform variable.other.member.terraform
+#^^^ source.terraform support.constant.terraform
+#   ^ source.terraform keyword.operator.accessor.terraform
+#    ^^^^ source.terraform variable.other.member.terraform
+#        ^^^ source.terraform
+#           ^ source.terraform keyword.operator.accessor.terraform
+#            ^^ source.terraform variable.other.member.terraform
 >
 >var.list[*].interfaces[0].name
-#^^^ scope.terraform support.constant.terraform
-#   ^ scope.terraform keyword.operator.accessor.terraform
-#    ^^^^ scope.terraform variable.other.member.terraform
-#        ^^^ scope.terraform
-#           ^ scope.terraform keyword.operator.accessor.terraform
-#            ^^^^^^^^^^ scope.terraform variable.other.member.terraform
-#                      ^^^ scope.terraform
-#                         ^ scope.terraform keyword.operator.accessor.terraform
-#                          ^^^^ scope.terraform variable.other.member.terraform
+#^^^ source.terraform support.constant.terraform
+#   ^ source.terraform keyword.operator.accessor.terraform
+#    ^^^^ source.terraform variable.other.member.terraform
+#        ^^^ source.terraform
+#           ^ source.terraform keyword.operator.accessor.terraform
+#            ^^^^^^^^^^ source.terraform variable.other.member.terraform
+#                      ^^^ source.terraform
+#                         ^ source.terraform keyword.operator.accessor.terraform
+#                          ^^^^ source.terraform variable.other.member.terraform
 >

--- a/tests/snapshot/terraform/expressions_strings.tf.snap
+++ b/tests/snapshot/terraform/expressions_strings.tf.snap
@@ -1,199 +1,199 @@
 >"hello"
-#^ scope.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-# ^^^^^ scope.terraform string.quoted.double.terraform
-#      ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^ source.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+# ^^^^^ source.terraform string.quoted.double.terraform
+#      ^ source.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >
 >"\n\r\t\"\\"
-#^ scope.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-# ^^ scope.terraform string.quoted.double.terraform constant.character.escape.terraform
-#   ^^ scope.terraform string.quoted.double.terraform constant.character.escape.terraform
-#     ^^ scope.terraform string.quoted.double.terraform constant.character.escape.terraform
-#       ^^ scope.terraform string.quoted.double.terraform constant.character.escape.terraform
-#         ^^ scope.terraform string.quoted.double.terraform constant.character.escape.terraform
-#           ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^ source.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+# ^^ source.terraform string.quoted.double.terraform constant.character.escape.terraform
+#   ^^ source.terraform string.quoted.double.terraform constant.character.escape.terraform
+#     ^^ source.terraform string.quoted.double.terraform constant.character.escape.terraform
+#       ^^ source.terraform string.quoted.double.terraform constant.character.escape.terraform
+#         ^^ source.terraform string.quoted.double.terraform constant.character.escape.terraform
+#           ^ source.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >
 >"$${}"
-#^ scope.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-# ^^^^ scope.terraform string.quoted.double.terraform
-#     ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^ source.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+# ^^^^ source.terraform string.quoted.double.terraform
+#     ^ source.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >
 >"%%{}"
-#^ scope.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-# ^^^^ scope.terraform string.quoted.double.terraform
-#     ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^ source.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+# ^^^^ source.terraform string.quoted.double.terraform
+#     ^ source.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >
 >thing = <<EOT
-#^^^^^ scope.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#     ^ scope.terraform variable.declaration.terraform
-#      ^ scope.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#       ^ scope.terraform variable.declaration.terraform
-#        ^^ scope.terraform string.unquoted.heredoc.terraform keyword.operator.heredoc.terraform
-#          ^^^ scope.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
+#^^^^^ source.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#     ^ source.terraform variable.declaration.terraform
+#      ^ source.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#       ^ source.terraform variable.declaration.terraform
+#        ^^ source.terraform string.unquoted.heredoc.terraform keyword.operator.heredoc.terraform
+#          ^^^ source.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
 >hello
-#^^^^^^ scope.terraform string.unquoted.heredoc.terraform
+#^^^^^^ source.terraform string.unquoted.heredoc.terraform
 >world
-#^^^^^^ scope.terraform string.unquoted.heredoc.terraform
+#^^^^^^ source.terraform string.unquoted.heredoc.terraform
 >EOT
-#^^^^ scope.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
+#^^^^ source.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
 >
 >block {
-#^^^^^ scope.terraform meta.block.terraform entity.name.label.terraform
-#     ^ scope.terraform meta.block.terraform
-#      ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^ source.terraform meta.block.terraform entity.name.label.terraform
+#     ^ source.terraform meta.block.terraform
+#      ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  value = <<EOT
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#       ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#        ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#         ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#          ^^ scope.terraform meta.block.terraform string.unquoted.heredoc.terraform keyword.operator.heredoc.terraform
-#            ^^^ scope.terraform meta.block.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#       ^ source.terraform meta.block.terraform variable.declaration.terraform
+#        ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#         ^ source.terraform meta.block.terraform variable.declaration.terraform
+#          ^^ source.terraform meta.block.terraform string.unquoted.heredoc.terraform keyword.operator.heredoc.terraform
+#            ^^^ source.terraform meta.block.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
 >hello
-#^^^^^^ scope.terraform meta.block.terraform string.unquoted.heredoc.terraform
+#^^^^^^ source.terraform meta.block.terraform string.unquoted.heredoc.terraform
 >world
-#^^^^^^ scope.terraform meta.block.terraform string.unquoted.heredoc.terraform
+#^^^^^^ source.terraform meta.block.terraform string.unquoted.heredoc.terraform
 >EOT
-#^^^^ scope.terraform meta.block.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
+#^^^^ source.terraform meta.block.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >block {
-#^^^^^ scope.terraform meta.block.terraform entity.name.label.terraform
-#     ^ scope.terraform meta.block.terraform
-#      ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^ source.terraform meta.block.terraform entity.name.label.terraform
+#     ^ source.terraform meta.block.terraform
+#      ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  value = <<-EOT
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#       ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#        ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#         ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#          ^^^ scope.terraform meta.block.terraform string.unquoted.heredoc.terraform keyword.operator.heredoc.terraform
-#             ^^^ scope.terraform meta.block.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#       ^ source.terraform meta.block.terraform variable.declaration.terraform
+#        ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#         ^ source.terraform meta.block.terraform variable.declaration.terraform
+#          ^^^ source.terraform meta.block.terraform string.unquoted.heredoc.terraform keyword.operator.heredoc.terraform
+#             ^^^ source.terraform meta.block.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
 >  hello
-#^^^^^^^^ scope.terraform meta.block.terraform string.unquoted.heredoc.terraform
+#^^^^^^^^ source.terraform meta.block.terraform string.unquoted.heredoc.terraform
 >    world
-#^^^^^^^^^^ scope.terraform meta.block.terraform string.unquoted.heredoc.terraform
+#^^^^^^^^^^ source.terraform meta.block.terraform string.unquoted.heredoc.terraform
 >  EOT
-#^^^^^^ scope.terraform meta.block.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
+#^^^^^^ source.terraform meta.block.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >"Hello, ${var.name}!"
-#^ scope.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-# ^^^^^^ scope.terraform string.quoted.double.terraform
-#       ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform
-#        ^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
-#          ^^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform support.constant.terraform
-#             ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.operator.accessor.terraform
-#              ^^^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform variable.other.member.terraform
-#                  ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
-#                   ^ scope.terraform string.quoted.double.terraform
-#                    ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^ source.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+# ^^^^^^ source.terraform string.quoted.double.terraform
+#       ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform
+#        ^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
+#          ^^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform support.constant.terraform
+#             ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.operator.accessor.terraform
+#              ^^^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform variable.other.member.terraform
+#                  ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
+#                   ^ source.terraform string.quoted.double.terraform
+#                    ^ source.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >
 >"Hello, %{ if var.name != "" }${var.name}%{ else }unnamed%{ endif }!"
-#^ scope.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-# ^^^^^^ scope.terraform string.quoted.double.terraform
-#       ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform
-#        ^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
-#          ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform
-#           ^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.control.terraform
-#             ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform
-#              ^^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform support.constant.terraform
-#                 ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.operator.accessor.terraform
-#                  ^^^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform variable.other.member.terraform
-#                      ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform
-#                       ^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.operator.terraform
-#                         ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform
-#                          ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                           ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                            ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform
-#                             ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
-#                              ^^^^^^^^^^ scope.terraform string.quoted.double.terraform
-#                                        ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform
-#                                         ^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
-#                                           ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform
-#                                            ^^^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.control.terraform
-#                                                ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform
-#                                                 ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
-#                                                  ^^^^^^ scope.terraform string.quoted.double.terraform
-#                                                        ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform
-#                                                         ^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
-#                                                           ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform
-#                                                            ^^^^^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.control.terraform
-#                                                                 ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform
-#                                                                  ^ scope.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
-#                                                                   ^ scope.terraform string.quoted.double.terraform
-#                                                                    ^ scope.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^ source.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+# ^^^^^^ source.terraform string.quoted.double.terraform
+#       ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform
+#        ^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
+#          ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform
+#           ^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.control.terraform
+#             ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform
+#              ^^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform support.constant.terraform
+#                 ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.operator.accessor.terraform
+#                  ^^^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform variable.other.member.terraform
+#                      ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform
+#                       ^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.operator.terraform
+#                         ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform
+#                          ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                           ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                            ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform
+#                             ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
+#                              ^^^^^^^^^^ source.terraform string.quoted.double.terraform
+#                                        ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform
+#                                         ^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
+#                                           ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform
+#                                            ^^^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.control.terraform
+#                                                ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform
+#                                                 ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
+#                                                  ^^^^^^ source.terraform string.quoted.double.terraform
+#                                                        ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform
+#                                                         ^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
+#                                                           ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform
+#                                                            ^^^^^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.control.terraform
+#                                                                 ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform
+#                                                                  ^ source.terraform string.quoted.double.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
+#                                                                   ^ source.terraform string.quoted.double.terraform
+#                                                                    ^ source.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >
 ><<EOT
-#^^ scope.terraform string.unquoted.heredoc.terraform keyword.operator.heredoc.terraform
-#  ^^^ scope.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
+#^^ source.terraform string.unquoted.heredoc.terraform keyword.operator.heredoc.terraform
+#  ^^^ source.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
 >%{ for ip in aws_instance.example.*.private_ip }
-#^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
-#  ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#   ^^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.control.terraform
-#      ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#       ^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.readwrite.terraform
-#         ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#          ^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.control.terraform
-#            ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#             ^^^^^^^^^^^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.readwrite.terraform
-#                         ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.operator.accessor.terraform
-#                          ^^^^^^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.member.terraform
-#                                 ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.operator.accessor.terraform
-#                                  ^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#                                    ^^^^^^^^^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.member.terraform
-#                                              ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#                                               ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
+#^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
+#  ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#   ^^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.control.terraform
+#      ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#       ^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.readwrite.terraform
+#         ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#          ^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.control.terraform
+#            ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#             ^^^^^^^^^^^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.readwrite.terraform
+#                         ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.operator.accessor.terraform
+#                          ^^^^^^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.member.terraform
+#                                 ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.operator.accessor.terraform
+#                                  ^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#                                    ^^^^^^^^^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.member.terraform
+#                                              ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#                                               ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
 >server ${ip}
-#^^^^^^ scope.terraform string.unquoted.heredoc.terraform
-#      ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#       ^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
-#         ^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.readwrite.terraform
-#           ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
+#^^^^^^ source.terraform string.unquoted.heredoc.terraform
+#      ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#       ^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
+#         ^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.readwrite.terraform
+#           ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
 >%{ endfor }
-#^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
-#  ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#   ^^^^^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.control.terraform
-#         ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#          ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
+#^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
+#  ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#   ^^^^^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.control.terraform
+#         ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#          ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
 >EOT
-#^^^^ scope.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
+#^^^^ source.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
 >
 ><<EOT
-#^^ scope.terraform string.unquoted.heredoc.terraform keyword.operator.heredoc.terraform
-#  ^^^ scope.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
+#^^ source.terraform string.unquoted.heredoc.terraform keyword.operator.heredoc.terraform
+#  ^^^ source.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
 >%{ for ip in aws_instance.example.*.private_ip ~}
-#^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
-#  ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#   ^^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.control.terraform
-#      ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#       ^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.readwrite.terraform
-#         ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#          ^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.control.terraform
-#            ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#             ^^^^^^^^^^^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.readwrite.terraform
-#                         ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.operator.accessor.terraform
-#                          ^^^^^^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.member.terraform
-#                                 ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.operator.accessor.terraform
-#                                  ^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#                                    ^^^^^^^^^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.member.terraform
-#                                              ^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.operator.template.right.trim.terraform
-#                                                ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
+#^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
+#  ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#   ^^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.control.terraform
+#      ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#       ^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.readwrite.terraform
+#         ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#          ^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.control.terraform
+#            ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#             ^^^^^^^^^^^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.readwrite.terraform
+#                         ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.operator.accessor.terraform
+#                          ^^^^^^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.member.terraform
+#                                 ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.operator.accessor.terraform
+#                                  ^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#                                    ^^^^^^^^^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.member.terraform
+#                                              ^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.operator.template.right.trim.terraform
+#                                                ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
 >server ${ip}
-#^^^^^^ scope.terraform string.unquoted.heredoc.terraform
-#      ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#       ^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
-#         ^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.readwrite.terraform
-#           ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
+#^^^^^^ source.terraform string.unquoted.heredoc.terraform
+#      ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#       ^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
+#         ^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform variable.other.readwrite.terraform
+#           ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
 >%{ endfor ~}
-#^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
-#  ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
-#   ^^^^^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.control.terraform
-#         ^^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.operator.template.right.trim.terraform
-#           ^ scope.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
+#^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.begin.terraform
+#  ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform
+#   ^^^^^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.control.terraform
+#         ^^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.operator.template.right.trim.terraform
+#           ^ source.terraform string.unquoted.heredoc.terraform meta.interpolation.terraform keyword.other.interpolation.end.terraform
 >EOT
-#^^^^ scope.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
+#^^^^ source.terraform string.unquoted.heredoc.terraform keyword.control.heredoc.terraform
 >
 >
 >

--- a/tests/snapshot/terraform/modules.tf.snap
+++ b/tests/snapshot/terraform/modules.tf.snap
@@ -1,59 +1,59 @@
 >module "servers" {
-#^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#      ^ scope.terraform meta.block.terraform
-#       ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#        ^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#               ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                ^ scope.terraform meta.block.terraform
-#                 ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#      ^ source.terraform meta.block.terraform
+#       ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#        ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#               ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                ^ source.terraform meta.block.terraform
+#                 ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  source = "./app-cluster"
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#        ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#         ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#          ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#           ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#            ^^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#        ^ source.terraform meta.block.terraform variable.declaration.terraform
+#         ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#          ^ source.terraform meta.block.terraform variable.declaration.terraform
+#           ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#            ^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >
 >  servers = 5
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#         ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#          ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#           ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#            ^ scope.terraform meta.block.terraform constant.numeric.integer.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#         ^ source.terraform meta.block.terraform variable.declaration.terraform
+#          ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#           ^ source.terraform meta.block.terraform variable.declaration.terraform
+#            ^ source.terraform meta.block.terraform constant.numeric.integer.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >resource "aws_elb" "example" {
-#^^^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#        ^ scope.terraform meta.block.terraform
-#         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                 ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                  ^ scope.terraform meta.block.terraform
-#                   ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                    ^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                           ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                            ^ scope.terraform meta.block.terraform
-#                             ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#        ^ source.terraform meta.block.terraform
+#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                  ^ source.terraform meta.block.terraform
+#                   ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                    ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                           ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                            ^ source.terraform meta.block.terraform
+#                             ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  # ...
-#^^ scope.terraform meta.block.terraform
-#  ^ scope.terraform meta.block.terraform comment.line.terraform punctuation.definition.comment.terraform
-#   ^^^^ scope.terraform meta.block.terraform comment.line.terraform
+#^^ source.terraform meta.block.terraform
+#  ^ source.terraform meta.block.terraform comment.line.terraform punctuation.definition.comment.terraform
+#   ^^^^ source.terraform meta.block.terraform comment.line.terraform
 >
 >  instances = module.servers.instance_ids
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#           ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#            ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#             ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#              ^^^^^^ scope.terraform meta.block.terraform support.constant.terraform
-#                    ^ scope.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                     ^^^^^^^ scope.terraform meta.block.terraform variable.other.member.terraform
-#                            ^ scope.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                             ^^^^^^^^^^^^ scope.terraform meta.block.terraform variable.other.member.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#           ^ source.terraform meta.block.terraform variable.declaration.terraform
+#            ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#             ^ source.terraform meta.block.terraform variable.declaration.terraform
+#              ^^^^^^ source.terraform meta.block.terraform support.constant.terraform
+#                    ^ source.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                     ^^^^^^^ source.terraform meta.block.terraform variable.other.member.terraform
+#                            ^ source.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                             ^^^^^^^^^^^^ source.terraform meta.block.terraform variable.other.member.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >

--- a/tests/snapshot/terraform/providers.tf.snap
+++ b/tests/snapshot/terraform/providers.tf.snap
@@ -1,29 +1,29 @@
 >provider "google" {
-#^^^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#        ^ scope.terraform meta.block.terraform
-#         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                 ^ scope.terraform meta.block.terraform
-#                  ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#        ^ source.terraform meta.block.terraform
+#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                 ^ source.terraform meta.block.terraform
+#                  ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  project = "acme-app"
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#         ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#          ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#           ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#            ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#             ^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                     ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#         ^ source.terraform meta.block.terraform variable.declaration.terraform
+#          ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#           ^ source.terraform meta.block.terraform variable.declaration.terraform
+#            ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#             ^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                     ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >  region  = "us-central1"
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#        ^^ scope.terraform meta.block.terraform variable.declaration.terraform
-#          ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#           ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#            ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#             ^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                        ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#        ^^ source.terraform meta.block.terraform variable.declaration.terraform
+#          ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#           ^ source.terraform meta.block.terraform variable.declaration.terraform
+#            ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#             ^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                        ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >

--- a/tests/snapshot/terraform/variables_input.tf.snap
+++ b/tests/snapshot/terraform/variables_input.tf.snap
@@ -1,227 +1,227 @@
 ># input variables
-#^ scope.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^^^^^^^^^ scope.terraform comment.line.terraform
+#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
+# ^^^^^^^^^^^^^^^^ source.terraform comment.line.terraform
 >
 >variable "image_id" {
-#^^^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#        ^ scope.terraform meta.block.terraform
-#         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                  ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                   ^ scope.terraform meta.block.terraform
-#                    ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#        ^ source.terraform meta.block.terraform
+#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                  ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                   ^ source.terraform meta.block.terraform
+#                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type = string
-#^^ scope.terraform meta.block.terraform
-#  ^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#      ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#       ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#        ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#         ^^^^^^ scope.terraform meta.block.terraform storage.type.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#      ^ source.terraform meta.block.terraform variable.declaration.terraform
+#       ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#        ^ source.terraform meta.block.terraform variable.declaration.terraform
+#         ^^^^^^ source.terraform meta.block.terraform storage.type.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >variable "availability_zone_names" {
-#^^^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#        ^ scope.terraform meta.block.terraform
-#         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                                 ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                  ^ scope.terraform meta.block.terraform
-#                                   ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#        ^ source.terraform meta.block.terraform
+#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                  ^ source.terraform meta.block.terraform
+#                                   ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type    = list(string)
-#^^ scope.terraform meta.block.terraform
-#  ^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#      ^^^^ scope.terraform meta.block.terraform variable.declaration.terraform
-#          ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#           ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#            ^^^^ scope.terraform meta.block.terraform meta.function-call.terraform support.function.builtin.terraform
-#                ^ scope.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#                 ^^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform storage.type.terraform
-#                       ^ scope.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#      ^^^^ source.terraform meta.block.terraform variable.declaration.terraform
+#          ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#           ^ source.terraform meta.block.terraform variable.declaration.terraform
+#            ^^^^ source.terraform meta.block.terraform meta.function-call.terraform support.function.builtin.terraform
+#                ^ source.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#                 ^^^^^^ source.terraform meta.block.terraform meta.function-call.terraform storage.type.terraform
+#                       ^ source.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >  default = ["us-west-1a"]
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#         ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#          ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#           ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#            ^ scope.terraform meta.block.terraform punctuation.section.brackets.begin.terraform
-#             ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#              ^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                        ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                         ^ scope.terraform meta.block.terraform punctuation.section.brackets.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#         ^ source.terraform meta.block.terraform variable.declaration.terraform
+#          ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#           ^ source.terraform meta.block.terraform variable.declaration.terraform
+#            ^ source.terraform meta.block.terraform punctuation.section.brackets.begin.terraform
+#             ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#              ^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                        ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                         ^ source.terraform meta.block.terraform punctuation.section.brackets.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >variable "docker_ports" {
-#^^^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#        ^ scope.terraform meta.block.terraform
-#         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                      ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                       ^ scope.terraform meta.block.terraform
-#                        ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#        ^ source.terraform meta.block.terraform
+#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                      ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                       ^ source.terraform meta.block.terraform
+#                        ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type = list(object({
-#^^ scope.terraform meta.block.terraform
-#  ^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#      ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#       ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#        ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#         ^^^^ scope.terraform meta.block.terraform meta.function-call.terraform support.function.builtin.terraform
-#             ^ scope.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#              ^^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform support.function.builtin.terraform
-#                    ^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#                     ^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform punctuation.section.braces.begin.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#      ^ source.terraform meta.block.terraform variable.declaration.terraform
+#       ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#        ^ source.terraform meta.block.terraform variable.declaration.terraform
+#         ^^^^ source.terraform meta.block.terraform meta.function-call.terraform support.function.builtin.terraform
+#             ^ source.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#              ^^^^^^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform support.function.builtin.terraform
+#                    ^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#                     ^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform punctuation.section.braces.begin.terraform
 >    internal = number
-#^^^^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform
-#    ^^^^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#            ^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform
-#             ^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#              ^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform
-#               ^^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform storage.type.terraform
+#^^^^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform
+#    ^^^^^^^^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#            ^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform
+#             ^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#              ^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform
+#               ^^^^^^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform storage.type.terraform
 >    external = number
-#^^^^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform
-#    ^^^^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#            ^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform
-#             ^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#              ^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform
-#               ^^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform storage.type.terraform
+#^^^^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform
+#    ^^^^^^^^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#            ^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform
+#             ^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#              ^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform
+#               ^^^^^^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform storage.type.terraform
 >    protocol = string
-#^^^^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform
-#    ^^^^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#            ^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform
-#             ^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#              ^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform
-#               ^^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform storage.type.terraform
+#^^^^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform
+#    ^^^^^^^^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#            ^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform
+#             ^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#              ^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform variable.declaration.terraform
+#               ^^^^^^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform storage.type.terraform
 >  }))
-#^^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform
-#  ^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform punctuation.section.braces.end.terraform
-#   ^ scope.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
-#    ^ scope.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform
+#  ^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform punctuation.section.braces.end.terraform
+#   ^ source.terraform meta.block.terraform meta.function-call.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#    ^ source.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >  default = [
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#         ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#          ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#           ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#            ^ scope.terraform meta.block.terraform punctuation.section.brackets.begin.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#         ^ source.terraform meta.block.terraform variable.declaration.terraform
+#          ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#           ^ source.terraform meta.block.terraform variable.declaration.terraform
+#            ^ source.terraform meta.block.terraform punctuation.section.brackets.begin.terraform
 >    {
-#^^^^ scope.terraform meta.block.terraform
-#    ^ scope.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
+#^^^^ source.terraform meta.block.terraform
+#    ^ source.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
 >      internal = 8300
-#^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#      ^^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
-#              ^ scope.terraform meta.block.terraform meta.braces.terraform
-#               ^ scope.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-#                ^ scope.terraform meta.block.terraform meta.braces.terraform
-#                 ^^^^ scope.terraform meta.block.terraform meta.braces.terraform constant.numeric.integer.terraform
+#^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#      ^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+#              ^ source.terraform meta.block.terraform meta.braces.terraform
+#               ^ source.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#                ^ source.terraform meta.block.terraform meta.braces.terraform
+#                 ^^^^ source.terraform meta.block.terraform meta.braces.terraform constant.numeric.integer.terraform
 >      external = 8300
-#^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#      ^^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
-#              ^ scope.terraform meta.block.terraform meta.braces.terraform
-#               ^ scope.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-#                ^ scope.terraform meta.block.terraform meta.braces.terraform
-#                 ^^^^ scope.terraform meta.block.terraform meta.braces.terraform constant.numeric.integer.terraform
+#^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#      ^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+#              ^ source.terraform meta.block.terraform meta.braces.terraform
+#               ^ source.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#                ^ source.terraform meta.block.terraform meta.braces.terraform
+#                 ^^^^ source.terraform meta.block.terraform meta.braces.terraform constant.numeric.integer.terraform
 >      protocol = "tcp"
-#^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#      ^^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
-#              ^ scope.terraform meta.block.terraform meta.braces.terraform
-#               ^ scope.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-#                ^ scope.terraform meta.block.terraform meta.braces.terraform
-#                 ^ scope.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                  ^^^ scope.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
-#                     ^ scope.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#      ^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+#              ^ source.terraform meta.block.terraform meta.braces.terraform
+#               ^ source.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#                ^ source.terraform meta.block.terraform meta.braces.terraform
+#                 ^ source.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                  ^^^ source.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
+#                     ^ source.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >    }
-#^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#    ^ scope.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
+#^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#    ^ source.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
 >  ]
-#^^ scope.terraform meta.block.terraform
-#  ^ scope.terraform meta.block.terraform punctuation.section.brackets.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^ source.terraform meta.block.terraform punctuation.section.brackets.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >variable "image_id" {
-#^^^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#        ^ scope.terraform meta.block.terraform
-#         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                  ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                   ^ scope.terraform meta.block.terraform
-#                    ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#        ^ source.terraform meta.block.terraform
+#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                  ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                   ^ source.terraform meta.block.terraform
+#                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type        = string
-#^^ scope.terraform meta.block.terraform
-#  ^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#      ^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform
-#              ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#               ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                ^^^^^^ scope.terraform meta.block.terraform storage.type.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#      ^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform
+#              ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#               ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                ^^^^^^ source.terraform meta.block.terraform storage.type.terraform
 >  description = "The id of the machine image (AMI) to use for the server."
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#             ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#              ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#               ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                                                                         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#             ^ source.terraform meta.block.terraform variable.declaration.terraform
+#              ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#               ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                                                                         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >
 >  validation {
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
-#            ^ scope.terraform meta.block.terraform meta.block.terraform
-#             ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+#            ^ source.terraform meta.block.terraform meta.block.terraform
+#             ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >    condition     = length(var.image_id) > 4 && substr(var.image_id, 0, 4) == "ami-"
-#^^^^ scope.terraform meta.block.terraform meta.block.terraform
-#    ^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#             ^^^^^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#                  ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#                   ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#                    ^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform support.function.builtin.terraform
-#                          ^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#                           ^^^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform support.constant.terraform
-#                              ^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform keyword.operator.accessor.terraform
-#                               ^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform variable.other.member.terraform
-#                                       ^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
-#                                        ^ scope.terraform meta.block.terraform meta.block.terraform
-#                                         ^ scope.terraform meta.block.terraform meta.block.terraform keyword.operator.terraform
-#                                          ^ scope.terraform meta.block.terraform meta.block.terraform
-#                                           ^ scope.terraform meta.block.terraform meta.block.terraform constant.numeric.integer.terraform
-#                                            ^ scope.terraform meta.block.terraform meta.block.terraform
-#                                             ^^ scope.terraform meta.block.terraform meta.block.terraform keyword.operator.logical.terraform
-#                                               ^ scope.terraform meta.block.terraform meta.block.terraform
-#                                                ^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform support.function.builtin.terraform
-#                                                      ^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#                                                       ^^^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform support.constant.terraform
-#                                                          ^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform keyword.operator.accessor.terraform
-#                                                           ^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform variable.other.member.terraform
-#                                                                   ^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform punctuation.separator.terraform
-#                                                                    ^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform
-#                                                                     ^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#                                                                      ^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform punctuation.separator.terraform
-#                                                                       ^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform
-#                                                                        ^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform constant.numeric.integer.terraform
-#                                                                         ^ scope.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
-#                                                                          ^ scope.terraform meta.block.terraform meta.block.terraform
-#                                                                           ^^ scope.terraform meta.block.terraform meta.block.terraform keyword.operator.terraform
-#                                                                             ^ scope.terraform meta.block.terraform meta.block.terraform
-#                                                                              ^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                                                                               ^^^^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                                                                                   ^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^^^ source.terraform meta.block.terraform meta.block.terraform
+#    ^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#             ^^^^^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#                  ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                   ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#                    ^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform support.function.builtin.terraform
+#                          ^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#                           ^^^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform support.constant.terraform
+#                              ^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform keyword.operator.accessor.terraform
+#                               ^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform variable.other.member.terraform
+#                                       ^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#                                        ^ source.terraform meta.block.terraform meta.block.terraform
+#                                         ^ source.terraform meta.block.terraform meta.block.terraform keyword.operator.terraform
+#                                          ^ source.terraform meta.block.terraform meta.block.terraform
+#                                           ^ source.terraform meta.block.terraform meta.block.terraform constant.numeric.integer.terraform
+#                                            ^ source.terraform meta.block.terraform meta.block.terraform
+#                                             ^^ source.terraform meta.block.terraform meta.block.terraform keyword.operator.logical.terraform
+#                                               ^ source.terraform meta.block.terraform meta.block.terraform
+#                                                ^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform support.function.builtin.terraform
+#                                                      ^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#                                                       ^^^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform support.constant.terraform
+#                                                          ^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform keyword.operator.accessor.terraform
+#                                                           ^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform variable.other.member.terraform
+#                                                                   ^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform punctuation.separator.terraform
+#                                                                    ^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform
+#                                                                     ^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#                                                                      ^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform punctuation.separator.terraform
+#                                                                       ^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform
+#                                                                        ^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform constant.numeric.integer.terraform
+#                                                                         ^ source.terraform meta.block.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#                                                                          ^ source.terraform meta.block.terraform meta.block.terraform
+#                                                                           ^^ source.terraform meta.block.terraform meta.block.terraform keyword.operator.terraform
+#                                                                             ^ source.terraform meta.block.terraform meta.block.terraform
+#                                                                              ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                                                                               ^^^^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
+#                                                                                   ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >    error_message = "The image_id value must be a valid AMI id, starting with \"ami-\"."
-#^^^^ scope.terraform meta.block.terraform meta.block.terraform
-#    ^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#                 ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#                  ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#                   ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-#                    ^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                                                                              ^^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform constant.character.escape.terraform
-#                                                                                ^^^^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                                                                                    ^^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform constant.character.escape.terraform
-#                                                                                      ^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                                                                                       ^ scope.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^^^ source.terraform meta.block.terraform meta.block.terraform
+#    ^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#                 ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#                  ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                   ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+#                    ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
+#                                                                              ^^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform constant.character.escape.terraform
+#                                                                                ^^^^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
+#                                                                                    ^^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform constant.character.escape.terraform
+#                                                                                      ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
+#                                                                                       ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >  }
-#^^ scope.terraform meta.block.terraform meta.block.terraform
-#  ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^^ source.terraform meta.block.terraform meta.block.terraform
+#  ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >

--- a/tests/snapshot/terraform/variables_local.tf.snap
+++ b/tests/snapshot/terraform/variables_local.tf.snap
@@ -1,124 +1,124 @@
 >locals {
-#^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#      ^ scope.terraform meta.block.terraform
-#       ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#      ^ source.terraform meta.block.terraform
+#       ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  service_name = "forum"
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#              ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#               ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#                ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                 ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                  ^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                       ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#              ^ source.terraform meta.block.terraform variable.declaration.terraform
+#               ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                  ^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                       ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >  owner        = "Community Team"
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#       ^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform
-#               ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#                ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                 ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                  ^^^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                                ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#       ^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform
+#               ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                  ^^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                                ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >locals {
-#^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#      ^ scope.terraform meta.block.terraform
-#       ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#      ^ source.terraform meta.block.terraform
+#       ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  # Ids for multiple sets of EC2 instances, merged together
-#^^ scope.terraform meta.block.terraform
-#  ^ scope.terraform meta.block.terraform comment.line.terraform punctuation.definition.comment.terraform
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform comment.line.terraform
+#^^ source.terraform meta.block.terraform
+#  ^ source.terraform meta.block.terraform comment.line.terraform punctuation.definition.comment.terraform
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform comment.line.terraform
 >  instance_ids = concat(aws_instance.blue.*.id, aws_instance.green.*.id)
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#              ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#               ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#                ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                 ^^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform support.function.builtin.terraform
-#                       ^ scope.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
-#                        ^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform
-#                                    ^ scope.terraform meta.block.terraform meta.function-call.terraform keyword.operator.accessor.terraform
-#                                     ^^^^ scope.terraform meta.block.terraform meta.function-call.terraform variable.other.member.terraform
-#                                         ^ scope.terraform meta.block.terraform meta.function-call.terraform keyword.operator.accessor.terraform
-#                                          ^^ scope.terraform meta.block.terraform meta.function-call.terraform
-#                                            ^^ scope.terraform meta.block.terraform meta.function-call.terraform variable.other.member.terraform
-#                                              ^ scope.terraform meta.block.terraform meta.function-call.terraform punctuation.separator.terraform
-#                                               ^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform
-#                                                            ^ scope.terraform meta.block.terraform meta.function-call.terraform keyword.operator.accessor.terraform
-#                                                             ^^^^^ scope.terraform meta.block.terraform meta.function-call.terraform variable.other.member.terraform
-#                                                                  ^ scope.terraform meta.block.terraform meta.function-call.terraform keyword.operator.accessor.terraform
-#                                                                   ^^ scope.terraform meta.block.terraform meta.function-call.terraform
-#                                                                     ^^ scope.terraform meta.block.terraform meta.function-call.terraform variable.other.member.terraform
-#                                                                       ^ scope.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#              ^ source.terraform meta.block.terraform variable.declaration.terraform
+#               ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                 ^^^^^^ source.terraform meta.block.terraform meta.function-call.terraform support.function.builtin.terraform
+#                       ^ source.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.begin.terraform
+#                        ^^^^^^^^^^^^ source.terraform meta.block.terraform meta.function-call.terraform
+#                                    ^ source.terraform meta.block.terraform meta.function-call.terraform keyword.operator.accessor.terraform
+#                                     ^^^^ source.terraform meta.block.terraform meta.function-call.terraform variable.other.member.terraform
+#                                         ^ source.terraform meta.block.terraform meta.function-call.terraform keyword.operator.accessor.terraform
+#                                          ^^ source.terraform meta.block.terraform meta.function-call.terraform
+#                                            ^^ source.terraform meta.block.terraform meta.function-call.terraform variable.other.member.terraform
+#                                              ^ source.terraform meta.block.terraform meta.function-call.terraform punctuation.separator.terraform
+#                                               ^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.function-call.terraform
+#                                                            ^ source.terraform meta.block.terraform meta.function-call.terraform keyword.operator.accessor.terraform
+#                                                             ^^^^^ source.terraform meta.block.terraform meta.function-call.terraform variable.other.member.terraform
+#                                                                  ^ source.terraform meta.block.terraform meta.function-call.terraform keyword.operator.accessor.terraform
+#                                                                   ^^ source.terraform meta.block.terraform meta.function-call.terraform
+#                                                                     ^^ source.terraform meta.block.terraform meta.function-call.terraform variable.other.member.terraform
+#                                                                       ^ source.terraform meta.block.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >locals {
-#^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#      ^ scope.terraform meta.block.terraform
-#       ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#      ^ source.terraform meta.block.terraform
+#       ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  # Common tags to be assigned to all resources
-#^^ scope.terraform meta.block.terraform
-#  ^ scope.terraform meta.block.terraform comment.line.terraform punctuation.definition.comment.terraform
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform comment.line.terraform
+#^^ source.terraform meta.block.terraform
+#  ^ source.terraform meta.block.terraform comment.line.terraform punctuation.definition.comment.terraform
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform comment.line.terraform
 >  common_tags = {
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#             ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#              ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#               ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                ^ scope.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#             ^ source.terraform meta.block.terraform variable.declaration.terraform
+#              ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#               ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                ^ source.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
 >    Service = local.service_name
-#^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#    ^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
-#           ^ scope.terraform meta.block.terraform meta.braces.terraform
-#            ^ scope.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-#             ^ scope.terraform meta.block.terraform meta.braces.terraform
-#              ^^^^^ scope.terraform meta.block.terraform meta.braces.terraform support.constant.terraform
-#                   ^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
+#^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#    ^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+#           ^ source.terraform meta.block.terraform meta.braces.terraform
+#            ^ source.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#             ^ source.terraform meta.block.terraform meta.braces.terraform
+#              ^^^^^ source.terraform meta.block.terraform meta.braces.terraform support.constant.terraform
+#                   ^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
 >    Owner   = local.owner
-#^^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#    ^^^^^ scope.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
-#         ^^^ scope.terraform meta.block.terraform meta.braces.terraform
-#            ^ scope.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-#             ^ scope.terraform meta.block.terraform meta.braces.terraform
-#              ^^^^^ scope.terraform meta.block.terraform meta.braces.terraform support.constant.terraform
-#                   ^^^^^^^ scope.terraform meta.block.terraform meta.braces.terraform
+#^^^^ source.terraform meta.block.terraform meta.braces.terraform
+#    ^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+#         ^^^ source.terraform meta.block.terraform meta.braces.terraform
+#            ^ source.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+#             ^ source.terraform meta.block.terraform meta.braces.terraform
+#              ^^^^^ source.terraform meta.block.terraform meta.braces.terraform support.constant.terraform
+#                   ^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform
 >  }
-#^^ scope.terraform meta.block.terraform meta.braces.terraform
-#  ^ scope.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
+#^^ source.terraform meta.block.terraform meta.braces.terraform
+#  ^ source.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >resource "aws_instance" "example" {
-#^^^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#        ^ scope.terraform meta.block.terraform
-#         ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                      ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                       ^ scope.terraform meta.block.terraform
-#                        ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                         ^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                                ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                                 ^ scope.terraform meta.block.terraform
-#                                  ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#        ^ source.terraform meta.block.terraform
+#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                      ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                       ^ source.terraform meta.block.terraform
+#                        ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                         ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                                ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                 ^ source.terraform meta.block.terraform
+#                                  ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  # ...
-#^^ scope.terraform meta.block.terraform
-#  ^ scope.terraform meta.block.terraform comment.line.terraform punctuation.definition.comment.terraform
-#   ^^^^ scope.terraform meta.block.terraform comment.line.terraform
+#^^ source.terraform meta.block.terraform
+#  ^ source.terraform meta.block.terraform comment.line.terraform punctuation.definition.comment.terraform
+#   ^^^^ source.terraform meta.block.terraform comment.line.terraform
 >
 >  tags = local.common_tags
-#^^ scope.terraform meta.block.terraform
-#  ^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#      ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#       ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#        ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#         ^^^^^ scope.terraform meta.block.terraform support.constant.terraform
-#              ^ scope.terraform meta.block.terraform keyword.operator.accessor.terraform
-#               ^^^^^^^^^^^ scope.terraform meta.block.terraform variable.other.member.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#      ^ source.terraform meta.block.terraform variable.declaration.terraform
+#       ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#        ^ source.terraform meta.block.terraform variable.declaration.terraform
+#         ^^^^^ source.terraform meta.block.terraform support.constant.terraform
+#              ^ source.terraform meta.block.terraform keyword.operator.accessor.terraform
+#               ^^^^^^^^^^^ source.terraform meta.block.terraform variable.other.member.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >

--- a/tests/snapshot/terraform/variables_output.tf.snap
+++ b/tests/snapshot/terraform/variables_output.tf.snap
@@ -1,70 +1,70 @@
 >output "instance_ip_addr" {
-#^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#      ^ scope.terraform meta.block.terraform
-#       ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#        ^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                        ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                         ^ scope.terraform meta.block.terraform
-#                          ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#      ^ source.terraform meta.block.terraform
+#       ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#        ^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                        ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                         ^ source.terraform meta.block.terraform
+#                          ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  value = aws_instance.server.private_ip
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#       ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#        ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#         ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#          ^^^^^^^^^^^^ scope.terraform meta.block.terraform
-#                      ^ scope.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                       ^^^^^^ scope.terraform meta.block.terraform variable.other.member.terraform
-#                             ^ scope.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                              ^^^^^^^^^^ scope.terraform meta.block.terraform variable.other.member.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#       ^ source.terraform meta.block.terraform variable.declaration.terraform
+#        ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#         ^ source.terraform meta.block.terraform variable.declaration.terraform
+#          ^^^^^^^^^^^^ source.terraform meta.block.terraform
+#                      ^ source.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                       ^^^^^^ source.terraform meta.block.terraform variable.other.member.terraform
+#                             ^ source.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                              ^^^^^^^^^^ source.terraform meta.block.terraform variable.other.member.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >output "instance_ip_addr" {
-#^^^^^^ scope.terraform meta.block.terraform entity.name.type.terraform
-#      ^ scope.terraform meta.block.terraform
-#       ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#        ^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                        ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-#                         ^ scope.terraform meta.block.terraform
-#                          ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#      ^ source.terraform meta.block.terraform
+#       ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#        ^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                        ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                         ^ source.terraform meta.block.terraform
+#                          ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  value       = aws_instance.server.private_ip
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#       ^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform
-#              ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#               ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                ^^^^^^^^^^^^ scope.terraform meta.block.terraform
-#                            ^ scope.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                             ^^^^^^ scope.terraform meta.block.terraform variable.other.member.terraform
-#                                   ^ scope.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                                    ^^^^^^^^^^ scope.terraform meta.block.terraform variable.other.member.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#       ^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform
+#              ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#               ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                ^^^^^^^^^^^^ source.terraform meta.block.terraform
+#                            ^ source.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                             ^^^^^^ source.terraform meta.block.terraform variable.other.member.terraform
+#                                   ^ source.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                                    ^^^^^^^^^^ source.terraform meta.block.terraform variable.other.member.terraform
 >  description = "The private IP address of the main server instance."
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#             ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#              ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#               ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#                ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-#                                                                    ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#             ^ source.terraform meta.block.terraform variable.declaration.terraform
+#              ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#               ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                                                                    ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >
 >  depends_on = [
-#^^ scope.terraform meta.block.terraform
-#  ^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-#            ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#             ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-#              ^ scope.terraform meta.block.terraform variable.declaration.terraform
-#               ^ scope.terraform meta.block.terraform punctuation.section.brackets.begin.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#            ^ source.terraform meta.block.terraform variable.declaration.terraform
+#             ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#              ^ source.terraform meta.block.terraform variable.declaration.terraform
+#               ^ source.terraform meta.block.terraform punctuation.section.brackets.begin.terraform
 >    aws_security_group_rule.local_access,
-#^^^^ scope.terraform meta.block.terraform
-#    ^^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform variable.other.readwrite.terraform
-#                           ^ scope.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                            ^^^^^^^^^^^^ scope.terraform meta.block.terraform variable.other.member.terraform
-#                                        ^ scope.terraform meta.block.terraform punctuation.separator.terraform
+#^^^^ source.terraform meta.block.terraform
+#    ^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform variable.other.readwrite.terraform
+#                           ^ source.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                            ^^^^^^^^^^^^ source.terraform meta.block.terraform variable.other.member.terraform
+#                                        ^ source.terraform meta.block.terraform punctuation.separator.terraform
 >  ]
-#^^ scope.terraform meta.block.terraform
-#  ^ scope.terraform meta.block.terraform punctuation.section.brackets.end.terraform
+#^^ source.terraform meta.block.terraform
+#  ^ source.terraform meta.block.terraform punctuation.section.brackets.end.terraform
 >}
-#^ scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >

--- a/tests/unit/terraform/basic.tf
+++ b/tests/unit/terraform/basic.tf
@@ -1,119 +1,119 @@
-; SYNTAX TEST "scope.terraform" "basic sample"
+; SYNTAX TEST "source.terraform" "basic sample"
 
 # line comment
-; <- scope.terraform comment.line.terraform punctuation.definition.comment.terraform
-;  ^^^^^^^^^^^^^ scope.terraform comment.line.terraform
+; <- source.terraform comment.line.terraform punctuation.definition.comment.terraform
+;  ^^^^^^^^^^^^^ source.terraform comment.line.terraform
 
 // line comment
-; <-- scope.terraform comment.line.terraform punctuation.definition.comment.terraform
-;   ^^^^^^^^^^^^^ scope.terraform comment.line.terraform
+; <-- source.terraform comment.line.terraform punctuation.definition.comment.terraform
+;   ^^^^^^^^^^^^^ source.terraform comment.line.terraform
 
 /*
-; <~- scope.terraform comment.block.terraform punctuation.definition.comment.terraform
+; <~- source.terraform comment.block.terraform punctuation.definition.comment.terraform
   Block comment
-; ^^^^^^^^^^^^^^^^ scope.terraform comment.block.terraform
+; ^^^^^^^^^^^^^^^^ source.terraform comment.block.terraform
 */
-; <~- scope.terraform comment.block.terraform punctuation.definition.comment.terraform
+; <~- source.terraform comment.block.terraform punctuation.definition.comment.terraform
 
 terraform {
-; <--------- scope.terraform meta.block.terraform entity.name.type.terraform
-;        ^ scope.terraform meta.block.terraform
-;         ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+; <--------- source.terraform meta.block.terraform entity.name.type.terraform
+;        ^ source.terraform meta.block.terraform
+;         ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
   required_providers {
-; ^^ scope.terraform meta.block.terraform
-; ^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
-;                   ^ scope.terraform meta.block.terraform meta.block.terraform
-;                    ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+; ^^ source.terraform meta.block.terraform
+; ^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+;                   ^ source.terraform meta.block.terraform meta.block.terraform
+;                    ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
     azurerm = {
-; ^^^^ scope.terraform meta.block.terraform meta.block.terraform
-;   ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-;          ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-;           ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-;            ^ scope.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
-;             ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
+; ^^^^ source.terraform meta.block.terraform meta.block.terraform
+;   ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+;          ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+;           ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+;            ^ source.terraform meta.block.terraform meta.block.terraform variable.declaration.terraform
+;             ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
       source  = "hashicorp/azurerm"
-; ^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
-;     ^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
-;           ^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
-;             ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-;              ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
-;               ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-;                ^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
-;                                 ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+; ^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+;     ^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+;           ^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+;             ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+;              ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+;               ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;                ^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
+;                                 ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
       version = "~> 2.65"
-; ^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
-;     ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
-;            ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
-;             ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
-;              ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
-;               ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-;                ^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
-;                       ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+; ^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+;     ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform string.unquoted.terraform
+;            ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+;             ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform keyword.operator.terraform
+;              ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+;               ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;                ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
+;                       ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
     }
-; ^^^^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
-;   ^ scope.terraform meta.block.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
+; ^^^^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform
+;   ^ source.terraform meta.block.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
   }
-; ^^ scope.terraform meta.block.terraform meta.block.terraform
-; ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+; ^^ source.terraform meta.block.terraform meta.block.terraform
+; ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
 
   required_version = ">= 1.1.0"
-; <-- scope.terraform meta.block.terraform
-; ^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-;                 ^ scope.terraform meta.block.terraform variable.declaration.terraform
-;                  ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-;                   ^ scope.terraform meta.block.terraform variable.declaration.terraform
-;                    ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-;                     ^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-;                             ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+; <-- source.terraform meta.block.terraform
+; ^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+;                 ^ source.terraform meta.block.terraform variable.declaration.terraform
+;                  ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+;                   ^ source.terraform meta.block.terraform variable.declaration.terraform
+;                    ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;                     ^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+;                             ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 }
-; <- scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+; <- source.terraform meta.block.terraform punctuation.section.block.end.terraform
 
 provider "azurerm" {
-; <-------- scope.terraform meta.block.terraform entity.name.type.terraform
-;       ^ scope.terraform meta.block.terraform
-;        ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-;         ^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-;                ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-;                 ^ scope.terraform meta.block.terraform
-;                  ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+; <-------- source.terraform meta.block.terraform entity.name.type.terraform
+;       ^ source.terraform meta.block.terraform
+;        ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;         ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+;                ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+;                 ^ source.terraform meta.block.terraform
+;                  ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
   features {}
-; <-- scope.terraform meta.block.terraform
-; ^^^^^^^^ scope.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
-;         ^ scope.terraform meta.block.terraform meta.block.terraform
-;          ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
-;           ^ scope.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
+; <-- source.terraform meta.block.terraform
+; ^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
+;         ^ source.terraform meta.block.terraform meta.block.terraform
+;          ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
+;           ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.end.terraform
 }
-; <- scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+; <- source.terraform meta.block.terraform punctuation.section.block.end.terraform
 
 resource "azurerm_resource_group" "rg" {
-; <-------- scope.terraform meta.block.terraform entity.name.type.terraform
-;       ^ scope.terraform meta.block.terraform
-;        ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-;         ^^^^^^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-;                               ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-;                                ^ scope.terraform meta.block.terraform
-;                                 ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-;                                  ^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-;                                    ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
-;                                     ^ scope.terraform meta.block.terraform
-;                                      ^ scope.terraform meta.block.terraform punctuation.section.block.begin.terraform
+; <-------- source.terraform meta.block.terraform entity.name.type.terraform
+;       ^ source.terraform meta.block.terraform
+;        ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;         ^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+;                               ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+;                                ^ source.terraform meta.block.terraform
+;                                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;                                  ^^ source.terraform meta.block.terraform string.quoted.double.terraform
+;                                    ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+;                                     ^ source.terraform meta.block.terraform
+;                                      ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
   name     = "myTFResourceGroup"
-; <-- scope.terraform meta.block.terraform
-; ^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-;     ^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform
-;          ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-;           ^ scope.terraform meta.block.terraform variable.declaration.terraform
-;            ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-;             ^^^^^^^^^^^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-;                              ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+; <-- source.terraform meta.block.terraform
+; ^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+;     ^^^^^ source.terraform meta.block.terraform variable.declaration.terraform
+;          ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+;           ^ source.terraform meta.block.terraform variable.declaration.terraform
+;            ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;             ^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+;                              ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
   location = "westus2"
-; <-- scope.terraform meta.block.terraform
-; ^^^^^^^^ scope.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
-;         ^ scope.terraform meta.block.terraform variable.declaration.terraform
-;          ^ scope.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
-;           ^ scope.terraform meta.block.terraform variable.declaration.terraform
-;            ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-;             ^^^^^^^ scope.terraform meta.block.terraform string.quoted.double.terraform
-;                    ^ scope.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+; <-- source.terraform meta.block.terraform
+; ^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+;         ^ source.terraform meta.block.terraform variable.declaration.terraform
+;          ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+;           ^ source.terraform meta.block.terraform variable.declaration.terraform
+;            ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+;             ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+;                    ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 }
-; <- scope.terraform meta.block.terraform punctuation.section.block.end.terraform
+; <- source.terraform meta.block.terraform punctuation.section.block.end.terraform


### PR DESCRIPTION
This commit changes the TextMate scopeName from `scope.terraform` to `source.terraform` inside the Terraform TextMate Grammar file.

The current scopeName for the Terraform TextMate grammar is `scope.terraform`: https://github.com/hashicorp/vscode-terraform/blob/59987ae480a970b5955c94260abfa41fccb8577e/syntaxes/terraform.tmGrammar.json#L2

According to the TextMate documentation, the scopename should follow this naming conventions:

> scopeName — this should be a unique name for the grammar, following the convention of being a dot-separated name where each new (left-most) part specializes the name. Normally it would be a two-part name where the first is either text or source and the second is the name of the language or document type.

This means we need to change the Terraform scope name to `source.terraform`.

This should not affect any existing themes or current syntax as themes are targeted towards the most specific token scope, like `comment.line`.double-slash, and not the language scopeName. Themes would be affected if our scopes were named `comment.line.double-slash.terraform` and we were changing the terraform part, but we have not named our scopes that way so we are unaffected.
