### PR TITLE
Fix highlighting for computed map keys

### DIFF
--- a/syntaxes/terraform.tmGrammar.json
+++ b/syntaxes/terraform.tmGrammar.json
@@ -527,7 +527,7 @@
 							"name": "punctuation.section.parens.begin.terraform"
 						}
 					},
-					"end": "(\\))\\s*(\\=)\\s*",
+					"end": "(\\))\\s*(=|:)\\s*",
 					"endCaptures": {
 						"1": {
 							"name": "punctuation.section.parens.end.terraform"

--- a/tests/snapshot/terraform/issue809.tf
+++ b/tests/snapshot/terraform/issue809.tf
@@ -1,0 +1,10 @@
+locals {
+  key_name = "testing"
+  test_example = {
+    (local.key_name): "test"
+  }
+}
+
+variable "test" {
+  default = "test"
+}

--- a/tests/snapshot/terraform/issue809.tf.snap
+++ b/tests/snapshot/terraform/issue809.tf.snap
@@ -23,16 +23,33 @@
 #     ^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform support.constant.terraform
 #          ^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform keyword.operator.accessor.terraform
 #           ^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform variable.other.member.terraform
-#                   ^^^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform
+#                   ^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform punctuation.section.parens.end.terraform
+#                    ^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform keyword.operator.terraform
+#                     ^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform
+#                      ^ source.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#                       ^^^^ source.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform
+#                           ^ source.terraform meta.block.terraform meta.braces.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >  }
-#^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform
+#^^ source.terraform meta.block.terraform meta.braces.terraform
+#  ^ source.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.end.terraform
 >}
-#^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >
 >variable "test" {
-#^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform
+#^^^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#        ^ source.terraform meta.block.terraform
+#         ^^^^^^ source.terraform meta.block.terraform variable.other.enummember.terraform
+#               ^ source.terraform meta.block.terraform
+#                ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
 >  default = "test"
-#^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#         ^ source.terraform meta.block.terraform variable.declaration.terraform
+#          ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#           ^ source.terraform meta.block.terraform variable.declaration.terraform
+#            ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#             ^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                 ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
 >}
-#^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform
+#^ source.terraform meta.block.terraform punctuation.section.block.end.terraform
 >

--- a/tests/snapshot/terraform/issue809.tf.snap
+++ b/tests/snapshot/terraform/issue809.tf.snap
@@ -1,0 +1,38 @@
+>locals {
+#^^^^^^ source.terraform meta.block.terraform entity.name.type.terraform
+#      ^ source.terraform meta.block.terraform
+#       ^ source.terraform meta.block.terraform punctuation.section.block.begin.terraform
+>  key_name = "testing"
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#          ^ source.terraform meta.block.terraform variable.declaration.terraform
+#           ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#            ^ source.terraform meta.block.terraform variable.declaration.terraform
+#             ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.begin.terraform
+#              ^^^^^^^ source.terraform meta.block.terraform string.quoted.double.terraform
+#                     ^ source.terraform meta.block.terraform string.quoted.double.terraform punctuation.definition.string.end.terraform
+>  test_example = {
+#^^ source.terraform meta.block.terraform
+#  ^^^^^^^^^^^^ source.terraform meta.block.terraform variable.declaration.terraform variable.other.readwrite.terraform
+#              ^ source.terraform meta.block.terraform variable.declaration.terraform
+#               ^ source.terraform meta.block.terraform variable.declaration.terraform keyword.operator.assignment.terraform
+#                ^ source.terraform meta.block.terraform variable.declaration.terraform
+#                 ^ source.terraform meta.block.terraform meta.braces.terraform punctuation.section.braces.begin.terraform
+>    (local.key_name): "test"
+#^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform punctuation.section.parens.begin.terraform
+#     ^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform support.constant.terraform
+#          ^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform keyword.operator.accessor.terraform
+#           ^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform variable.other.member.terraform
+#                   ^^^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform
+>  }
+#^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform
+>}
+#^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform
+>
+>variable "test" {
+#^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform
+>  default = "test"
+#^^^^^^^^^^^^^^^^^^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform
+>}
+#^^ source.terraform meta.block.terraform meta.braces.terraform meta.mapping.key.terraform
+>


### PR DESCRIPTION
This PR adds the missing `:` operator for computed map keys. Until now the `end` regex wasn't able to match anything and claimed the rest of the file as `meta.mapping.key`.
 
## Before
<img width="274" alt="CleanShot 2022-03-02 at 17 35 07@2x" src="https://user-images.githubusercontent.com/45985/156405914-1dd127ea-4469-4b6d-b53f-c7671aa89729.png">

## After
<img width="279" alt="CleanShot 2022-03-02 at 17 35 23@2x" src="https://user-images.githubusercontent.com/45985/156405923-b6f945e5-94fe-4b06-ac96-f5b7c5420b58.png">

Closes #809 