### PR TITLE
Restore region markers support

### DIFF
--- a/language-configuration.json
+++ b/language-configuration.json
@@ -71,5 +71,11 @@
 			"'",
 			"'"
 		]
-	]
+	],
+	"folding": {
+		"markers": {
+			"start": "^\\s*#region",
+			"end": "^\\s*#endregion"
+		}
+	}
 }


### PR DESCRIPTION
This PR restores changes from 3ae5eea0b2689d2839db75b388d9baadd81d0f55 to detect region markers (`#region` and `#endregion`) used for [folding blocks of code](https://code.visualstudio.com/docs/editor/codebasics#_folding).

## Demo

https://user-images.githubusercontent.com/1751980/153667692-0578a05e-5135-4602-8092-78a99a8d6297.mov