### PR TITLE
Fix LANGUAGE_SERVER_VERSION test in preview script

### DIFF
--- a/build/preview
+++ b/build/preview
@@ -9,7 +9,7 @@ cd $ROOT_RELATIVE_DIR
 
 # get current version info
 VERSION=`git log -1 --format=%cd --date="format:%Y.%-m.%-d%H"`
-if [ -z "$LANGUAGE_SERVER_VERSION" ]; then
+if [ -z "${LANGUAGE_SERVER_VERSION:-}" ]; then
   LANGUAGE_SERVER_VERSION="$(jq -r .langServer.version package.json)"
 fi
 


### PR DESCRIPTION
While testing #1032, I noticed that the test for the `LANGUAGE_SERVER_VERSION` variable isn't working if the variable is unset, and the script exits with an error. This PR fixes the test.

```bash
$ ./build/preview
./build/preview: line 12: LANGUAGE_SERVER_VERSION: unbound variable
```