### PR TITLE
Add terraform.languageServer.ignoreSingleFileWarning setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -220,6 +220,11 @@
               "trace.server": "off"
             }
           },
+          "terraform.languageServer.ignoreSingleFileWarning": {
+            "scope": "resource",
+            "type": "boolean",
+            "description": "Path to the Terraform binary"
+          },
           "terraform-ls.rootModules": {
             "scope": "resource",
             "type": "array",

--- a/package.json
+++ b/package.json
@@ -223,7 +223,8 @@
           "terraform.languageServer.ignoreSingleFileWarning": {
             "scope": "resource",
             "type": "boolean",
-            "description": "Path to the Terraform binary"
+            "default": false,
+            "description": "This setting controls whether terraform-ls sends a warning about opening up a single Terraform file instead of a Terraform folder. Setting this to `true` will prevent the message being sent. The default value is `false`."
           },
           "terraform-ls.rootModules": {
             "scope": "resource",

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -137,6 +137,8 @@ export class ClientHandler {
     const excludeModulePaths = config('terraform-ls').get<string[]>('excludeRootModules', []);
     const ignoreDirectoryNames = config('terraform-ls').get<string[]>('ignoreDirectoryNames', []);
 
+    const ignoreSingleFileWarning = config('terraform').get<boolean>('languageServer.ignoreSingleFileWarning', false);
+
     if (rootModulePaths.length > 0 && excludeModulePaths.length > 0) {
       throw new Error(
         'Only one of rootModules and excludeRootModules can be set at the same time, please remove the conflicting config and reload',
@@ -147,6 +149,7 @@ export class ClientHandler {
     const initializationOptions = {
       commandPrefix,
       experimentalFeatures,
+      ignoreSingleFileWarning,
       ...(terraformExecPath.length > 0 && { terraformExecPath }),
       ...(terraformExecTimeout.length > 0 && { terraformExecTimeout }),
       ...(terraformLogFilePath.length > 0 && { terraformLogFilePath }),


### PR DESCRIPTION
Adds the terraform-ls setting that controls whether warnings are shown when editing single Terraform files.

Works with https://github.com/hashicorp/terraform-ls/pull/843