### PR TITLE
Extract LanguageClient from ClientHandler

### DIFF
--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -1,168 +1,53 @@
-import * as vscode from 'vscode';
-import TelemetryReporter from '@vscode/extension-telemetry';
-import {
-  DocumentSelector,
-  Executable,
-  LanguageClient,
-  LanguageClientOptions,
-  RevealOutputChannelOn,
-  ServerOptions,
-  State,
-} from 'vscode-languageclient/node';
+import { Executable, ServerOptions } from 'vscode-languageclient/node';
 import { config } from './utils/vscode';
 import { ServerPath } from './utils/serverPath';
-import { PartialManifest, CustomSemanticTokens } from './features/semanticTokens';
-import { ShowReferencesFeature } from './features/showReferences';
-import { TelemetryFeature } from './features/telemetry';
 
-/**
- * ClientHandler maintains lifecycles of language clients
- * based on the server's capabilities
- */
-export class ClientHandler {
-  private client: LanguageClient | undefined;
-  private commands: string[] = [];
+export async function getServerOptions(lsPath: ServerPath): Promise<ServerOptions> {
+  const cmd = await lsPath.resolvedPathToBinary();
+  const serverArgs = config('terraform').get<string[]>('languageServer.args', []);
 
-  public extSemanticTokenTypes: string[] = [];
-  public extSemanticTokenModifiers: string[] = [];
+  const executable: Executable = {
+    command: cmd,
+    args: serverArgs,
+    options: {},
+  };
+  const serverOptions: ServerOptions = {
+    run: executable,
+    debug: executable,
+  };
 
-  constructor(
-    private lsPath: ServerPath,
-    private outputChannel: vscode.OutputChannel,
-    private reporter: TelemetryReporter,
-    private manifest: PartialManifest,
-  ) {
-    if (lsPath.hasCustomBinPath()) {
-      this.reporter.sendTelemetryEvent('usePathToBinary');
-    }
+  // this.outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
+
+  return serverOptions;
+}
+
+export function getInitializationOptions() {
+  const rootModulePaths = config('terraform-ls').get<string[]>('rootModules', []);
+  const terraformExecPath = config('terraform-ls').get<string>('terraformExecPath', '');
+  const terraformExecTimeout = config('terraform-ls').get<string>('terraformExecTimeout', '');
+  const terraformLogFilePath = config('terraform-ls').get<string>('terraformLogFilePath', '');
+  const excludeModulePaths = config('terraform-ls').get<string[]>('excludeRootModules', []);
+  const ignoreDirectoryNames = config('terraform-ls').get<string[]>('ignoreDirectoryNames', []);
+
+  const ignoreSingleFileWarning = config('terraform').get<boolean>('languageServer.ignoreSingleFileWarning', false);
+
+  if (rootModulePaths.length > 0 && excludeModulePaths.length > 0) {
+    throw new Error(
+      'Only one of rootModules and excludeRootModules can be set at the same time, please remove the conflicting config and reload',
+    );
   }
 
-  public async startClient(): Promise<vscode.Disposable> {
-    console.log('Starting client');
+  const experimentalFeatures = config('terraform-ls').get('experimentalFeatures');
+  const initializationOptions = {
+    experimentalFeatures,
+    ignoreSingleFileWarning,
+    ...(terraformExecPath.length > 0 && { terraformExecPath }),
+    ...(terraformExecTimeout.length > 0 && { terraformExecTimeout }),
+    ...(terraformLogFilePath.length > 0 && { terraformLogFilePath }),
+    ...(rootModulePaths.length > 0 && { rootModulePaths }),
+    ...(excludeModulePaths.length > 0 && { excludeModulePaths }),
+    ...(ignoreDirectoryNames.length > 0 && { ignoreDirectoryNames }),
+  };
 
-    this.client = await this.createTerraformClient();
-    const disposable = this.client.start();
-
-    await this.client.onReady();
-
-    this.reporter.sendTelemetryEvent('startClient');
-
-    const initializeResult = this.client.initializeResult;
-    if (initializeResult !== undefined) {
-      const multiFoldersSupported = initializeResult.capabilities.workspace?.workspaceFolders?.supported;
-      console.log(`Multi-folder support: ${multiFoldersSupported}`);
-
-      this.commands = initializeResult.capabilities.executeCommandProvider?.commands ?? [];
-    }
-
-    return disposable;
-  }
-
-  private async createTerraformClient(): Promise<LanguageClient> {
-    const initializationOptions = this.getInitializationOptions();
-
-    const serverOptions = await this.getServerOptions();
-
-    const documentSelector: DocumentSelector = [
-      { scheme: 'file', language: 'terraform' },
-      { scheme: 'file', language: 'terraform-vars' },
-    ];
-
-    const clientOptions: LanguageClientOptions = {
-      documentSelector: documentSelector,
-      initializationOptions: initializationOptions,
-      initializationFailedHandler: (error) => {
-        this.reporter.sendTelemetryException(error);
-        return false;
-      },
-      outputChannel: this.outputChannel,
-      revealOutputChannelOn: RevealOutputChannelOn.Never,
-    };
-
-    const id = `terraform`;
-    const client = new LanguageClient(id, serverOptions, clientOptions);
-
-    client.registerFeature(new CustomSemanticTokens(client, this.manifest));
-
-    const codeLensReferenceCount = config('terraform').get<boolean>('codelens.referenceCount');
-    if (codeLensReferenceCount) {
-      client.registerFeature(new ShowReferencesFeature(client));
-    }
-
-    if (vscode.env.isTelemetryEnabled) {
-      client.registerFeature(new TelemetryFeature(client, this.reporter));
-    }
-
-    client.onDidChangeState((event) => {
-      console.log(`Client: ${State[event.oldState]} --> ${State[event.newState]}`);
-      if (event.newState === State.Stopped) {
-        this.reporter.sendTelemetryEvent('stopClient');
-      }
-    });
-
-    return client;
-  }
-
-  private async getServerOptions(): Promise<ServerOptions> {
-    const cmd = await this.lsPath.resolvedPathToBinary();
-    const serverArgs = config('terraform').get<string[]>('languageServer.args', []);
-    const executable: Executable = {
-      command: cmd,
-      args: serverArgs,
-      options: {},
-    };
-    const serverOptions: ServerOptions = {
-      run: executable,
-      debug: executable,
-    };
-    this.outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
-    return serverOptions;
-  }
-
-  private getInitializationOptions() {
-    const rootModulePaths = config('terraform-ls').get<string[]>('rootModules', []);
-    const terraformExecPath = config('terraform-ls').get<string>('terraformExecPath', '');
-    const terraformExecTimeout = config('terraform-ls').get<string>('terraformExecTimeout', '');
-    const terraformLogFilePath = config('terraform-ls').get<string>('terraformLogFilePath', '');
-    const excludeModulePaths = config('terraform-ls').get<string[]>('excludeRootModules', []);
-    const ignoreDirectoryNames = config('terraform-ls').get<string[]>('ignoreDirectoryNames', []);
-
-    const ignoreSingleFileWarning = config('terraform').get<boolean>('languageServer.ignoreSingleFileWarning', false);
-
-    if (rootModulePaths.length > 0 && excludeModulePaths.length > 0) {
-      throw new Error(
-        'Only one of rootModules and excludeRootModules can be set at the same time, please remove the conflicting config and reload',
-      );
-    }
-
-    const experimentalFeatures = config('terraform-ls').get('experimentalFeatures');
-    const initializationOptions = {
-      experimentalFeatures,
-      ignoreSingleFileWarning,
-      ...(terraformExecPath.length > 0 && { terraformExecPath }),
-      ...(terraformExecTimeout.length > 0 && { terraformExecTimeout }),
-      ...(terraformLogFilePath.length > 0 && { terraformLogFilePath }),
-      ...(rootModulePaths.length > 0 && { rootModulePaths }),
-      ...(excludeModulePaths.length > 0 && { excludeModulePaths }),
-      ...(ignoreDirectoryNames.length > 0 && { ignoreDirectoryNames }),
-    };
-    return initializationOptions;
-  }
-
-  public async stopClient(): Promise<void> {
-    if (this.client === undefined) {
-      return;
-    }
-
-    await this.client.stop();
-    console.log('Client stopped');
-  }
-
-  public getClient(): LanguageClient | undefined {
-    return this.client;
-  }
-
-  public clientSupportsCommand(cmdName: string): boolean {
-    return this.commands.includes(cmdName);
-  }
+  return initializationOptions;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import {
   ServerOptions,
 } from 'vscode-languageclient/node';
 import { Utils } from 'vscode-uri';
-import { getInitializationOptions, getServerExecutable } from './utils/clientHelpers';
+import { clientSupportsCommand, getInitializationOptions, getServerExecutable } from './utils/clientHelpers';
 import { GenerateBugReportCommand } from './commands/generateBugReport';
 import { ModuleCallsDataProvider } from './providers/moduleCalls';
 import { ModuleProvidersDataProvider } from './providers/moduleProviders';
@@ -195,9 +195,7 @@ export async function updateTerraformStatusBar(documentUri: vscode.Uri): Promise
     return;
   }
 
-  // const initSupported = clientHandler.clientSupportsCommand(`terraform-ls.terraform.init`);
-  const initSupported =
-    client.initializeResult?.capabilities.executeCommandProvider?.commands.includes('terraform-ls.terraform.init');
+  const initSupported = clientSupportsCommand(client.initializeResult, `terraform-ls.terraform.init`);
   if (!initSupported) {
     return;
   }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,14 +4,15 @@ import {
   DocumentSelector,
   ExecuteCommandParams,
   ExecuteCommandRequest,
+  LanguageClient,
   LanguageClientOptions,
   RevealOutputChannelOn,
   State,
   StaticFeature,
-} from 'vscode-languageclient';
-import { LanguageClient } from 'vscode-languageclient/node';
+  ServerOptions,
+} from 'vscode-languageclient/node';
 import { Utils } from 'vscode-uri';
-import { getInitializationOptions, getServerOptions } from './clientHandler';
+import { getInitializationOptions, getServerExecutable } from './utils/clientHelpers';
 import { GenerateBugReportCommand } from './commands/generateBugReport';
 import { ModuleCallsDataProvider } from './providers/moduleCalls';
 import { ModuleProvidersDataProvider } from './providers/moduleProviders';
@@ -104,9 +105,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   if (lsPath.hasCustomBinPath()) {
     reporter.sendTelemetryEvent('usePathToBinary');
   }
-  const serverOptions = await getServerOptions(lsPath);
-  const initializationOptions = getInitializationOptions();
+  const executable = await getServerExecutable(lsPath);
+  const serverOptions: ServerOptions = {
+    run: executable,
+    debug: executable,
+  };
+  outputChannel.appendLine(`Launching language server: ${executable.command} ${executable.args?.join(' ')}`);
 
+  const initializationOptions = getInitializationOptions();
   const clientOptions: LanguageClientOptions = {
     documentSelector: documentSelector,
     initializationOptions: initializationOptions,

--- a/src/providers/moduleCalls.ts
+++ b/src/providers/moduleCalls.ts
@@ -77,7 +77,7 @@ export class ModuleCallsDataProvider implements vscode.TreeDataProvider<ModuleCa
 
   private svg = '';
 
-  constructor(ctx: vscode.ExtensionContext, public handler: LanguageClient) {
+  constructor(ctx: vscode.ExtensionContext, public client: LanguageClient) {
     this.svg = ctx.asAbsolutePath(path.join('assets', 'icons', 'terraform.svg'));
 
     ctx.subscriptions.push(
@@ -131,16 +131,14 @@ export class ModuleCallsDataProvider implements vscode.TreeDataProvider<ModuleCa
 
     const editor = activeEditor.document.uri;
     const documentURI = Utils.dirname(editor);
-    if (this.handler === undefined) {
+    if (this.client === undefined) {
       return [];
     }
-    await this.handler.onReady();
+    await this.client.onReady();
 
     // clientSupportsCommand(`terraform-ls.module.calls`)
     const commandSupported =
-      this.handler.initializeResult?.capabilities.executeCommandProvider?.commands.includes(
-        'terraform-ls.module.calls',
-      );
+      this.client.initializeResult?.capabilities.executeCommandProvider?.commands.includes('terraform-ls.module.calls');
     if (!commandSupported) {
       return Promise.resolve([]);
     }
@@ -150,7 +148,7 @@ export class ModuleCallsDataProvider implements vscode.TreeDataProvider<ModuleCa
       arguments: [`uri=${documentURI}`],
     };
 
-    const response = await this.handler.sendRequest<ExecuteCommandParams, ModuleCallsResponse, void>(
+    const response = await this.client.sendRequest<ExecuteCommandParams, ModuleCallsResponse, void>(
       ExecuteCommandRequest.type,
       params,
     );

--- a/src/providers/moduleCalls.ts
+++ b/src/providers/moduleCalls.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import { ExecuteCommandParams, ExecuteCommandRequest } from 'vscode-languageclient';
 import { LanguageClient } from 'vscode-languageclient/node';
 import { Utils } from 'vscode-uri';
+import { clientSupportsCommand } from '../utils/clientHelpers';
 import { getActiveTextEditor, isTerraformFile } from '../utils/vscode';
 
 /* eslint-disable @typescript-eslint/naming-convention */
@@ -136,9 +137,7 @@ export class ModuleCallsDataProvider implements vscode.TreeDataProvider<ModuleCa
     }
     await this.client.onReady();
 
-    // clientSupportsCommand(`terraform-ls.module.calls`)
-    const commandSupported =
-      this.client.initializeResult?.capabilities.executeCommandProvider?.commands.includes('terraform-ls.module.calls');
+    const commandSupported = clientSupportsCommand(this.client.initializeResult, 'terraform-ls.module.calls');
     if (!commandSupported) {
       return Promise.resolve([]);
     }

--- a/src/providers/moduleProviders.ts
+++ b/src/providers/moduleProviders.ts
@@ -4,6 +4,7 @@ import { ExecuteCommandParams, ExecuteCommandRequest } from 'vscode-languageclie
 
 import { getActiveTextEditor, isTerraformFile } from '../utils/vscode';
 import { LanguageClient } from 'vscode-languageclient/node';
+import { clientSupportsCommand } from '../utils/clientHelpers';
 
 /* eslint-disable @typescript-eslint/naming-convention */
 interface ModuleProvidersResponse {
@@ -101,10 +102,7 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
     }
     await this.client.onReady();
 
-    // const commandSupported = this.handler.clientSupportsCommand(`terraform-ls.module.providers`);
-    const commandSupported = this.client.initializeResult?.capabilities.executeCommandProvider?.commands.includes(
-      'terraform-ls.module.providers',
-    );
+    const commandSupported = clientSupportsCommand(this.client.initializeResult, 'terraform-ls.module.providers');
     if (!commandSupported) {
       return [];
     }

--- a/src/providers/moduleProviders.ts
+++ b/src/providers/moduleProviders.ts
@@ -45,7 +45,7 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
   private readonly didChangeTreeData = new vscode.EventEmitter<void | ModuleProviderItem>();
   public readonly onDidChangeTreeData = this.didChangeTreeData.event;
 
-  constructor(ctx: vscode.ExtensionContext, private handler: LanguageClient) {
+  constructor(ctx: vscode.ExtensionContext, private client: LanguageClient) {
     ctx.subscriptions.push(
       vscode.commands.registerCommand('terraform.providers.refreshList', () => this.refresh()),
       vscode.window.onDidChangeActiveTextEditor(async (event: vscode.TextEditor | undefined) => {
@@ -96,13 +96,13 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
 
     const editor = activeEditor.document.uri;
     const documentURI = Utils.dirname(editor);
-    if (this.handler === undefined) {
+    if (this.client === undefined) {
       return [];
     }
-    await this.handler.onReady();
+    await this.client.onReady();
 
     // const commandSupported = this.handler.clientSupportsCommand(`terraform-ls.module.providers`);
-    const commandSupported = this.handler.initializeResult?.capabilities.executeCommandProvider?.commands.includes(
+    const commandSupported = this.client.initializeResult?.capabilities.executeCommandProvider?.commands.includes(
       'terraform-ls.module.providers',
     );
     if (!commandSupported) {
@@ -114,7 +114,7 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
       arguments: [`uri=${documentURI}`],
     };
 
-    const response = await this.handler.sendRequest<ExecuteCommandParams, ModuleProvidersResponse, void>(
+    const response = await this.client.sendRequest<ExecuteCommandParams, ModuleProvidersResponse, void>(
       ExecuteCommandRequest.type,
       params,
     );

--- a/src/utils/clientHelpers.ts
+++ b/src/utils/clientHelpers.ts
@@ -1,8 +1,8 @@
-import { Executable, ServerOptions } from 'vscode-languageclient/node';
-import { config } from './utils/vscode';
-import { ServerPath } from './utils/serverPath';
+import { Executable } from 'vscode-languageclient/node';
+import { config } from './vscode';
+import { ServerPath } from './serverPath';
 
-export async function getServerOptions(lsPath: ServerPath): Promise<ServerOptions> {
+export async function getServerExecutable(lsPath: ServerPath): Promise<Executable> {
   const cmd = await lsPath.resolvedPathToBinary();
   const serverArgs = config('terraform').get<string[]>('languageServer.args', []);
 
@@ -11,17 +11,16 @@ export async function getServerOptions(lsPath: ServerPath): Promise<ServerOption
     args: serverArgs,
     options: {},
   };
-  const serverOptions: ServerOptions = {
-    run: executable,
-    debug: executable,
-  };
 
-  // this.outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
-
-  return serverOptions;
+  return executable;
 }
 
 export function getInitializationOptions() {
+  /*
+    This is basically a set of settings masquerading as a function. The intention
+    here is to make room for this to be added to a configuration builder when
+    we tackle #791
+  */
   const rootModulePaths = config('terraform-ls').get<string[]>('rootModules', []);
   const terraformExecPath = config('terraform-ls').get<string>('terraformExecPath', '');
   const terraformExecTimeout = config('terraform-ls').get<string>('terraformExecTimeout', '');

--- a/src/utils/clientHelpers.ts
+++ b/src/utils/clientHelpers.ts
@@ -1,4 +1,4 @@
-import { Executable } from 'vscode-languageclient/node';
+import { Executable, InitializeResult } from 'vscode-languageclient/node';
 import { config } from './vscode';
 import { ServerPath } from './serverPath';
 
@@ -49,4 +49,12 @@ export function getInitializationOptions() {
   };
 
   return initializationOptions;
+}
+
+export function clientSupportsCommand(initializeResult: InitializeResult | undefined, cmdName: string): boolean {
+  if (!initializeResult) {
+    return false;
+  }
+
+  return initializeResult.capabilities.executeCommandProvider?.commands.includes(cmdName) ?? false;
 }

--- a/src/utils/serverPath.ts
+++ b/src/utils/serverPath.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import * as which from 'which';
 
 const INSTALL_FOLDER_NAME = 'bin';
-export const CUSTOM_BIN_PATH_OPTION_NAME = 'languageServer.pathToBinary';
+const CUSTOM_BIN_PATH_OPTION_NAME = 'languageServer.pathToBinary';
 
 export class ServerPath {
   private customBinPath: string | undefined;
@@ -12,22 +12,15 @@ export class ServerPath {
     this.customBinPath = vscode.workspace.getConfiguration('terraform').get(CUSTOM_BIN_PATH_OPTION_NAME);
   }
 
-  public installPath(): string {
+  private installPath(): string {
     return path.join(this.context.extensionPath, INSTALL_FOLDER_NAME);
-  }
-
-  // legacyBinPath represents old location where LS was installed.
-  // We only use it to ensure that old installations are removed
-  // from there after LS is installed into the new path.
-  public legacyBinPath(): string {
-    return path.resolve(this.context.asAbsolutePath('lsp'), this.binName());
   }
 
   public hasCustomBinPath(): boolean {
     return !!this.customBinPath;
   }
 
-  public binPath(): string {
+  private binPath(): string {
     if (this.customBinPath) {
       return this.customBinPath;
     }
@@ -35,7 +28,7 @@ export class ServerPath {
     return path.resolve(this.installPath(), this.binName());
   }
 
-  public binName(): string {
+  private binName(): string {
     if (this.customBinPath) {
       return path.basename(this.customBinPath);
     }


### PR DESCRIPTION
This extracts the LanguageClient creation from ClientHandler and puts it directly inside the activation point.

In order to implement https://github.com/hashicorp/terraform-ls/issues/722 we need to add a new StaticFeature to register a client-side command for terraform-ls to call when it knows the `terraform.providers` view needs to be refreshed.

StaticFeatures are registered using the LanguageClient.registerFeature method, which means the ClientHandler class needs to create the StaticFeature. The StaticFeature needs both the LanguageClient and `terraform.providers` view created before it can be initialized. The LanguageClient is created by the ClientHandler class. This all results in a cyclic dependency.

We could resolve this cyclic dependency by adding more responsibility to ClientHandler, but this introduces more complexity to the class. This will become increasingly hard to deal with as more aspects like StaticFeature are added.

We resolve this by extracting the creation of LanguageClient and moving dependent features like the StaticFeatures to the main activation method. This puts all the parts that rely on each other in the same place where the data needed is located to make decisions about whether they are activated or not.

This builds on work done in:

- https://github.com/hashicorp/vscode-terraform/pull/1073
- https://github.com/hashicorp/vscode-terraform/pull/1074
- https://github.com/hashicorp/vscode-terraform/pull/1075
- https://github.com/hashicorp/vscode-terraform/pull/1079
