### PR TITLE
deps: bump LS to 0.27.0

### DIFF
--- a/build/downloader.ts
+++ b/build/downloader.ts
@@ -63,7 +63,7 @@ async function downloadLanguageServer(platform: string, architecture: string, ex
   const repoDir = cwd.replace(buildDir, '');
   const installPath = path.join(repoDir, 'bin');
   if (fs.existsSync(installPath)) {
-    console.log('terraform-ls path exists. Exiting');
+    console.log(`bin path exists at ${installPath}. Exiting`);
     return;
   }
 

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "vscode": "^1.61.0"
   },
   "langServer": {
-    "version": "0.26.0"
+    "version": "0.27.0"
   },
   "syntax": {
     "version": "0.2.0"


### PR DESCRIPTION
https://github.com/hashicorp/terraform-ls/releases/tag/v0.27.0

I also adjusted the log message.

I initially ran `rm bin/terraform-ls` and then was left confused why am I getting `terraform-ls path exists` when it's already gone. Only after reading the relevant code more carefully I realized that we're checking for the parent directory.

We could be checking the binary path instead of the parent dir, but I thought this just improves the UX without changing the behaviour.
