### PR TITLE
github: declare explicit permissions for workflows

### DIFF
--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -1,5 +1,9 @@
 name: Issue Comment Created Triage
 
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   issue_comment:
     types: [created]

--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -1,5 +1,9 @@
 name: 'Lock Threads'
 
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   schedule:
     - cron: '0 3 * * *'
@@ -10,7 +14,6 @@ jobs:
     steps:
       - uses: dessant/lock-threads@v2
         with:
-          github-token: ${{ github.token }}
           issue-lock-comment: >
             I'm going to lock this issue because it has been closed for _30 days_ ⏳. This helps our maintainers find and focus on the active issues.
 

--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -1,5 +1,8 @@
 name: Publish Preview release
 
+permissions:
+  contents: write # for uploading release artifacts
+
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,5 +1,8 @@
 name: Publish release
 
+permissions:
+  contents: write # for uploading release artifacts
+
 on:
   push:
     tags:

--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,4 +1,9 @@
 name: "Stale issues and pull requests"
+
+permissions:
+  issues: write
+  pull-requests: write
+
 on:
   schedule:
   - cron: "10 3 * * *"
@@ -9,7 +14,6 @@ jobs:
     steps:
     - uses: actions/stale@v3
       with:
-        repo-token: ${{ secrets.GITHUB_TOKEN }}
         days-before-stale: '-1'
         days-before-close: '90'
         only-labels: 'waiting-response'

--- a/.github/workflows/syntax.yml
+++ b/.github/workflows/syntax.yml
@@ -1,5 +1,8 @@
 name: Run syntax tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,8 @@
 name: Run tests
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
This allows us to be a little bit more defensive by not giving any workflows more permissions than they really need and use this safer default settings for the repo

![Screenshot 2022-03-04 at 09 16 36](https://user-images.githubusercontent.com/287584/156740631-5438a304-319c-4eb4-9226-6e31dcb30fda.png)

