### PR TITLE
Add OpenVSX publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -91,6 +91,6 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
       - name: Publish Extension
-        run: npx ovsx publish --no-git-tag-version --packagePath $(find . -iname *.vsix)
+        run: npx ovsx publish --packagePath $(find . -iname *.vsix)
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -71,18 +71,26 @@ jobs:
           name: ${{ matrix.vsce_target }}
           path: "*.vsix"
 
-  publish:
-    name: Publish All
+  publish-vsce:
+    name: Publish All (Microsoft Marketplace)
     runs-on: ubuntu-latest
     needs: build
     if: success() && startsWith( github.ref, 'refs/tags/v')
     steps:
       - uses: actions/download-artifact@v3
-      - name: Publish Extension (Microsoft Marketplace)
+      - name: Publish Extension
         run: npx vsce publish --no-git-tag-version --packagePath $(find . -iname *.vsix)
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
-      - name: Publish Extension (OpenVSX)
+
+  publish-ovsx:
+    name: Publish All (OpenVSX)
+    runs-on: ubuntu-latest
+    needs: build
+    if: success() && startsWith( github.ref, 'refs/tags/v')
+    steps:
+      - uses: actions/download-artifact@v3
+      - name: Publish Extension
         run: npx ovsx publish --no-git-tag-version --packagePath $(find . -iname *.vsix)
         env:
           OVSX_PAT: ${{ secrets.OVSX_PAT }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,7 +78,11 @@ jobs:
     if: success() && startsWith( github.ref, 'refs/tags/v')
     steps:
       - uses: actions/download-artifact@v3
-      - name: Publish Extension
+      - name: Publish Extension (Microsoft Marketplace)
         run: npx vsce publish --no-git-tag-version --packagePath $(find . -iname *.vsix)
         env:
           VSCE_PAT: ${{ secrets.VSCE_PAT }}
+      - name: Publish Extension (OpenVSX)
+        run: npx ovsx publish --no-git-tag-version --packagePath $(find . -iname *.vsix)
+        env:
+          OVSX_PAT: ${{ secrets.OVSX_PAT }}


### PR DESCRIPTION
This is a succession to https://github.com/hashicorp/vscode-terraform/pull/388, which adapts publishing to OpenVSX embedded in the publishing workflow in GitHub Actions.

Fixes #379 

Before using this it is necessary to set up an `OVSX_PAT` GitHub Action secret with the value from [open-vsx.org/user-settings/tokens](https://open-vsx.org/user-settings/tokens). A claim of the `hashicorp` namespace will be also required (this can be done by submitting [an issue](https://github.com/EclipseFdn/open-vsx.org/issues/new?assignees=&labels=namespace&template=claim-namespace-ownership.md&title=Claiming+namespace+%5Bname%5D) in the OpenVSX repo).
