### PR TITLE
Github Release Notes Generator file

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,32 @@
+changelog:
+  categories:
+    - title: BREAKING CHANGES
+      labels:
+        - breaking
+    - title: NOTES
+      labels:
+        - note
+        - documentation
+    - title: FEATURES
+      labels:
+        - feature
+    - title: ENHANCEMENTS
+      labels:
+        - enhancement
+    - title: BUG FIXES
+      labels:
+        - bug
+    - title: INTERNAL
+      labels:
+        - dependencies
+        - ci
+        - "*"
+  exclude:
+    labels:
+      - duplicate
+      - wontfix
+      - question
+      - invalid
+      - needs-reproduction
+      - needs-research
+      - stale


### PR DESCRIPTION
This adds a configuration file to the repo for the Github Release Notes
API to read. This does not create a release or any other change to the
repo, it just generates a changelog that is very close to how we
currently format the changelog. This aids in reconciling changes before
release time.
