### PR TITLE
Disable naming convention warning for Code Action identifier

### DIFF
--- a/src/test/integration/codeAction.test.ts
+++ b/src/test/integration/codeAction.test.ts
@@ -14,6 +14,7 @@ suite('code actions', () => {
       .update('languageServer', { external: true }, vscode.ConfigurationTarget.Workspace);
     await vscode.workspace
       .getConfiguration('editor')
+      // eslint-disable-next-line @typescript-eslint/naming-convention
       .update('codeActionsOnSave', { 'source.formatAll.terraform': true }, vscode.ConfigurationTarget.Workspace);
 
     const docUri = getDocUri('actions.tf');


### PR DESCRIPTION
The Typescript naming convention does not apply to Code Action identifiers, but is being triggerd here because it's being used as a object property key to update the VS Code settings in this test. This can be safely ignored.
