### PR TITLE
Remove terraform.languageServer.requiredVersion

### DIFF
--- a/package.json
+++ b/package.json
@@ -194,11 +194,6 @@
               ],
               "default": "off",
               "description": "Traces the communication between VS Code and the language server."
-            },
-            "requiredVersion": {
-              "type": "string",
-              "description": "The required version of the Language Server described as a semantic version string, for example '^2.0.1' or '> 1.0'. Defaults to latest available version.",
-              "deprecationMessage": "Deprecated: A platform specific Language Server binary will be bundled with the extension in a future release. If you wish to use a different version than the one shipped with the extension, use terraform.languageServer.pathToBinary"
             }
           },
           "default": {


### PR DESCRIPTION
This was deprecated in https://github.com/hashicorp/vscode-terraform/commit/3668713bd926678d7393afc5d50659033b524e88 and the usage was removed in https://github.com/hashicorp/vscode-terraform/commit/2a3888160b4b9aa7165f0eceb07cc5e8986b1f2e. This no longer needs to be in the extension.
