### PR TITLE
Fix ignore markdown files

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,14 +7,14 @@ on:
     paths-ignore:
       - 'syntaxes/**'
       - 'tests/**'
-      - '*.md'
+      - '**.md'
   pull_request:
     branches:
       - main
     paths-ignore:
       - 'syntaxes/**'
       - 'tests/**'
-      - '*.md'
+      - '**.md'
 
 jobs:
   lint:


### PR DESCRIPTION
This fixes the Markdown file glob for the GitHub Test Action.
