### PR TITLE
vscode: omit redundant `file.associations` section

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -15,10 +15,6 @@
     "node_modules": true,
     "out": true
   },
-  "files.associations": {
-    "language-configuration.json": "jsonc",
-    ".vscode/**.json": "jsonc"
-  },
 
   "typescript.format.enable": false,
   "typescript.tsc.autoDetect": "off",


### PR DESCRIPTION
As it turns out this is already covered via a VSCode built-in extension:

https://github.com/microsoft/vscode/blob/bd3165e41777e5b7879a53c448062cd34617c2d2/extensions/configuration-editing/package.json#L32-L58

and so VSCode will actually highlight these files as `JSON with Comments` by default already. I just confusingly expected `package.json` to be treated the same way but as @jpogran mentioned to me earlier that file should be kept as more "strict" JSON (without comments).

The GitHub Linguist hints added to `.gitattributes` are still useful for GitHub highlighting though.