### PR TITLE
Remove command prefix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.4.9",
-        "short-unique-id": "^3.2.3",
         "vscode-languageclient": "^7.0.0",
         "vscode-uri": "^3.0.2",
         "which": "^2.0.2"
@@ -7019,14 +7018,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/short-unique-id": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-3.2.3.tgz",
-      "integrity": "sha512-DaUTmZe2PP34AQ2DmBOjo0W41Br/74EbKmEosfipbMJdJf2MCdzgJBOXn+PRe/ERFnr9uRKnUa6Kb5X+VC3bCQ==",
-      "bin": {
-        "short-unique-id": "bin/short-unique-id"
-      }
-    },
     "node_modules/side-channel": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
@@ -13709,11 +13700,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
-    },
-    "short-unique-id": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/short-unique-id/-/short-unique-id-3.2.3.tgz",
-      "integrity": "sha512-DaUTmZe2PP34AQ2DmBOjo0W41Br/74EbKmEosfipbMJdJf2MCdzgJBOXn+PRe/ERFnr9uRKnUa6Kb5X+VC3bCQ=="
     },
     "side-channel": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -418,7 +418,6 @@
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.4.9",
-    "short-unique-id": "^3.2.3",
     "vscode-languageclient": "^7.0.0",
     "vscode-uri": "^3.0.2",
     "which": "^2.0.2"

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -17,7 +17,6 @@ import { ShowReferencesFeature } from './features/showReferences';
 import { TelemetryFeature } from './features/telemetry';
 
 export interface TerraformLanguageClient {
-  commandPrefix: string;
   client: LanguageClient;
 }
 
@@ -66,9 +65,7 @@ export class ClientHandler {
   }
 
   private async createTerraformClient(): Promise<TerraformLanguageClient> {
-    const commandPrefix = this.shortUid.seq();
-
-    const initializationOptions = this.getInitializationOptions(commandPrefix);
+    const initializationOptions = this.getInitializationOptions();
 
     const serverOptions = await this.getServerOptions();
 
@@ -109,7 +106,7 @@ export class ClientHandler {
       }
     });
 
-    return { commandPrefix, client };
+    return { client };
   }
 
   private async getServerOptions(): Promise<ServerOptions> {
@@ -128,7 +125,7 @@ export class ClientHandler {
     return serverOptions;
   }
 
-  private getInitializationOptions(commandPrefix: string) {
+  private getInitializationOptions() {
     const rootModulePaths = config('terraform-ls').get<string[]>('rootModules', []);
     const terraformExecPath = config('terraform-ls').get<string>('terraformExecPath', '');
     const terraformExecTimeout = config('terraform-ls').get<string>('terraformExecTimeout', '');
@@ -146,7 +143,6 @@ export class ClientHandler {
 
     const experimentalFeatures = config('terraform-ls').get('experimentalFeatures');
     const initializationOptions = {
-      commandPrefix,
       experimentalFeatures,
       ignoreSingleFileWarning,
       ...(terraformExecPath.length > 0 && { terraformExecPath }),

--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -1,4 +1,3 @@
-import ShortUniqueId from 'short-unique-id';
 import * as vscode from 'vscode';
 import TelemetryReporter from '@vscode/extension-telemetry';
 import {
@@ -16,17 +15,12 @@ import { PartialManifest, CustomSemanticTokens } from './features/semanticTokens
 import { ShowReferencesFeature } from './features/showReferences';
 import { TelemetryFeature } from './features/telemetry';
 
-export interface TerraformLanguageClient {
-  client: LanguageClient;
-}
-
 /**
  * ClientHandler maintains lifecycles of language clients
  * based on the server's capabilities
  */
 export class ClientHandler {
-  private shortUid: ShortUniqueId = new ShortUniqueId();
-  private tfClient: TerraformLanguageClient | undefined;
+  private client: LanguageClient | undefined;
   private commands: string[] = [];
 
   public extSemanticTokenTypes: string[] = [];
@@ -46,14 +40,14 @@ export class ClientHandler {
   public async startClient(): Promise<vscode.Disposable> {
     console.log('Starting client');
 
-    this.tfClient = await this.createTerraformClient();
-    const disposable = this.tfClient.client.start();
+    this.client = await this.createTerraformClient();
+    const disposable = this.client.start();
 
-    await this.tfClient.client.onReady();
+    await this.client.onReady();
 
     this.reporter.sendTelemetryEvent('startClient');
 
-    const initializeResult = this.tfClient.client.initializeResult;
+    const initializeResult = this.client.initializeResult;
     if (initializeResult !== undefined) {
       const multiFoldersSupported = initializeResult.capabilities.workspace?.workspaceFolders?.supported;
       console.log(`Multi-folder support: ${multiFoldersSupported}`);
@@ -64,7 +58,7 @@ export class ClientHandler {
     return disposable;
   }
 
-  private async createTerraformClient(): Promise<TerraformLanguageClient> {
+  private async createTerraformClient(): Promise<LanguageClient> {
     const initializationOptions = this.getInitializationOptions();
 
     const serverOptions = await this.getServerOptions();
@@ -106,7 +100,7 @@ export class ClientHandler {
       }
     });
 
-    return { client };
+    return client;
   }
 
   private async getServerOptions(): Promise<ServerOptions> {
@@ -156,16 +150,16 @@ export class ClientHandler {
   }
 
   public async stopClient(): Promise<void> {
-    if (this.tfClient?.client === undefined) {
+    if (this.client === undefined) {
       return;
     }
 
-    await this.tfClient.client.stop();
+    await this.client.stop();
     console.log('Client stopped');
   }
 
-  public getClient(): TerraformLanguageClient | undefined {
-    return this.tfClient;
+  public getClient(): LanguageClient | undefined {
+    return this.client;
   }
 
   public clientSupportsCommand(cmdName: string): boolean {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -99,7 +99,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       if (selected && client) {
         const moduleUri = selected[0];
         const requestParams: ExecuteCommandParams = {
-          command: `${client.commandPrefix}.terraform-ls.terraform.init`,
+          command: `terraform-ls.terraform.init`,
           arguments: [`uri=${moduleUri}`],
         };
         await execWorkspaceCommand(client.client, requestParams);
@@ -162,7 +162,7 @@ export async function updateTerraformStatusBar(documentUri: vscode.Uri): Promise
     return;
   }
 
-  const initSupported = clientHandler.clientSupportsCommand(`${client.commandPrefix}.terraform-ls.terraform.init`);
+  const initSupported = clientHandler.clientSupportsCommand(`terraform-ls.terraform.init`);
   if (!initSupported) {
     return;
   }
@@ -238,7 +238,7 @@ interface ModuleCallersResponse {
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 async function modulesCallersCommand(languageClient: TerraformLanguageClient, moduleUri: string): Promise<any> {
   const requestParams: ExecuteCommandParams = {
-    command: `${languageClient.commandPrefix}.terraform-ls.module.callers`,
+    command: `terraform-ls.module.callers`,
     arguments: [`uri=${moduleUri}`],
   };
   return execWorkspaceCommand(languageClient.client, requestParams);
@@ -286,7 +286,7 @@ async function terraformCommand(command: string, languageServerExec = true): Pro
 
     if (languageServerExec && languageClient) {
       const requestParams: ExecuteCommandParams = {
-        command: `${languageClient.commandPrefix}.terraform-ls.terraform.${command}`,
+        command: `terraform-ls.terraform.${command}`,
         arguments: [`uri=${selectedModule}`],
       };
       return execWorkspaceCommand(languageClient.client, requestParams);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -3,7 +3,7 @@ import TelemetryReporter from '@vscode/extension-telemetry';
 import { ExecuteCommandParams, ExecuteCommandRequest } from 'vscode-languageclient';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { Utils } from 'vscode-uri';
-import { ClientHandler, TerraformLanguageClient } from './clientHandler';
+import { ClientHandler } from './clientHandler';
 import { GenerateBugReportCommand } from './commands/generateBugReport';
 import { ModuleCallsDataProvider } from './providers/moduleCalls';
 import { ModuleProvidersDataProvider } from './providers/moduleProviders';
@@ -102,7 +102,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
           command: `terraform-ls.terraform.init`,
           arguments: [`uri=${moduleUri}`],
         };
-        await execWorkspaceCommand(client.client, requestParams);
+        await execWorkspaceCommand(client, requestParams);
       }
     }),
     vscode.commands.registerCommand('terraform.initCurrent', async () => {
@@ -236,12 +236,12 @@ interface ModuleCallersResponse {
 }
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-async function modulesCallersCommand(languageClient: TerraformLanguageClient, moduleUri: string): Promise<any> {
+async function modulesCallersCommand(languageClient: LanguageClient, moduleUri: string): Promise<any> {
   const requestParams: ExecuteCommandParams = {
     command: `terraform-ls.module.callers`,
     arguments: [`uri=${moduleUri}`],
   };
-  return execWorkspaceCommand(languageClient.client, requestParams);
+  return execWorkspaceCommand(languageClient, requestParams);
 }
 
 export async function moduleCallers(moduleUri: string): Promise<ModuleCallersResponse> {
@@ -289,7 +289,7 @@ async function terraformCommand(command: string, languageServerExec = true): Pro
         command: `terraform-ls.terraform.${command}`,
         arguments: [`uri=${selectedModule}`],
       };
-      return execWorkspaceCommand(languageClient.client, requestParams);
+      return execWorkspaceCommand(languageClient, requestParams);
     } else {
       const terminalName = `Terraform ${selectedModule}`;
       const moduleURI = vscode.Uri.parse(selectedModule);

--- a/src/providers/moduleCalls.ts
+++ b/src/providers/moduleCalls.ts
@@ -136,7 +136,7 @@ export class ModuleCallsDataProvider implements vscode.TreeDataProvider<ModuleCa
       return [];
     }
 
-    return await handler.client.onReady().then(async () => {
+    return await handler.onReady().then(async () => {
       const moduleCallsSupported = this.handler.clientSupportsCommand(`terraform-ls.module.calls`);
       if (!moduleCallsSupported) {
         return Promise.resolve([]);
@@ -147,7 +147,7 @@ export class ModuleCallsDataProvider implements vscode.TreeDataProvider<ModuleCa
         arguments: [`uri=${documentURI}`],
       };
 
-      const response = await handler.client.sendRequest<ExecuteCommandParams, ModuleCallsResponse, void>(
+      const response = await handler.sendRequest<ExecuteCommandParams, ModuleCallsResponse, void>(
         ExecuteCommandRequest.type,
         params,
       );

--- a/src/providers/moduleCalls.ts
+++ b/src/providers/moduleCalls.ts
@@ -79,6 +79,7 @@ export class ModuleCallsDataProvider implements vscode.TreeDataProvider<ModuleCa
 
   constructor(ctx: vscode.ExtensionContext, public handler: ClientHandler) {
     this.svg = ctx.asAbsolutePath(path.join('assets', 'icons', 'terraform.svg'));
+
     ctx.subscriptions.push(
       vscode.commands.registerCommand('terraform.modules.refreshList', () => this.refresh()),
       vscode.commands.registerCommand('terraform.modules.openDocumentation', (module: ModuleCallItem) => {
@@ -136,15 +137,13 @@ export class ModuleCallsDataProvider implements vscode.TreeDataProvider<ModuleCa
     }
 
     return await handler.client.onReady().then(async () => {
-      const moduleCallsSupported = this.handler.clientSupportsCommand(
-        `${handler.commandPrefix}.terraform-ls.module.calls`,
-      );
+      const moduleCallsSupported = this.handler.clientSupportsCommand(`terraform-ls.module.calls`);
       if (!moduleCallsSupported) {
         return Promise.resolve([]);
       }
 
       const params: ExecuteCommandParams = {
-        command: `${handler.commandPrefix}.terraform-ls.module.calls`,
+        command: `terraform-ls.module.calls`,
         arguments: [`uri=${documentURI}`],
       };
 

--- a/src/providers/moduleCalls.ts
+++ b/src/providers/moduleCalls.ts
@@ -135,32 +135,31 @@ export class ModuleCallsDataProvider implements vscode.TreeDataProvider<ModuleCa
     if (handler === undefined) {
       return [];
     }
+    await handler.onReady();
 
-    return await handler.onReady().then(async () => {
-      const moduleCallsSupported = this.handler.clientSupportsCommand(`terraform-ls.module.calls`);
-      if (!moduleCallsSupported) {
-        return Promise.resolve([]);
-      }
+    const commandSupported = this.handler.clientSupportsCommand(`terraform-ls.module.calls`);
+    if (!commandSupported) {
+      return Promise.resolve([]);
+    }
 
-      const params: ExecuteCommandParams = {
-        command: `terraform-ls.module.calls`,
-        arguments: [`uri=${documentURI}`],
-      };
+    const params: ExecuteCommandParams = {
+      command: `terraform-ls.module.calls`,
+      arguments: [`uri=${documentURI}`],
+    };
 
-      const response = await handler.sendRequest<ExecuteCommandParams, ModuleCallsResponse, void>(
-        ExecuteCommandRequest.type,
-        params,
-      );
-      if (response === null) {
-        return Promise.resolve([]);
-      }
+    const response = await handler.sendRequest<ExecuteCommandParams, ModuleCallsResponse, void>(
+      ExecuteCommandRequest.type,
+      params,
+    );
+    if (response === null) {
+      return Promise.resolve([]);
+    }
 
-      const list = response.module_calls.map((m) =>
-        this.toModuleCall(m.name, m.source_addr, m.version, m.source_type, m.docs_link, this.svg, m.dependent_modules),
-      );
+    const list = response.module_calls.map((m) =>
+      this.toModuleCall(m.name, m.source_addr, m.version, m.source_type, m.docs_link, this.svg, m.dependent_modules),
+    );
 
-      return list;
-    });
+    return list;
   }
 
   toModuleCall(

--- a/src/providers/moduleProviders.ts
+++ b/src/providers/moduleProviders.ts
@@ -100,7 +100,7 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
     if (handler === undefined) {
       return [];
     }
-    await handler.client.onReady();
+    await handler.onReady();
 
     const moduleCallsSupported = this.handler.clientSupportsCommand(`terraform-ls.module.providers`);
     if (!moduleCallsSupported) {
@@ -112,7 +112,7 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
       arguments: [`uri=${documentURI}`],
     };
 
-    const response = await handler.client.sendRequest<ExecuteCommandParams, ModuleProvidersResponse, void>(
+    const response = await handler.sendRequest<ExecuteCommandParams, ModuleProvidersResponse, void>(
       ExecuteCommandRequest.type,
       params,
     );

--- a/src/providers/moduleProviders.ts
+++ b/src/providers/moduleProviders.ts
@@ -102,15 +102,13 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
     }
     await handler.client.onReady();
 
-    const moduleCallsSupported = this.handler.clientSupportsCommand(
-      `${handler.commandPrefix}.terraform-ls.module.providers`,
-    );
+    const moduleCallsSupported = this.handler.clientSupportsCommand(`terraform-ls.module.providers`);
     if (!moduleCallsSupported) {
       return [];
     }
 
     const params: ExecuteCommandParams = {
-      command: `${handler.commandPrefix}.terraform-ls.module.providers`,
+      command: `terraform-ls.module.providers`,
       arguments: [`uri=${documentURI}`],
     };
 

--- a/src/providers/moduleProviders.ts
+++ b/src/providers/moduleProviders.ts
@@ -102,8 +102,8 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
     }
     await handler.onReady();
 
-    const moduleCallsSupported = this.handler.clientSupportsCommand(`terraform-ls.module.providers`);
-    if (!moduleCallsSupported) {
+    const commandSupported = this.handler.clientSupportsCommand(`terraform-ls.module.providers`);
+    if (!commandSupported) {
       return [];
     }
 


### PR DESCRIPTION
This removes generating a command prefix when registering commands for the language client connecting to terraform-ls.

Previously the extension would create a LanguageClient/terraform-ls pair per 'folder' in a workspace. This means there was a terraform-ls process per folder to keep track of. The https://github.com/hashicorp/terraform-ls/pull/502 PR enabled a single terraform-ls process to handle multi-folder workspaces, which meant we could refactor the extension In https://github.com/hashicorp/vscode-terraform/pull/845 to use a single LanguageClient instance. A leftover from the original design was a prefix for commands registered between terraform-ls and the client. This ensured unique command IDs when multiple clients were present, but is no longer necessary with a single language client.

Acceptance tests:

- Open a single folder and use any LS based commands
- Open a single folder, then use `Add Folder to workspace` to open a multi-folder workspace
- Open a multi-folder workspace directly using a workspace file like `something.code-workspace`
- In any example, open one of the Module Views, wait for items to show up, then close editor (do not close views). Then re-open editor. The Module views should show a progress bar until the LS is ready and responds with data, without error.

In each case, the extension should start with no errors. When adding additional folders to the workspace or when opening a mult-folder workspace directly, there should be no errors regarding duplicate commands.