### PR TITLE
Advertise proper exectution location

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,9 @@
   "license": "MPL-2.0",
   "preview": false,
   "private": true,
+  "extensionKind": [
+    "workspace"
+  ],
   "engines": {
     "npm": "~8.X",
     "node": "~16.X",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   "preview": false,
   "private": true,
   "extensionKind": [
-    "workspace"
+    "workspace",
+    "ui"
   ],
   "engines": {
     "npm": "~8.X",


### PR DESCRIPTION
Specify the workspace execution location so that VS Code prefers to install this extension in the remote host when using Remote Extensions like the Remote Container, SSH, or WSL extensions. VS Code will still install this extension locally when working on the local machine.

For more inforamtion see:

- https://code.visualstudio.com/api/advanced-topics/remote-extensions#incorrect-execution-location
- https://code.visualstudio.com/api/advanced-topics/extension-host#preferred-extension-location

Install to local:

![image](https://user-images.githubusercontent.com/272569/157523709-d18f4e42-65bb-483b-8662-b817ccc4c270.png)

Install to WSL:

![image](https://user-images.githubusercontent.com/272569/157524366-c824178e-23b1-499a-9a46-40b89b13ebc3.png)
