### PR TITLE
Fix highlighting for attribute access with a dash

### DIFF
--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -638,7 +638,7 @@
 					"name": "keyword.operator.accessor.terraform"
 				}
 			},
-			"end": "\\w+(\\[[0-9\\*]+\\])?",
+			"end": "[[:alpha:]][[:alnum:]_-]*(\\[[0-9\\*]+\\])?",
 			"endCaptures": {
 				"0": {
 					"patterns": [
@@ -646,11 +646,7 @@
 							"match": "\\b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\\b",
 							"comment": "Attribute access",
 							"name": "variable.other.member.terraform"
-						}
-					]
-				},
-				"1": {
-					"patterns": [
+						},
 						{
 							"match": "\\d+",
 							"comment": "Subscript",

--- a/tests/snapshot/terraform/expressions_splat.tf.snap
+++ b/tests/snapshot/terraform/expressions_splat.tf.snap
@@ -21,7 +21,9 @@
 #^^^ source.terraform support.constant.terraform
 #   ^ source.terraform keyword.operator.accessor.terraform
 #    ^^^^ source.terraform variable.other.member.terraform
-#        ^^^ source.terraform
+#        ^ source.terraform
+#         ^ source.terraform keyword.operator.splat.terraform
+#          ^ source.terraform
 #           ^ source.terraform keyword.operator.accessor.terraform
 #            ^^ source.terraform variable.other.member.terraform
 >
@@ -29,10 +31,14 @@
 #^^^ source.terraform support.constant.terraform
 #   ^ source.terraform keyword.operator.accessor.terraform
 #    ^^^^ source.terraform variable.other.member.terraform
-#        ^^^ source.terraform
+#        ^ source.terraform
+#         ^ source.terraform keyword.operator.splat.terraform
+#          ^ source.terraform
 #           ^ source.terraform keyword.operator.accessor.terraform
 #            ^^^^^^^^^^ source.terraform variable.other.member.terraform
-#                      ^^^ source.terraform
+#                      ^ source.terraform
+#                       ^ source.terraform constant.numeric.integer.terraform
+#                        ^ source.terraform
 #                         ^ source.terraform keyword.operator.accessor.terraform
 #                          ^^^^ source.terraform variable.other.member.terraform
 >

--- a/tests/snapshot/terraform/issue927.tf
+++ b/tests/snapshot/terraform/issue927.tf
@@ -1,0 +1,16 @@
+variable "foo" {}
+output "result-val" { value = var.foo }
+
+variable "some-var" {
+  default = "value"
+}
+
+module "foo-mod" {
+  source = "./foo"
+  foo = var.some-var
+}
+
+module "bar" {
+  source = "./foo"
+  foo = module.foo-mod.result-val
+}

--- a/tests/snapshot/terraform/issue927.tf.snap
+++ b/tests/snapshot/terraform/issue927.tf.snap
@@ -71,9 +71,7 @@
 #       ^ source.terraform meta.block.terraform variable.declaration.terraform
 #        ^^^ source.terraform meta.block.terraform support.constant.terraform
 #           ^ source.terraform meta.block.terraform keyword.operator.accessor.terraform
-#            ^^^^ source.terraform meta.block.terraform variable.other.member.terraform
-#                ^ source.terraform meta.block.terraform keyword.operator.arithmetic.terraform
-#                 ^^^ source.terraform meta.block.terraform support.constant.terraform
+#            ^^^^^^^^ source.terraform meta.block.terraform variable.other.member.terraform
 >}
 #^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
@@ -102,12 +100,8 @@
 #       ^ source.terraform meta.block.terraform variable.declaration.terraform
 #        ^^^^^^ source.terraform meta.block.terraform support.constant.terraform
 #              ^ source.terraform meta.block.terraform keyword.operator.accessor.terraform
-#               ^^^ source.terraform meta.block.terraform variable.other.member.terraform
-#                  ^ source.terraform meta.block.terraform keyword.operator.arithmetic.terraform
-#                   ^^^ source.terraform meta.block.terraform
+#               ^^^^^^^ source.terraform meta.block.terraform variable.other.member.terraform
 #                      ^ source.terraform meta.block.terraform keyword.operator.accessor.terraform
-#                       ^^^^^^ source.terraform meta.block.terraform variable.other.member.terraform
-#                             ^ source.terraform meta.block.terraform keyword.operator.arithmetic.terraform
-#                              ^^^^ source.terraform meta.block.terraform
+#                       ^^^^^^^^^^ source.terraform meta.block.terraform variable.other.member.terraform
 >}
 #^ source.terraform meta.block.terraform punctuation.section.block.end.terraform

--- a/tests/snapshot/terraform/issue927.tf.snap
+++ b/tests/snapshot/terraform/issue927.tf.snap
@@ -1,0 +1,113 @@
+>variable "foo" {}
+#^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#        ^ source.terraform meta.block.terraform
+#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#             ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#              ^ source.terraform meta.block.terraform
+#               ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#                ^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
+>output "result-val" { value = var.foo }
+#^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#      ^ source.terraform meta.block.terraform
+#       ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#        ^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                  ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                   ^ source.terraform meta.block.terraform
+#                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
+#                     ^ source.terraform meta.block.terraform
+#                      ^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#                           ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                            ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                             ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                              ^^^ source.terraform meta.block.terraform support.constant.terraform
+#                                 ^ source.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                                  ^^^ source.terraform meta.block.terraform variable.other.member.terraform
+#                                     ^ source.terraform meta.block.terraform
+#                                      ^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
+>
+>variable "some-var" {
+#^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#        ^ source.terraform meta.block.terraform
+#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#          ^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                  ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                   ^ source.terraform meta.block.terraform
+#                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
+>  default = "value"
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#         ^ source.terraform meta.block.terraform variable.declaration.terraform
+#          ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#           ^ source.terraform meta.block.terraform variable.declaration.terraform
+#            ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#             ^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                  ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+>}
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
+>
+>module "foo-mod" {
+#^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#      ^ source.terraform meta.block.terraform
+#       ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#        ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#               ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                ^ source.terraform meta.block.terraform
+#                 ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
+>  source = "./foo"
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#        ^ source.terraform meta.block.terraform variable.declaration.terraform
+#         ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#          ^ source.terraform meta.block.terraform variable.declaration.terraform
+#           ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#            ^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+>  foo = var.some-var
+#^^ source.terraform meta.block.terraform
+#  ^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#     ^ source.terraform meta.block.terraform variable.declaration.terraform
+#      ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#       ^ source.terraform meta.block.terraform variable.declaration.terraform
+#        ^^^ source.terraform meta.block.terraform support.constant.terraform
+#           ^ source.terraform meta.block.terraform keyword.operator.accessor.terraform
+#            ^^^^ source.terraform meta.block.terraform variable.other.member.terraform
+#                ^ source.terraform meta.block.terraform keyword.operator.arithmetic.terraform
+#                 ^^^ source.terraform meta.block.terraform support.constant.terraform
+>}
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
+>
+>module "bar" {
+#^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#      ^ source.terraform meta.block.terraform
+#       ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#        ^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#           ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#            ^ source.terraform meta.block.terraform
+#             ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
+>  source = "./foo"
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#        ^ source.terraform meta.block.terraform variable.declaration.terraform
+#         ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#          ^ source.terraform meta.block.terraform variable.declaration.terraform
+#           ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#            ^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+>  foo = module.foo-mod.result-val
+#^^ source.terraform meta.block.terraform
+#  ^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#     ^ source.terraform meta.block.terraform variable.declaration.terraform
+#      ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#       ^ source.terraform meta.block.terraform variable.declaration.terraform
+#        ^^^^^^ source.terraform meta.block.terraform support.constant.terraform
+#              ^ source.terraform meta.block.terraform keyword.operator.accessor.terraform
+#               ^^^ source.terraform meta.block.terraform variable.other.member.terraform
+#                  ^ source.terraform meta.block.terraform keyword.operator.arithmetic.terraform
+#                   ^^^ source.terraform meta.block.terraform
+#                      ^ source.terraform meta.block.terraform keyword.operator.accessor.terraform
+#                       ^^^^^^ source.terraform meta.block.terraform variable.other.member.terraform
+#                             ^ source.terraform meta.block.terraform keyword.operator.arithmetic.terraform
+#                              ^^^^ source.terraform meta.block.terraform
+>}
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform


### PR DESCRIPTION
This PR fixes the syntax highlighting for attribute access containing a dash (`-`) and the splat and indices detection.

## UX Impact
### Variables with dashes
Before
![CleanShot 2022-02-10 at 12 06 49](https://user-images.githubusercontent.com/45985/153394806-72de8782-75cb-4c28-9d55-d4bbc4a55744.png)

After
![CleanShot 2022-02-10 at 12 07 02](https://user-images.githubusercontent.com/45985/153394818-957e73b9-5722-4281-82f3-8714c850054a.png)

### Splat & Indices
Before
![CleanShot 2022-02-10 at 12 08 22](https://user-images.githubusercontent.com/45985/153394979-be535c14-b801-4e55-b14a-881167e5ecf0.png)

After
![CleanShot 2022-02-10 at 12 08 02](https://user-images.githubusercontent.com/45985/153395000-1e9dff0d-5582-4736-a825-a850e7742ce1.png)

Fixes #927 
