### PR TITLE
Add new scope for block type and name 

### DIFF
--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -112,6 +112,7 @@
 		},
 		"block": {
 			"name": "meta.block.terraform",
+			"comment": "This will match Terraform blocks like `resource \"aws_instance\" \"web\" {` or `module {`",
 			"begin": "(\\w+)(?:([\\s\\\"\\-[:word:]]*)(\\{))",
 			"beginCaptures": {
 				"1": {
@@ -130,7 +131,19 @@
 				"2": {
 					"patterns": [
 						{
-							"include": "#string_literals"
+							"name":"entity.name.tag.terraform",
+							"begin": "\"",
+							"beginCaptures": {
+								"0": {
+									"name": "entity.name.tag.begin.terraform"
+								}
+							},
+							"end": "\"",
+							"endCaptures": {
+								"0": {
+									"name": "entity.name.tag.end.terraform"
+								}
+							}
 						}
 					]
 				},

--- a/tests/snapshot/terraform/basic.tf.snap
+++ b/tests/snapshot/terraform/basic.tf.snap
@@ -69,9 +69,9 @@
 >provider "azurerm" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#          ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                 ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                  ^ source.terraform meta.block.terraform
 #                   ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  features {}
@@ -86,13 +86,13 @@
 >resource "azurerm_resource_group" "rg" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                                ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#          ^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                                ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                                 ^ source.terraform meta.block.terraform
-#                                  ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                                   ^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                                     ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                                  ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#                                   ^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                                     ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                                      ^ source.terraform meta.block.terraform
 #                                       ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  name     = "myTFResourceGroup"

--- a/tests/snapshot/terraform/blocks.tf.snap
+++ b/tests/snapshot/terraform/blocks.tf.snap
@@ -1,13 +1,13 @@
 >resource "aws_instance" "web" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                      ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#          ^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                      ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                       ^ source.terraform meta.block.terraform
-#                        ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                         ^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                            ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                        ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#                         ^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                            ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                             ^ source.terraform meta.block.terraform
 #                              ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  ami           = "ami-a1b2c3d4"

--- a/tests/snapshot/terraform/data_sources.tf.snap
+++ b/tests/snapshot/terraform/data_sources.tf.snap
@@ -1,13 +1,13 @@
 >data "aws_ami" "example" {
 #^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #    ^ source.terraform meta.block.terraform
-#     ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#      ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#             ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#     ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#      ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#             ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #              ^ source.terraform meta.block.terraform
-#               ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                       ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#               ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#                ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                       ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                        ^ source.terraform meta.block.terraform
 #                         ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  most_recent = true

--- a/tests/snapshot/terraform/expressions_dynamic.tf.snap
+++ b/tests/snapshot/terraform/expressions_dynamic.tf.snap
@@ -1,13 +1,13 @@
 >resource "thing" "name" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#               ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#          ^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#               ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                ^ source.terraform meta.block.terraform
-#                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                  ^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                      ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                 ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#                  ^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                      ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                       ^ source.terraform meta.block.terraform
 #                        ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  name = "tf-test-name"
@@ -24,9 +24,9 @@
 #^^ source.terraform meta.block.terraform
 #  ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
 #         ^ source.terraform meta.block.terraform meta.block.terraform
-#          ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#           ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                  ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#          ^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#           ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform
+#                  ^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                   ^ source.terraform meta.block.terraform meta.block.terraform
 #                    ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >    for_each = var.settings
@@ -96,9 +96,9 @@
 #^^ source.terraform meta.block.terraform
 #  ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
 #         ^ source.terraform meta.block.terraform meta.block.terraform
-#          ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#           ^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                       ^ source.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#          ^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#           ^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform
+#                       ^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                        ^ source.terraform meta.block.terraform meta.block.terraform
 #                         ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >    for_each = var.load_balancer_origin_groups
@@ -129,9 +129,9 @@
 #^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
 #      ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
 #             ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#              ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#               ^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform
-#                     ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#              ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#               ^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform
+#                     ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                      ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
 #                       ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >        for_each = origin_group.value.origins

--- a/tests/snapshot/terraform/issue927.tf.snap
+++ b/tests/snapshot/terraform/issue927.tf.snap
@@ -1,18 +1,18 @@
 >variable "foo" {}
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#             ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#          ^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#             ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #              ^ source.terraform meta.block.terraform
 #               ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 #                ^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >output "result-val" { value = var.foo }
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#        ^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                  ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#       ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#        ^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                  ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                   ^ source.terraform meta.block.terraform
 #                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 #                     ^ source.terraform meta.block.terraform
@@ -29,9 +29,9 @@
 >variable "some-var" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                  ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#          ^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                  ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                   ^ source.terraform meta.block.terraform
 #                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  default = "value"
@@ -49,9 +49,9 @@
 >module "foo-mod" {
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#        ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#               ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#       ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#        ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#               ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                ^ source.terraform meta.block.terraform
 #                 ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  source = "./foo"
@@ -78,9 +78,9 @@
 >module "bar" {
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#        ^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#           ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#       ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#        ^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#           ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #            ^ source.terraform meta.block.terraform
 #             ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  source = "./foo"

--- a/tests/snapshot/terraform/modules.tf.snap
+++ b/tests/snapshot/terraform/modules.tf.snap
@@ -1,9 +1,9 @@
 >module "servers" {
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#        ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#               ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#       ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#        ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#               ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                ^ source.terraform meta.block.terraform
 #                 ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  source = "./app-cluster"
@@ -29,13 +29,13 @@
 >resource "aws_elb" "example" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#          ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                 ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                  ^ source.terraform meta.block.terraform
-#                   ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                    ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                           ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                   ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#                    ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                           ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                            ^ source.terraform meta.block.terraform
 #                             ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  # ...

--- a/tests/snapshot/terraform/providers.tf.snap
+++ b/tests/snapshot/terraform/providers.tf.snap
@@ -1,9 +1,9 @@
 >provider "google" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#          ^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                 ^ source.terraform meta.block.terraform
 #                  ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  project = "acme-app"

--- a/tests/snapshot/terraform/variables_input.tf.snap
+++ b/tests/snapshot/terraform/variables_input.tf.snap
@@ -5,9 +5,9 @@
 >variable "image_id" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                  ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#          ^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                  ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                   ^ source.terraform meta.block.terraform
 #                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type = string
@@ -23,9 +23,9 @@
 >variable "availability_zone_names" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#          ^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                                 ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                                  ^ source.terraform meta.block.terraform
 #                                   ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type    = list(string)
@@ -55,9 +55,9 @@
 >variable "docker_ports" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                      ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#          ^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                      ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                       ^ source.terraform meta.block.terraform
 #                        ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type = list(object({
@@ -142,9 +142,9 @@
 >variable "image_id" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                  ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#          ^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                  ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                   ^ source.terraform meta.block.terraform
 #                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type        = string

--- a/tests/snapshot/terraform/variables_local.tf.snap
+++ b/tests/snapshot/terraform/variables_local.tf.snap
@@ -96,13 +96,13 @@
 >resource "aws_instance" "example" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#          ^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                      ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#          ^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                      ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                       ^ source.terraform meta.block.terraform
-#                        ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#                         ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                                ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#                        ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#                         ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                                ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                                 ^ source.terraform meta.block.terraform
 #                                  ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  # ...

--- a/tests/snapshot/terraform/variables_output.tf.snap
+++ b/tests/snapshot/terraform/variables_output.tf.snap
@@ -1,9 +1,9 @@
 >output "instance_ip_addr" {
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#        ^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                        ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#       ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#        ^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                        ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                         ^ source.terraform meta.block.terraform
 #                          ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  value = aws_instance.server.private_ip
@@ -23,9 +23,9 @@
 >output "instance_ip_addr" {
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-#        ^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-#                        ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+#       ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+#        ^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                        ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 #                         ^ source.terraform meta.block.terraform
 #                          ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  value       = aws_instance.server.private_ip

--- a/tests/unit/terraform/basic.tf
+++ b/tests/unit/terraform/basic.tf
@@ -71,9 +71,9 @@ terraform {
 provider "azurerm" {
 ; <-------- source.terraform meta.block.terraform entity.name.type.terraform
 ;       ^ source.terraform meta.block.terraform
-;        ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-;         ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-;                ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+;        ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+;         ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+;                ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 ;                 ^ source.terraform meta.block.terraform
 ;                  ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
   features {}
@@ -88,13 +88,13 @@ provider "azurerm" {
 resource "azurerm_resource_group" "rg" {
 ; <-------- source.terraform meta.block.terraform entity.name.type.terraform
 ;       ^ source.terraform meta.block.terraform
-;        ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-;         ^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
-;                               ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+;        ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+;         ^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+;                               ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 ;                                ^ source.terraform meta.block.terraform
-;                                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
-;                                  ^^ source.terraform meta.block.terraform string.quoted.double.terraform
-;                                    ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+;                                 ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
+;                                  ^^ source.terraform meta.block.terraform entity.name.tag.terraform
+;                                    ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
 ;                                     ^ source.terraform meta.block.terraform
 ;                                      ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
   name     = "myTFResourceGroup"

--- a/tests/unit/terraform/resource.tf
+++ b/tests/unit/terraform/resource.tf
@@ -1,0 +1,7 @@
+; SYNTAX TEST "source.terraform" "basic sample"
+
+resource "foo" "bar"{
+;        ^ source.terraform meta.block.terraform entity.name.tag.begin.terraform
+;         ^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+;            ^ source.terraform meta.block.terraform entity.name.tag.end.terraform
+}


### PR DESCRIPTION
This changes the existing block matcher to differentiate the type and name of a given block.

Previously the type and name of a block were scoped as `string.quoted.double`. This change scopes them to an `entity.name.tag`, which is commonly used to indicate a tag or attribute.

This will match Terraform blocks like `resource "aws_instance" "web" {` or `module "foo" {`

![image](https://user-images.githubusercontent.com/272569/154549870-b82f3dc7-f6a9-4466-9f8d-573602ed3654.png)

This will match Terraform blocks like `module "foo" {` or `variable`.

![image](https://user-images.githubusercontent.com/272569/154549998-4b356ce1-803d-4fae-b07a-183c4f412c82.png)

This will leave alone blocks without types or names:

![image](https://user-images.githubusercontent.com/272569/154550079-b14a3273-840a-4e96-b8d1-4ee5c1fbdc5c.png)

> **Note:** The LS needs to be disabled for you to see this until the semantic tokens are updated in the terraform-ls project.

Fixes #710 