### PR TITLE
Ensure VSCode JSON files are treated as JSON with comments

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,8 @@
 # GitHub Actions CI doesn't have "native" solution for this
 # See https://github.com/actions/checkout/issues/226
 *.ts text eol=lf
+language-configuration.json linguist-language=jsonc
+.vscode/**.json linguist-language=jsonc
 *.json text eol=lf
 *.md text eol=lf
 *.tf text eol=lf

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,6 +15,10 @@
     "node_modules": true,
     "out": true
   },
+  "files.associations": {
+    "language-configuration.json": "jsonc",
+    ".vscode/**.json": "jsonc"
+  },
 
   "typescript.format.enable": false,
   "typescript.tsc.autoDetect": "off",


### PR DESCRIPTION
This is to help in editing in VSCode (where it automatically picks `JSON with Comments` instead of `JSON`) and also in highlighting in GitHub UI, so comments are no longer treated as "invalid" and no longer highlighted as red.

See https://code.visualstudio.com/docs/languages/identifiers and https://github.com/github/linguist/blob/master/docs/overrides.md#using-gitattributes