### PR TITLE
Improve comment detection

### DIFF
--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -53,18 +53,26 @@
 		},
 		"comments": {
 			"patterns": [
-				{
-					"include": "#inline_comments"
-				},
-				{
-					"include": "#block_comments"
-				}
+				{ "include": "#hash_line_comments" },
+				{ "include": "#double_slash_line_comments" },
+				{ "include": "#block_inline_comments" }
 			]
 		},
-		"inline_comments": {
-			"begin": "#|//",
-			"comment": "Inline Comments",
-			"name": "comment.line.terraform",
+		"hash_line_comments": {
+			"name": "comment.line.number-sign.hcl",
+			"comment": "Line comments start with # sequence and end with the next newline sequence. A line comment is considered equivalent to a newline sequence",
+			"begin": "#",
+			"end": "$\\n?",
+			"captures": {
+				"0": {
+					"name": "punctuation.definition.comment.terraform"
+				}
+			}
+		},
+		"double_slash_line_comments": {
+			"name": "comment.line.double-slash.hcl",
+			"comment": "Line comments start with // sequence and end with the next newline sequence. A line comment is considered equivalent to a newline sequence",
+			"begin": "//",
 			"captures": {
 				"0": {
 					"name": "punctuation.definition.comment.terraform"
@@ -72,10 +80,10 @@
 			},
 			"end": "$\\n?"
 		},
-		"block_comments": {
+		"block_inline_comments": {
+			"name": "comment.block.hcl",
+			"comment": "Inline comments start with the /* sequence and end with the */ sequence, and may have any characters within except the ending sequence. An inline comment is considered equivalent to a whitespace sequence",
 			"begin": "/\\*",
-			"comment": "Block comments",
-			"name": "comment.block.terraform",
 			"captures": {
 				"0": {
 					"name": "punctuation.definition.comment.terraform"

--- a/tests/snapshot/terraform/basic.tf.snap
+++ b/tests/snapshot/terraform/basic.tf.snap
@@ -1,17 +1,17 @@
 ># line comment
-#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^^^^^^ source.terraform comment.line.terraform
+#^ source.terraform comment.line.number-sign.hcl punctuation.definition.comment.terraform
+# ^^^^^^^^^^^^^ source.terraform comment.line.number-sign.hcl
 >
 >// line comment
-#^^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
-#  ^^^^^^^^^^^^^ source.terraform comment.line.terraform
+#^^ source.terraform comment.line.double-slash.hcl punctuation.definition.comment.terraform
+#  ^^^^^^^^^^^^^ source.terraform comment.line.double-slash.hcl
 >
 >/*
-#^^ source.terraform comment.block.terraform punctuation.definition.comment.terraform
+#^^ source.terraform comment.block.hcl punctuation.definition.comment.terraform
 >  Block comment
-#^^^^^^^^^^^^^^^^ source.terraform comment.block.terraform
+#^^^^^^^^^^^^^^^^ source.terraform comment.block.hcl
 >*/
-#^^ source.terraform comment.block.terraform punctuation.definition.comment.terraform
+#^^ source.terraform comment.block.hcl punctuation.definition.comment.terraform
 >
 >terraform {
 #^^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform

--- a/tests/snapshot/terraform/comments.tf.snap
+++ b/tests/snapshot/terraform/comments.tf.snap
@@ -1,15 +1,15 @@
 ># line comment
-#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^^^^^^ source.terraform comment.line.terraform
+#^ source.terraform comment.line.number-sign.hcl punctuation.definition.comment.terraform
+# ^^^^^^^^^^^^^ source.terraform comment.line.number-sign.hcl
 >
 >// line comment
-#^^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
-#  ^^^^^^^^^^^^^ source.terraform comment.line.terraform
+#^^ source.terraform comment.line.double-slash.hcl punctuation.definition.comment.terraform
+#  ^^^^^^^^^^^^^ source.terraform comment.line.double-slash.hcl
 >
 >/*
-#^^ source.terraform comment.block.terraform punctuation.definition.comment.terraform
+#^^ source.terraform comment.block.hcl punctuation.definition.comment.terraform
 >  Block comment
-#^^^^^^^^^^^^^^^^ source.terraform comment.block.terraform
+#^^^^^^^^^^^^^^^^ source.terraform comment.block.hcl
 >*/
-#^^ source.terraform comment.block.terraform punctuation.definition.comment.terraform
+#^^ source.terraform comment.block.hcl punctuation.definition.comment.terraform
 >

--- a/tests/snapshot/terraform/expressions_functions.tf.snap
+++ b/tests/snapshot/terraform/expressions_functions.tf.snap
@@ -1,6 +1,6 @@
 ># numeric
-#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^ source.terraform comment.line.terraform
+#^ source.terraform comment.line.number-sign.hcl punctuation.definition.comment.terraform
+# ^^^^^^^^ source.terraform comment.line.number-sign.hcl
 >
 >abs(23)
 #^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform
@@ -73,8 +73,8 @@
 #          ^ source.terraform meta.function-call.terraform punctuation.section.parens.end.terraform
 >
 ># string
-#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^ source.terraform comment.line.terraform
+#^ source.terraform comment.line.number-sign.hcl punctuation.definition.comment.terraform
+# ^^^^^^^ source.terraform comment.line.number-sign.hcl
 >
 >chomp("hello\n")
 #^^^^^ source.terraform meta.function-call.terraform support.function.builtin.terraform

--- a/tests/snapshot/terraform/expressions_operators.tf.snap
+++ b/tests/snapshot/terraform/expressions_operators.tf.snap
@@ -1,6 +1,6 @@
 ># arithmetic
-#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^^^^ source.terraform comment.line.terraform
+#^ source.terraform comment.line.number-sign.hcl punctuation.definition.comment.terraform
+# ^^^^^^^^^^^ source.terraform comment.line.number-sign.hcl
 >
 >1 + 2 * 3 / 4
 #^ source.terraform constant.numeric.integer.terraform
@@ -29,8 +29,8 @@
 # ^^^^^^ source.terraform
 >
 ># equality
-#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^^ source.terraform comment.line.terraform
+#^ source.terraform comment.line.number-sign.hcl punctuation.definition.comment.terraform
+# ^^^^^^^^^ source.terraform comment.line.number-sign.hcl
 >
 >thing1 == thing2
 #^^^^^^^ source.terraform
@@ -42,8 +42,8 @@
 #         ^^^^^^^^ source.terraform
 >
 ># comparison
-#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^^^^ source.terraform comment.line.terraform
+#^ source.terraform comment.line.number-sign.hcl punctuation.definition.comment.terraform
+# ^^^^^^^^^^^ source.terraform comment.line.number-sign.hcl
 >
 >thing1 > thing2
 #^^^^^^^ source.terraform
@@ -63,8 +63,8 @@
 #         ^^^^^^^^ source.terraform
 >
 ># logical
-#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^ source.terraform comment.line.terraform
+#^ source.terraform comment.line.number-sign.hcl punctuation.definition.comment.terraform
+# ^^^^^^^^ source.terraform comment.line.number-sign.hcl
 >
 >thing1 || thing2
 #^^^^^^^ source.terraform

--- a/tests/snapshot/terraform/modules.tf.snap
+++ b/tests/snapshot/terraform/modules.tf.snap
@@ -40,8 +40,8 @@
 #                             ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  # ...
 #^^ source.terraform meta.block.terraform
-#  ^ source.terraform meta.block.terraform comment.line.terraform punctuation.definition.comment.terraform
-#   ^^^^ source.terraform meta.block.terraform comment.line.terraform
+#  ^ source.terraform meta.block.terraform comment.line.number-sign.hcl punctuation.definition.comment.terraform
+#   ^^^^ source.terraform meta.block.terraform comment.line.number-sign.hcl
 >
 >  instances = module.servers.instance_ids
 #^^ source.terraform meta.block.terraform

--- a/tests/snapshot/terraform/variables_input.tf.snap
+++ b/tests/snapshot/terraform/variables_input.tf.snap
@@ -1,6 +1,6 @@
 ># input variables
-#^ source.terraform comment.line.terraform punctuation.definition.comment.terraform
-# ^^^^^^^^^^^^^^^^ source.terraform comment.line.terraform
+#^ source.terraform comment.line.number-sign.hcl punctuation.definition.comment.terraform
+# ^^^^^^^^^^^^^^^^ source.terraform comment.line.number-sign.hcl
 >
 >variable "image_id" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform

--- a/tests/snapshot/terraform/variables_local.tf.snap
+++ b/tests/snapshot/terraform/variables_local.tf.snap
@@ -29,8 +29,8 @@
 #       ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  # Ids for multiple sets of EC2 instances, merged together
 #^^ source.terraform meta.block.terraform
-#  ^ source.terraform meta.block.terraform comment.line.terraform punctuation.definition.comment.terraform
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform comment.line.terraform
+#  ^ source.terraform meta.block.terraform comment.line.number-sign.hcl punctuation.definition.comment.terraform
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform comment.line.number-sign.hcl
 >  instance_ids = concat(aws_instance.blue.*.id, aws_instance.green.*.id)
 #^^ source.terraform meta.block.terraform
 #  ^^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
@@ -62,8 +62,8 @@
 #       ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  # Common tags to be assigned to all resources
 #^^ source.terraform meta.block.terraform
-#  ^ source.terraform meta.block.terraform comment.line.terraform punctuation.definition.comment.terraform
-#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform comment.line.terraform
+#  ^ source.terraform meta.block.terraform comment.line.number-sign.hcl punctuation.definition.comment.terraform
+#   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform comment.line.number-sign.hcl
 >  common_tags = {
 #^^ source.terraform meta.block.terraform
 #  ^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
@@ -107,8 +107,8 @@
 #                                  ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  # ...
 #^^ source.terraform meta.block.terraform
-#  ^ source.terraform meta.block.terraform comment.line.terraform punctuation.definition.comment.terraform
-#   ^^^^ source.terraform meta.block.terraform comment.line.terraform
+#  ^ source.terraform meta.block.terraform comment.line.number-sign.hcl punctuation.definition.comment.terraform
+#   ^^^^ source.terraform meta.block.terraform comment.line.number-sign.hcl
 >
 >  tags = local.common_tags
 #^^ source.terraform meta.block.terraform

--- a/tests/unit/terraform/basic.tf
+++ b/tests/unit/terraform/basic.tf
@@ -1,19 +1,19 @@
 ; SYNTAX TEST "source.terraform" "basic sample"
 
 # line comment
-; <- source.terraform comment.line.terraform punctuation.definition.comment.terraform
-;  ^^^^^^^^^^^^^ source.terraform comment.line.terraform
+; <- source.terraform comment.line.number-sign.hcl punctuation.definition.comment.terraform
+;  ^^^^^^^^^^^^^ source.terraform comment.line.number-sign.hcl
 
 // line comment
-; <-- source.terraform comment.line.terraform punctuation.definition.comment.terraform
-;   ^^^^^^^^^^^^^ source.terraform comment.line.terraform
+; <-- source.terraform comment.line.double-slash.hcl punctuation.definition.comment.terraform
+;   ^^^^^^^^^^^^^ source.terraform comment.line.double-slash.hcl
 
 /*
-; <~- source.terraform comment.block.terraform punctuation.definition.comment.terraform
+; <~- source.terraform comment.block.hcl punctuation.definition.comment.terraform
   Block comment
-; ^^^^^^^^^^^^^^^^ source.terraform comment.block.terraform
+; ^^^^^^^^^^^^^^^^ source.terraform comment.block.hcl
 */
-; <~- source.terraform comment.block.terraform punctuation.definition.comment.terraform
+; <~- source.terraform comment.block.hcl punctuation.definition.comment.terraform
 
 terraform {
 ; <--------- source.terraform meta.block.terraform entity.name.type.terraform


### PR DESCRIPTION
This disambiguates hash line comments, double slash comments, and block comments by adding unique identifiers. This will allow different highlighting for different comment types, as well as help with future code folding and keyboard shortcuts.
