### PR TITLE
Prevent preview from activating when stable is enabled

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,6 +23,17 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   reporter = new TelemetryReporter(context.extension.id, manifest.version, manifest.appInsightsKey);
   context.subscriptions.push(reporter);
 
+  if (context.extension.id === 'hashicorp.terraform-preview') {
+    const stable = vscode.extensions.getExtension('hashicorp.terraform');
+    if (stable !== null) {
+      vscode.window.showErrorMessage(
+        'Terraform Preview cannot be used while Terraform Stable is also enabled. Please ensure only one is enabled and reload this window',
+      );
+
+      return undefined;
+    }
+  }
+
   const lsPath = new ServerPath(context);
   clientHandler = new ClientHandler(lsPath, outputChannel, reporter);
   clientHandler.extSemanticTokenTypes = tokenTypesFromExtManifest(manifest);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,13 +23,21 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   reporter = new TelemetryReporter(context.extension.id, manifest.version, manifest.appInsightsKey);
   context.subscriptions.push(reporter);
 
-  if (context.extension.id === 'hashicorp.terraform-preview') {
-    const stable = vscode.extensions.getExtension('hashicorp.terraform');
-    if (stable !== null) {
-      vscode.window.showErrorMessage(
-        'Terraform Preview cannot be used while Terraform Stable is also enabled. Please ensure only one is enabled and reload this window',
-      );
+  const stable = vscode.extensions.getExtension('hashicorp.terraform');
+  const preview = vscode.extensions.getExtension('hashicorp.terraform-preview');
 
+  if (context.extension.id === 'hashicorp.terraform-preview') {
+    if (stable !== undefined) {
+      vscode.window.showErrorMessage(
+        'Terraform Preview cannot be used while Terraform Stable is also enabled. Please ensure only one is enabled or installed and reload this window',
+      );
+      return undefined;
+    }
+  } else if (context.extension.id === 'hashicorp.terraform') {
+    if (preview !== undefined) {
+      vscode.window.showErrorMessage(
+        'Terraform Stable cannot be used while Terraform Preview is also enabled. Please ensure only one is enabled or installed and reload this window',
+      );
       return undefined;
     }
   }


### PR DESCRIPTION
This PR prevents the preview extension from activating when the stable extension is enabled, or vice versa.

![image](https://user-images.githubusercontent.com/272569/162056901-aa5f1924-fc70-49e8-9d9d-ec4941ef439b.png)


To test:

> Note: You cannot test this inside the Extension host.

- Package hashicorp.terraform
- Package hashicorp.terraform-preview
- Install both in a new VS Code Install (or ensure your ~/.vscode/extensions directory does not have any existing installs)

On installing the second VSIX, you should get an error message popup. Disabling one and reloading should show a properly activated extension. Enabling the other one and disabling the first should produce a error message pop up.
