### PR TITLE
Resolve issue with tfvars comment toggling

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,11 +39,11 @@
   },
   "activationEvents": [
     "onLanguage:terraform",
-		"onLanguage:terraform-vars",
-		"onView:terraform-modules",
-		"workspaceContains:**/*.tf",
-		"workspaceContains:**/*.tfvars",
-		"onCommand:terraform.enableLanguageServer"
+    "onLanguage:terraform-vars",
+    "onView:terraform-modules",
+    "workspaceContains:**/*.tf",
+    "workspaceContains:**/*.tfvars",
+    "onCommand:terraform.enableLanguageServer"
   ],
   "main": "./out/extension",
   "contributes": {

--- a/package.json
+++ b/package.json
@@ -61,7 +61,8 @@
         "id": "terraform-vars",
         "extensions": [
           ".tfvars"
-        ]
+        ],
+        "configuration": "./language-configuration.json"
       },
       {
         "id": "json",

--- a/package.json
+++ b/package.json
@@ -39,9 +39,11 @@
   },
   "activationEvents": [
     "onLanguage:terraform",
-    "onView:terraform-modules",
-    "workspaceContains:**/*.tf",
-    "onCommand:terraform.enableLanguageServer"
+		"onLanguage:terraform-vars",
+		"onView:terraform-modules",
+		"workspaceContains:**/*.tf",
+		"workspaceContains:**/*.tfvars",
+		"onCommand:terraform.enableLanguageServer"
   ],
   "main": "./out/extension",
   "contributes": {


### PR DESCRIPTION
This fixes a bug with comment toggling found while I was using the extension. Basically, if a user opens a `*.tfvars` first, it breaks the comment toggling in `*.tfvars` files till the session is reloaded. This adds the explicit mapping to the configuration files, and activates the extension once a `*.tfvars` file is opened, and doesn't rely on a `*.tf` file to be loaded first.

Resolves #936 and may be related to #480