### PR TITLE
dependabot: Reduce interval for dev dependencies to weekly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,19 @@ updates:
     schedule:
       interval: "daily"
     labels: ["dependencies"]
+    allow:
+      - dependency-type: "production"
+      - dependency-name: "@hashicorp/js-releases"
+
+  - package-ecosystem: "npm"
+    versioning-strategy: lockfile-only
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels: ["dependencies"]
+    allow:
+      - dependency-type: "development"
+
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
The motivation is to reduce the noise coming mainly from frequently updated `@types/*` packages which are not critical for us, along with most dev dependencies.

`@hashicorp/js-releases` is one we maintain ourselves and don't release as frequently, so that shouldn't present the same challenge as the others.

https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#scheduleinterval