### PR TITLE
bump LS to 0.26.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "vscode": "^1.61.0"
   },
   "langServer": {
-    "version": "0.25.2"
+    "version": "0.26.0"
   },
   "qna": "https://discuss.hashicorp.com/c/terraform-core/terraform-editor-integrations/46",
   "bugs": {

--- a/src/test/integration/workspaces.test.ts
+++ b/src/test/integration/workspaces.test.ts
@@ -18,7 +18,12 @@ suite('moduleCallers', () => {
     assert.ok(response);
 
     assert.strictEqual(response.moduleCallers.length, 1);
-    assert.strictEqual(response.moduleCallers[0].uri, vscode.Uri.file(testFolderPath).toString(true));
+    assert.strictEqual(
+      // ensure both URIs are normalized, which is what VSCode would do anyway
+      // see https://github.com/microsoft/vscode/issues/42159#issuecomment-360533151
+      vscode.Uri.parse(response.moduleCallers[0].uri).toString(true),
+      vscode.Uri.file(testFolderPath).toString(true),
+    );
   });
 });
 


### PR DESCRIPTION
In terms of Changelog entries I expect we can basically link to https://github.com/hashicorp/terraform-ls/releases/tag/v0.26.0