### PR TITLE
syntax: Highlight block label as "enumMember" & highlight unquoted labels

### DIFF
--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -131,7 +131,7 @@
 				"2": {
 					"patterns": [
 						{
-							"name": "entity.name.tag.terraform",
+							"name": "variable.other.enummember.terraform",
 							"match": "[\\\"\\-\\w]+"
 						}
 					]

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -113,12 +113,12 @@
 		"block": {
 			"name": "meta.block.terraform",
 			"comment": "This will match Terraform blocks like `resource \"aws_instance\" \"web\" {` or `module {`",
-			"begin": "(\\w+)(?:([\\s\\\"\\-\\w]*)(\\{))",
+			"begin": "(\\w+)([\\s\\\"\\-\\w]*)(\\{)",
 			"beginCaptures": {
 				"1": {
 					"patterns": [
 						{
-							"match": "\\b(?:resource|provider|variable|output|locals|module|data|terraform)\\b",
+							"match": "\\bresource|provider|variable|output|locals|module|data|terraform\\b",
 							"name": "entity.name.type.terraform"
 						},
 						{

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -119,11 +119,12 @@
 					"patterns": [
 						{
 							"match": "\\bresource|provider|variable|output|locals|module|data|terraform\\b",
+							"comment": "Known block type",
 							"name": "entity.name.type.terraform"
 						},
 						{
 							"match": "\\b(?!null|false|true)[[:alpha:]][[:alnum:]_-]*\\b",
-							"comment": "Identifer label",
+							"comment": "Unknown block type",
 							"name": "entity.name.label.terraform"
 						}
 					]
@@ -132,6 +133,7 @@
 					"patterns": [
 						{
 							"name": "variable.other.enummember.terraform",
+							"comment": "Block label",
 							"match": "[\\\"\\-\\w]+"
 						}
 					]

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -131,19 +131,8 @@
 				"2": {
 					"patterns": [
 						{
-							"name":"entity.name.tag.terraform",
-							"begin": "\"",
-							"beginCaptures": {
-								"0": {
-									"name": "entity.name.tag.begin.terraform"
-								}
-							},
-							"end": "\"",
-							"endCaptures": {
-								"0": {
-									"name": "entity.name.tag.end.terraform"
-								}
-							}
+							"name": "entity.name.tag.terraform",
+							"match": "[\\\"\\-\\w]+"
 						}
 					]
 				},

--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -113,7 +113,7 @@
 		"block": {
 			"name": "meta.block.terraform",
 			"comment": "This will match Terraform blocks like `resource \"aws_instance\" \"web\" {` or `module {`",
-			"begin": "(\\w+)(?:([\\s\\\"\\-[:word:]]*)(\\{))",
+			"begin": "(\\w+)(?:([\\s\\\"\\-\\w]*)(\\{))",
 			"beginCaptures": {
 				"1": {
 					"patterns": [

--- a/tests/snapshot/terraform/basic.tf.snap
+++ b/tests/snapshot/terraform/basic.tf.snap
@@ -69,9 +69,7 @@
 >provider "azurerm" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#          ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                 ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#         ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                  ^ source.terraform meta.block.terraform
 #                   ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  features {}
@@ -86,13 +84,9 @@
 >resource "azurerm_resource_group" "rg" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#          ^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                                ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#         ^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                                 ^ source.terraform meta.block.terraform
-#                                  ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#                                   ^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                                     ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#                                  ^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                                      ^ source.terraform meta.block.terraform
 #                                       ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  name     = "myTFResourceGroup"

--- a/tests/snapshot/terraform/basic.tf.snap
+++ b/tests/snapshot/terraform/basic.tf.snap
@@ -69,7 +69,7 @@
 >provider "azurerm" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#         ^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                  ^ source.terraform meta.block.terraform
 #                   ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  features {}
@@ -84,9 +84,9 @@
 >resource "azurerm_resource_group" "rg" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#         ^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                                 ^ source.terraform meta.block.terraform
-#                                  ^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                                  ^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                                      ^ source.terraform meta.block.terraform
 #                                       ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  name     = "myTFResourceGroup"

--- a/tests/snapshot/terraform/blocks.tf.snap
+++ b/tests/snapshot/terraform/blocks.tf.snap
@@ -1,9 +1,9 @@
 >resource "aws_instance" "web" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#         ^^^^^^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                       ^ source.terraform meta.block.terraform
-#                        ^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                        ^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                             ^ source.terraform meta.block.terraform
 #                              ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  ami           = "ami-a1b2c3d4"

--- a/tests/snapshot/terraform/blocks.tf.snap
+++ b/tests/snapshot/terraform/blocks.tf.snap
@@ -1,13 +1,9 @@
 >resource "aws_instance" "web" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#          ^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                      ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#         ^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                       ^ source.terraform meta.block.terraform
-#                        ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#                         ^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                            ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#                        ^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                             ^ source.terraform meta.block.terraform
 #                              ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  ami           = "ami-a1b2c3d4"

--- a/tests/snapshot/terraform/data_sources.tf.snap
+++ b/tests/snapshot/terraform/data_sources.tf.snap
@@ -1,9 +1,9 @@
 >data "aws_ami" "example" {
 #^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #    ^ source.terraform meta.block.terraform
-#     ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#     ^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #              ^ source.terraform meta.block.terraform
-#               ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#               ^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                        ^ source.terraform meta.block.terraform
 #                         ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  most_recent = true

--- a/tests/snapshot/terraform/data_sources.tf.snap
+++ b/tests/snapshot/terraform/data_sources.tf.snap
@@ -1,13 +1,9 @@
 >data "aws_ami" "example" {
 #^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #    ^ source.terraform meta.block.terraform
-#     ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#      ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#             ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#     ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #              ^ source.terraform meta.block.terraform
-#               ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#                ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                       ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#               ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                        ^ source.terraform meta.block.terraform
 #                         ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  most_recent = true

--- a/tests/snapshot/terraform/expressions_dynamic.tf.snap
+++ b/tests/snapshot/terraform/expressions_dynamic.tf.snap
@@ -1,13 +1,9 @@
 >resource "thing" "name" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#          ^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#               ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#         ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                ^ source.terraform meta.block.terraform
-#                 ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#                  ^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                      ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#                 ^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                       ^ source.terraform meta.block.terraform
 #                        ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  name = "tf-test-name"
@@ -24,9 +20,7 @@
 #^^ source.terraform meta.block.terraform
 #  ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
 #         ^ source.terraform meta.block.terraform meta.block.terraform
-#          ^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#           ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform
-#                  ^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#          ^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform
 #                   ^ source.terraform meta.block.terraform meta.block.terraform
 #                    ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >    for_each = var.settings
@@ -96,9 +90,7 @@
 #^^ source.terraform meta.block.terraform
 #  ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
 #         ^ source.terraform meta.block.terraform meta.block.terraform
-#          ^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#           ^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform
-#                       ^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#          ^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform
 #                        ^ source.terraform meta.block.terraform meta.block.terraform
 #                         ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >    for_each = var.load_balancer_origin_groups
@@ -129,9 +121,7 @@
 #^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
 #      ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
 #             ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#              ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#               ^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform
-#                     ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#              ^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform
 #                      ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
 #                       ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >        for_each = origin_group.value.origins

--- a/tests/snapshot/terraform/expressions_dynamic.tf.snap
+++ b/tests/snapshot/terraform/expressions_dynamic.tf.snap
@@ -1,9 +1,9 @@
 >resource "thing" "name" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#         ^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                ^ source.terraform meta.block.terraform
-#                 ^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                 ^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                       ^ source.terraform meta.block.terraform
 #                        ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  name = "tf-test-name"
@@ -20,7 +20,7 @@
 #^^ source.terraform meta.block.terraform
 #  ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
 #         ^ source.terraform meta.block.terraform meta.block.terraform
-#          ^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform
+#          ^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform variable.other.enummember.terraform
 #                   ^ source.terraform meta.block.terraform meta.block.terraform
 #                    ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >    for_each = var.settings
@@ -90,7 +90,7 @@
 #^^ source.terraform meta.block.terraform
 #  ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
 #         ^ source.terraform meta.block.terraform meta.block.terraform
-#          ^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform
+#          ^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform variable.other.enummember.terraform
 #                        ^ source.terraform meta.block.terraform meta.block.terraform
 #                         ^ source.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >    for_each = var.load_balancer_origin_groups
@@ -121,7 +121,7 @@
 #^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform
 #      ^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.label.terraform
 #             ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
-#              ^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform entity.name.tag.terraform
+#              ^^^^^^^^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform variable.other.enummember.terraform
 #                      ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform
 #                       ^ source.terraform meta.block.terraform meta.block.terraform meta.block.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >        for_each = origin_group.value.origins

--- a/tests/snapshot/terraform/issue927.tf.snap
+++ b/tests/snapshot/terraform/issue927.tf.snap
@@ -1,18 +1,14 @@
 >variable "foo" {}
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#          ^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#             ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#         ^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #              ^ source.terraform meta.block.terraform
 #               ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 #                ^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >output "result-val" { value = var.foo }
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#        ^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                  ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#       ^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                   ^ source.terraform meta.block.terraform
 #                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 #                     ^ source.terraform meta.block.terraform
@@ -29,9 +25,7 @@
 >variable "some-var" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#          ^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                  ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#         ^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                   ^ source.terraform meta.block.terraform
 #                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  default = "value"
@@ -49,9 +43,7 @@
 >module "foo-mod" {
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#        ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#               ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#       ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                ^ source.terraform meta.block.terraform
 #                 ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  source = "./foo"
@@ -78,9 +70,7 @@
 >module "bar" {
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#        ^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#           ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#       ^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #            ^ source.terraform meta.block.terraform
 #             ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  source = "./foo"

--- a/tests/snapshot/terraform/issue927.tf.snap
+++ b/tests/snapshot/terraform/issue927.tf.snap
@@ -1,14 +1,14 @@
 >variable "foo" {}
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#         ^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #              ^ source.terraform meta.block.terraform
 #               ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 #                ^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >output "result-val" { value = var.foo }
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#       ^^^^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                   ^ source.terraform meta.block.terraform
 #                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 #                     ^ source.terraform meta.block.terraform
@@ -25,7 +25,7 @@
 >variable "some-var" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#         ^^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                   ^ source.terraform meta.block.terraform
 #                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  default = "value"
@@ -43,7 +43,7 @@
 >module "foo-mod" {
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#       ^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                ^ source.terraform meta.block.terraform
 #                 ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  source = "./foo"
@@ -70,7 +70,7 @@
 >module "bar" {
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#       ^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #            ^ source.terraform meta.block.terraform
 #             ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  source = "./foo"

--- a/tests/snapshot/terraform/modules.tf.snap
+++ b/tests/snapshot/terraform/modules.tf.snap
@@ -1,7 +1,7 @@
 >module "servers" {
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#       ^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                ^ source.terraform meta.block.terraform
 #                 ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  source = "./app-cluster"
@@ -27,9 +27,9 @@
 >resource "aws_elb" "example" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#         ^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                  ^ source.terraform meta.block.terraform
-#                   ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                   ^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                            ^ source.terraform meta.block.terraform
 #                             ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  # ...

--- a/tests/snapshot/terraform/modules.tf.snap
+++ b/tests/snapshot/terraform/modules.tf.snap
@@ -1,9 +1,7 @@
 >module "servers" {
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#        ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#               ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#       ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                ^ source.terraform meta.block.terraform
 #                 ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  source = "./app-cluster"
@@ -29,13 +27,9 @@
 >resource "aws_elb" "example" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#          ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                 ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#         ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                  ^ source.terraform meta.block.terraform
-#                   ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#                    ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                           ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#                   ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                            ^ source.terraform meta.block.terraform
 #                             ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  # ...

--- a/tests/snapshot/terraform/providers.tf.snap
+++ b/tests/snapshot/terraform/providers.tf.snap
@@ -1,7 +1,7 @@
 >provider "google" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#         ^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                 ^ source.terraform meta.block.terraform
 #                  ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  project = "acme-app"

--- a/tests/snapshot/terraform/providers.tf.snap
+++ b/tests/snapshot/terraform/providers.tf.snap
@@ -1,9 +1,7 @@
 >provider "google" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#          ^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#         ^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                 ^ source.terraform meta.block.terraform
 #                  ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  project = "acme-app"

--- a/tests/snapshot/terraform/variables_input.tf.snap
+++ b/tests/snapshot/terraform/variables_input.tf.snap
@@ -5,9 +5,7 @@
 >variable "image_id" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#          ^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                  ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#         ^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                   ^ source.terraform meta.block.terraform
 #                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type = string
@@ -23,9 +21,7 @@
 >variable "availability_zone_names" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#          ^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                                 ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                                  ^ source.terraform meta.block.terraform
 #                                   ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type    = list(string)
@@ -55,9 +51,7 @@
 >variable "docker_ports" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#          ^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                      ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#         ^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                       ^ source.terraform meta.block.terraform
 #                        ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type = list(object({
@@ -142,9 +136,7 @@
 >variable "image_id" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#          ^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                  ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#         ^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                   ^ source.terraform meta.block.terraform
 #                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type        = string

--- a/tests/snapshot/terraform/variables_input.tf.snap
+++ b/tests/snapshot/terraform/variables_input.tf.snap
@@ -5,7 +5,7 @@
 >variable "image_id" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#         ^^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                   ^ source.terraform meta.block.terraform
 #                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type = string
@@ -21,7 +21,7 @@
 >variable "availability_zone_names" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#         ^^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                                  ^ source.terraform meta.block.terraform
 #                                   ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type    = list(string)
@@ -51,7 +51,7 @@
 >variable "docker_ports" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#         ^^^^^^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                       ^ source.terraform meta.block.terraform
 #                        ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type = list(object({
@@ -136,7 +136,7 @@
 >variable "image_id" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#         ^^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                   ^ source.terraform meta.block.terraform
 #                    ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  type        = string

--- a/tests/snapshot/terraform/variables_local.tf.snap
+++ b/tests/snapshot/terraform/variables_local.tf.snap
@@ -96,13 +96,9 @@
 >resource "aws_instance" "example" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#          ^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                      ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#         ^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                       ^ source.terraform meta.block.terraform
-#                        ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#                         ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                                ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#                        ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                                 ^ source.terraform meta.block.terraform
 #                                  ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  # ...

--- a/tests/snapshot/terraform/variables_local.tf.snap
+++ b/tests/snapshot/terraform/variables_local.tf.snap
@@ -96,9 +96,9 @@
 >resource "aws_instance" "example" {
 #^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #        ^ source.terraform meta.block.terraform
-#         ^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#         ^^^^^^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                       ^ source.terraform meta.block.terraform
-#                        ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#                        ^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                                 ^ source.terraform meta.block.terraform
 #                                  ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  # ...

--- a/tests/snapshot/terraform/variables_output.tf.snap
+++ b/tests/snapshot/terraform/variables_output.tf.snap
@@ -1,9 +1,7 @@
 >output "instance_ip_addr" {
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#        ^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                        ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#       ^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                         ^ source.terraform meta.block.terraform
 #                          ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  value = aws_instance.server.private_ip
@@ -23,9 +21,7 @@
 >output "instance_ip_addr" {
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-#        ^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-#                        ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+#       ^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 #                         ^ source.terraform meta.block.terraform
 #                          ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  value       = aws_instance.server.private_ip

--- a/tests/snapshot/terraform/variables_output.tf.snap
+++ b/tests/snapshot/terraform/variables_output.tf.snap
@@ -1,7 +1,7 @@
 >output "instance_ip_addr" {
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#       ^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                         ^ source.terraform meta.block.terraform
 #                          ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  value = aws_instance.server.private_ip
@@ -21,7 +21,7 @@
 >output "instance_ip_addr" {
 #^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
 #      ^ source.terraform meta.block.terraform
-#       ^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+#       ^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 #                         ^ source.terraform meta.block.terraform
 #                          ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  value       = aws_instance.server.private_ip

--- a/tests/unit/terraform/basic.tf
+++ b/tests/unit/terraform/basic.tf
@@ -71,9 +71,7 @@ terraform {
 provider "azurerm" {
 ; <-------- source.terraform meta.block.terraform entity.name.type.terraform
 ;       ^ source.terraform meta.block.terraform
-;        ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-;         ^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-;                ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+;        ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 ;                 ^ source.terraform meta.block.terraform
 ;                  ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
   features {}
@@ -88,13 +86,9 @@ provider "azurerm" {
 resource "azurerm_resource_group" "rg" {
 ; <-------- source.terraform meta.block.terraform entity.name.type.terraform
 ;       ^ source.terraform meta.block.terraform
-;        ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-;         ^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-;                               ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+;        ^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 ;                                ^ source.terraform meta.block.terraform
-;                                 ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.begin.terraform
-;                                  ^^ source.terraform meta.block.terraform entity.name.tag.terraform
-;                                    ^ source.terraform meta.block.terraform entity.name.tag.terraform entity.name.tag.end.terraform
+;                                 ^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 ;                                     ^ source.terraform meta.block.terraform
 ;                                      ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
   name     = "myTFResourceGroup"

--- a/tests/unit/terraform/basic.tf
+++ b/tests/unit/terraform/basic.tf
@@ -71,7 +71,7 @@ terraform {
 provider "azurerm" {
 ; <-------- source.terraform meta.block.terraform entity.name.type.terraform
 ;       ^ source.terraform meta.block.terraform
-;        ^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+;        ^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 ;                 ^ source.terraform meta.block.terraform
 ;                  ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
   features {}
@@ -86,9 +86,9 @@ provider "azurerm" {
 resource "azurerm_resource_group" "rg" {
 ; <-------- source.terraform meta.block.terraform entity.name.type.terraform
 ;       ^ source.terraform meta.block.terraform
-;        ^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+;        ^^^^^^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 ;                                ^ source.terraform meta.block.terraform
-;                                 ^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+;                                 ^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 ;                                     ^ source.terraform meta.block.terraform
 ;                                      ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
   name     = "myTFResourceGroup"

--- a/tests/unit/terraform/resource.tf
+++ b/tests/unit/terraform/resource.tf
@@ -1,11 +1,11 @@
 ; SYNTAX TEST "source.terraform" "basic sample"
 
 resource "foo" "bar"{
-;        ^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-;              ^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+;        ^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
+;              ^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 }
 
 resource un quoted {
-;        ^^ source.terraform meta.block.terraform entity.name.tag.terraform
-;           ^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+;        ^^ source.terraform meta.block.terraform variable.other.enummember.terraform
+;           ^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
 }

--- a/tests/unit/terraform/resource.tf
+++ b/tests/unit/terraform/resource.tf
@@ -1,7 +1,11 @@
 ; SYNTAX TEST "source.terraform" "basic sample"
 
 resource "foo" "bar"{
-;        ^ source.terraform meta.block.terraform entity.name.tag.begin.terraform
-;         ^^^ source.terraform meta.block.terraform entity.name.tag.terraform
-;            ^ source.terraform meta.block.terraform entity.name.tag.end.terraform
+;        ^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+;              ^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
+}
+
+resource un quoted {
+;        ^^ source.terraform meta.block.terraform entity.name.tag.terraform
+;           ^^^^^^ source.terraform meta.block.terraform entity.name.tag.terraform
 }


### PR DESCRIPTION
This is to complement https://github.com/hashicorp/terraform-ls/pull/802 by aligning the scope of block labels in the grammar with semantic token type assigned by the language server.

It may seem counter-intuitive or wrong from semantic perspective to use `variable.other.` alongside `entity.name.` (used for known block type) for labels but as explained in the commit log - this is mostly a pragmatic decision made to provide better UX which otherwise would be hard/impossible to achieve due to the scopes used by default VSCode themes.

As mentioned in #802 we explored a number of other token types which VSCode mostly ends up just mapping down to available scope names per https://github.com/microsoft/vscode/blob/de9ab35ce9da7cb3c850a1b570876263a472174b/src/vs/platform/theme/common/tokenClassificationRegistry.ts#L540-L570

So these are the limitations we have to work within. Our future hope is possibly addition of some more token types into LSP as described in https://github.com/microsoft/language-server-protocol/issues/1067

## Before
![Screenshot 2022-02-23 at 20 30 18](https://user-images.githubusercontent.com/287584/155404513-d4a873d9-de81-45a5-878a-b6c176b5059c.png) ![Screenshot 2022-02-23 at 20 30 35](https://user-images.githubusercontent.com/287584/155404516-9837d9a0-f843-4e92-b419-626ffcfc6e0a.png)

## After
![Screenshot 2022-02-23 at 20 35 34](https://user-images.githubusercontent.com/287584/155404533-6e696611-368a-4c6a-8f16-64248d303332.png) ![Screenshot 2022-02-23 at 20 35 21](https://user-images.githubusercontent.com/287584/155404536-a1f97695-a279-42ba-b415-0a65cff6b225.png)

--- 

## Future Enhancements

@dbanck rightly pointed out that the LS/extension alignment may do a dis-service to the user in case of "invalid" labels. This is tracked under https://github.com/hashicorp/terraform-ls/issues/804

There was also point made in https://github.com/hashicorp/vscode-terraform/issues/710 about distinguishing "dependent labels" from "freeform-text labels". This is tracked under https://github.com/hashicorp/terraform-ls/issues/803