### PR TITLE
github: pin Windows to 2019 to prevent timeouts

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-latest
+          - windows-2019 # temporary pin to avoid timeouts on windows-2022
           - macos-latest
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
@@ -62,7 +62,7 @@ jobs:
           - 'insiders'
           - 'stable'
         os:
-          - windows-latest
+          - windows-2019 # temporary pin to avoid timeouts on windows-2022
           - macos-latest
           - macos-11.0
           - ubuntu-latest


### PR DESCRIPTION
As other people have reported in https://github.com/actions/virtual-environments/issues/4856 there are some issues with windows-2022 (which we consume through `windows-latest`) causing our windows builds to occasionally time out through no fault of our own.

This is in order to address that temporarily but I am hoping we can use 2022 soon, once the bugs are fixed by GitHub.