### PR TITLE
Add Module Providers view refresh button

### DIFF
--- a/package.json
+++ b/package.json
@@ -307,12 +307,12 @@
       },
       {
         "command": "terraform.modules.refreshList",
-        "title": "Refresh",
+        "title": "Refresh Module Calls",
         "icon": "$(refresh)"
       },
       {
         "command": "terraform.providers.refreshList",
-        "title": "Refresh",
+        "title": "Refresh Module Providers",
         "icon": "$(refresh)"
       },
       {

--- a/package.json
+++ b/package.json
@@ -311,6 +311,11 @@
         "icon": "$(refresh)"
       },
       {
+        "command": "terraform.providers.refreshList",
+        "title": "Refresh",
+        "icon": "$(refresh)"
+      },
+      {
         "command": "terraform.modules.openDocumentation",
         "title": "Open Documentation",
         "icon": "$(book)"
@@ -328,6 +333,10 @@
           "when": "false"
         },
         {
+          "command": "terraform.providers.refreshList",
+          "when": "false"
+        },
+        {
           "command": "terraform.modules.openDocumentation",
           "when": "false"
         },
@@ -340,6 +349,11 @@
         {
           "command": "terraform.modules.refreshList",
           "when": "view == terraform.modules",
+          "group": "navigation"
+        },
+        {
+          "command": "terraform.providers.refreshList",
+          "when": "view == terraform.providers",
           "group": "navigation"
         }
       ],

--- a/src/providers/moduleProviders.ts
+++ b/src/providers/moduleProviders.ts
@@ -47,6 +47,7 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
 
   constructor(ctx: vscode.ExtensionContext, private handler: ClientHandler) {
     ctx.subscriptions.push(
+      vscode.commands.registerCommand('terraform.providers.refreshList', () => this.refresh()),
       vscode.window.onDidChangeActiveTextEditor(async (event: vscode.TextEditor | undefined) => {
         const activeEditor = getActiveTextEditor();
 


### PR DESCRIPTION
This adds the refresh button to the Terraform Module Providers view and hooks it up to the refresh method.
