### PR TITLE
Subscribe to updates of module.providers

### DIFF
--- a/src/clientHandler.ts
+++ b/src/clientHandler.ts
@@ -1,168 +1,53 @@
-import * as vscode from 'vscode';
-import TelemetryReporter from '@vscode/extension-telemetry';
-import {
-  DocumentSelector,
-  Executable,
-  LanguageClient,
-  LanguageClientOptions,
-  RevealOutputChannelOn,
-  ServerOptions,
-  State,
-} from 'vscode-languageclient/node';
+import { Executable, ServerOptions } from 'vscode-languageclient/node';
 import { config } from './utils/vscode';
 import { ServerPath } from './utils/serverPath';
-import { PartialManifest, CustomSemanticTokens } from './features/semanticTokens';
-import { ShowReferencesFeature } from './features/showReferences';
-import { TelemetryFeature } from './features/telemetry';
 
-/**
- * ClientHandler maintains lifecycles of language clients
- * based on the server's capabilities
- */
-export class ClientHandler {
-  private client: LanguageClient | undefined;
-  private commands: string[] = [];
+export async function getServerOptions(lsPath: ServerPath): Promise<ServerOptions> {
+  const cmd = await lsPath.resolvedPathToBinary();
+  const serverArgs = config('terraform').get<string[]>('languageServer.args', []);
 
-  public extSemanticTokenTypes: string[] = [];
-  public extSemanticTokenModifiers: string[] = [];
+  const executable: Executable = {
+    command: cmd,
+    args: serverArgs,
+    options: {},
+  };
+  const serverOptions: ServerOptions = {
+    run: executable,
+    debug: executable,
+  };
 
-  constructor(
-    private lsPath: ServerPath,
-    private outputChannel: vscode.OutputChannel,
-    private reporter: TelemetryReporter,
-    private manifest: PartialManifest,
-  ) {
-    if (lsPath.hasCustomBinPath()) {
-      this.reporter.sendTelemetryEvent('usePathToBinary');
-    }
+  // this.outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
+
+  return serverOptions;
+}
+
+export function getInitializationOptions() {
+  const rootModulePaths = config('terraform-ls').get<string[]>('rootModules', []);
+  const terraformExecPath = config('terraform-ls').get<string>('terraformExecPath', '');
+  const terraformExecTimeout = config('terraform-ls').get<string>('terraformExecTimeout', '');
+  const terraformLogFilePath = config('terraform-ls').get<string>('terraformLogFilePath', '');
+  const excludeModulePaths = config('terraform-ls').get<string[]>('excludeRootModules', []);
+  const ignoreDirectoryNames = config('terraform-ls').get<string[]>('ignoreDirectoryNames', []);
+
+  const ignoreSingleFileWarning = config('terraform').get<boolean>('languageServer.ignoreSingleFileWarning', false);
+
+  if (rootModulePaths.length > 0 && excludeModulePaths.length > 0) {
+    throw new Error(
+      'Only one of rootModules and excludeRootModules can be set at the same time, please remove the conflicting config and reload',
+    );
   }
 
-  public async startClient(): Promise<vscode.Disposable> {
-    console.log('Starting client');
+  const experimentalFeatures = config('terraform-ls').get('experimentalFeatures');
+  const initializationOptions = {
+    experimentalFeatures,
+    ignoreSingleFileWarning,
+    ...(terraformExecPath.length > 0 && { terraformExecPath }),
+    ...(terraformExecTimeout.length > 0 && { terraformExecTimeout }),
+    ...(terraformLogFilePath.length > 0 && { terraformLogFilePath }),
+    ...(rootModulePaths.length > 0 && { rootModulePaths }),
+    ...(excludeModulePaths.length > 0 && { excludeModulePaths }),
+    ...(ignoreDirectoryNames.length > 0 && { ignoreDirectoryNames }),
+  };
 
-    this.client = await this.createTerraformClient();
-    const disposable = this.client.start();
-
-    await this.client.onReady();
-
-    this.reporter.sendTelemetryEvent('startClient');
-
-    const initializeResult = this.client.initializeResult;
-    if (initializeResult !== undefined) {
-      const multiFoldersSupported = initializeResult.capabilities.workspace?.workspaceFolders?.supported;
-      console.log(`Multi-folder support: ${multiFoldersSupported}`);
-
-      this.commands = initializeResult.capabilities.executeCommandProvider?.commands ?? [];
-    }
-
-    return disposable;
-  }
-
-  private async createTerraformClient(): Promise<LanguageClient> {
-    const initializationOptions = this.getInitializationOptions();
-
-    const serverOptions = await this.getServerOptions();
-
-    const documentSelector: DocumentSelector = [
-      { scheme: 'file', language: 'terraform' },
-      { scheme: 'file', language: 'terraform-vars' },
-    ];
-
-    const clientOptions: LanguageClientOptions = {
-      documentSelector: documentSelector,
-      initializationOptions: initializationOptions,
-      initializationFailedHandler: (error) => {
-        this.reporter.sendTelemetryException(error);
-        return false;
-      },
-      outputChannel: this.outputChannel,
-      revealOutputChannelOn: RevealOutputChannelOn.Never,
-    };
-
-    const id = `terraform`;
-    const client = new LanguageClient(id, serverOptions, clientOptions);
-
-    client.registerFeature(new CustomSemanticTokens(client, this.manifest));
-
-    const codeLensReferenceCount = config('terraform').get<boolean>('codelens.referenceCount');
-    if (codeLensReferenceCount) {
-      client.registerFeature(new ShowReferencesFeature(client));
-    }
-
-    if (vscode.env.isTelemetryEnabled) {
-      client.registerFeature(new TelemetryFeature(client, this.reporter));
-    }
-
-    client.onDidChangeState((event) => {
-      console.log(`Client: ${State[event.oldState]} --> ${State[event.newState]}`);
-      if (event.newState === State.Stopped) {
-        this.reporter.sendTelemetryEvent('stopClient');
-      }
-    });
-
-    return client;
-  }
-
-  private async getServerOptions(): Promise<ServerOptions> {
-    const cmd = await this.lsPath.resolvedPathToBinary();
-    const serverArgs = config('terraform').get<string[]>('languageServer.args', []);
-    const executable: Executable = {
-      command: cmd,
-      args: serverArgs,
-      options: {},
-    };
-    const serverOptions: ServerOptions = {
-      run: executable,
-      debug: executable,
-    };
-    this.outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
-    return serverOptions;
-  }
-
-  private getInitializationOptions() {
-    const rootModulePaths = config('terraform-ls').get<string[]>('rootModules', []);
-    const terraformExecPath = config('terraform-ls').get<string>('terraformExecPath', '');
-    const terraformExecTimeout = config('terraform-ls').get<string>('terraformExecTimeout', '');
-    const terraformLogFilePath = config('terraform-ls').get<string>('terraformLogFilePath', '');
-    const excludeModulePaths = config('terraform-ls').get<string[]>('excludeRootModules', []);
-    const ignoreDirectoryNames = config('terraform-ls').get<string[]>('ignoreDirectoryNames', []);
-
-    const ignoreSingleFileWarning = config('terraform').get<boolean>('languageServer.ignoreSingleFileWarning', false);
-
-    if (rootModulePaths.length > 0 && excludeModulePaths.length > 0) {
-      throw new Error(
-        'Only one of rootModules and excludeRootModules can be set at the same time, please remove the conflicting config and reload',
-      );
-    }
-
-    const experimentalFeatures = config('terraform-ls').get('experimentalFeatures');
-    const initializationOptions = {
-      experimentalFeatures,
-      ignoreSingleFileWarning,
-      ...(terraformExecPath.length > 0 && { terraformExecPath }),
-      ...(terraformExecTimeout.length > 0 && { terraformExecTimeout }),
-      ...(terraformLogFilePath.length > 0 && { terraformLogFilePath }),
-      ...(rootModulePaths.length > 0 && { rootModulePaths }),
-      ...(excludeModulePaths.length > 0 && { excludeModulePaths }),
-      ...(ignoreDirectoryNames.length > 0 && { ignoreDirectoryNames }),
-    };
-    return initializationOptions;
-  }
-
-  public async stopClient(): Promise<void> {
-    if (this.client === undefined) {
-      return;
-    }
-
-    await this.client.stop();
-    console.log('Client stopped');
-  }
-
-  public getClient(): LanguageClient | undefined {
-    return this.client;
-  }
-
-  public clientSupportsCommand(cmdName: string): boolean {
-    return this.commands.includes(cmdName);
-  }
+  return initializationOptions;
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -4,14 +4,15 @@ import {
   DocumentSelector,
   ExecuteCommandParams,
   ExecuteCommandRequest,
+  LanguageClient,
   LanguageClientOptions,
   RevealOutputChannelOn,
   State,
   StaticFeature,
-} from 'vscode-languageclient';
-import { LanguageClient } from 'vscode-languageclient/node';
+  ServerOptions,
+} from 'vscode-languageclient/node';
 import { Utils } from 'vscode-uri';
-import { getInitializationOptions, getServerOptions } from './clientHandler';
+import { getInitializationOptions, getServerExecutable } from './utils/clientHelpers';
 import { GenerateBugReportCommand } from './commands/generateBugReport';
 import { ModuleCallsDataProvider } from './providers/moduleCalls';
 import { ModuleProvidersDataProvider } from './providers/moduleProviders';
@@ -104,9 +105,14 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   if (lsPath.hasCustomBinPath()) {
     reporter.sendTelemetryEvent('usePathToBinary');
   }
-  const serverOptions = await getServerOptions(lsPath);
-  const initializationOptions = getInitializationOptions();
+  const executable = await getServerExecutable(lsPath);
+  const serverOptions: ServerOptions = {
+    run: executable,
+    debug: executable,
+  };
+  outputChannel.appendLine(`Launching language server: ${executable.command} ${executable.args?.join(' ')}`);
 
+  const initializationOptions = getInitializationOptions();
   const clientOptions: LanguageClientOptions = {
     documentSelector: documentSelector,
     initializationOptions: initializationOptions,

--- a/src/features/moduleProvidersFeature.ts
+++ b/src/features/moduleProvidersFeature.ts
@@ -6,7 +6,7 @@ import { ExperimentalClientCapabilities } from './types';
 export const CLIENT_MODULE_PROVIDERS_CMD_ID = 'client.refreshModuleProviders';
 
 export class ModuleProvidersFeature implements StaticFeature {
-  private registeredCommands: vscode.Disposable[] = [];
+  private disposables: vscode.Disposable[] = [];
 
   constructor(private client: BaseLanguageClient, private moduleProviderView: ModuleProvidersDataProvider) {}
 
@@ -29,16 +29,14 @@ export class ModuleProvidersFeature implements StaticFeature {
 
     await this.client.onReady();
 
-    this.client.onRequest(CLIENT_MODULE_PROVIDERS_CMD_ID, () => {
+    const d = this.client.onRequest(CLIENT_MODULE_PROVIDERS_CMD_ID, () => {
       console.log(`refreshing module view: ${this.moduleProviderView}`);
       this.moduleProviderView?.refresh();
     });
+    this.disposables.push(d);
   }
 
   public dispose(): void {
-    this.registeredCommands.forEach(function (cmd, index, commands) {
-      cmd.dispose();
-      commands.splice(index, 1);
-    });
+    this.disposables.forEach((d: vscode.Disposable) => d.dispose());
   }
 }

--- a/src/features/moduleProvidersFeature.ts
+++ b/src/features/moduleProvidersFeature.ts
@@ -1,0 +1,44 @@
+import * as vscode from 'vscode';
+import { BaseLanguageClient, ClientCapabilities, ServerCapabilities, StaticFeature } from 'vscode-languageclient';
+import { ModuleProvidersDataProvider } from '../providers/moduleProviders';
+import { ExperimentalClientCapabilities } from './types';
+
+export const CLIENT_MODULE_PROVIDERS_CMD_ID = 'client.refreshModuleProviders';
+
+export class ModuleProvidersFeature implements StaticFeature {
+  private registeredCommands: vscode.Disposable[] = [];
+
+  constructor(private client: BaseLanguageClient, private moduleProviderView: ModuleProvidersDataProvider) {}
+
+  public fillClientCapabilities(capabilities: ClientCapabilities & ExperimentalClientCapabilities): void {
+    if (!capabilities['experimental']) {
+      capabilities['experimental'] = {};
+    }
+    capabilities['experimental']['refereshModuleProvidersCommandId'] = CLIENT_MODULE_PROVIDERS_CMD_ID;
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  public async initialize(capabilities: ServerCapabilities): Promise<void> {
+    console.log('Initializing client.refreshModuleProviders');
+    if (!capabilities.experimental?.refreshModuleProviders) {
+      console.log('Server doesnt support client.refreshModuleProviders');
+      return;
+    }
+
+    console.log('Enabled client.refreshModuleProviders');
+
+    await this.client.onReady();
+
+    this.client.onRequest(CLIENT_MODULE_PROVIDERS_CMD_ID, () => {
+      console.log(`refreshing module view: ${this.moduleProviderView}`);
+      this.moduleProviderView?.refresh();
+    });
+  }
+
+  public dispose(): void {
+    this.registeredCommands.forEach(function (cmd, index, commands) {
+      cmd.dispose();
+      commands.splice(index, 1);
+    });
+  }
+}

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -5,5 +5,6 @@ export interface ExperimentalClientCapabilities {
   experimental: {
     telemetryVersion?: number;
     showReferencesCommandId?: string;
+    refereshModuleProvidersCommandId?: string;
   };
 }

--- a/src/providers/moduleCalls.ts
+++ b/src/providers/moduleCalls.ts
@@ -77,7 +77,7 @@ export class ModuleCallsDataProvider implements vscode.TreeDataProvider<ModuleCa
 
   private svg = '';
 
-  constructor(ctx: vscode.ExtensionContext, public handler: LanguageClient) {
+  constructor(ctx: vscode.ExtensionContext, public client: LanguageClient) {
     this.svg = ctx.asAbsolutePath(path.join('assets', 'icons', 'terraform.svg'));
 
     ctx.subscriptions.push(
@@ -131,16 +131,14 @@ export class ModuleCallsDataProvider implements vscode.TreeDataProvider<ModuleCa
 
     const editor = activeEditor.document.uri;
     const documentURI = Utils.dirname(editor);
-    if (this.handler === undefined) {
+    if (this.client === undefined) {
       return [];
     }
-    await this.handler.onReady();
+    await this.client.onReady();
 
     // clientSupportsCommand(`terraform-ls.module.calls`)
     const commandSupported =
-      this.handler.initializeResult?.capabilities.executeCommandProvider?.commands.includes(
-        'terraform-ls.module.calls',
-      );
+      this.client.initializeResult?.capabilities.executeCommandProvider?.commands.includes('terraform-ls.module.calls');
     if (!commandSupported) {
       return Promise.resolve([]);
     }
@@ -150,7 +148,7 @@ export class ModuleCallsDataProvider implements vscode.TreeDataProvider<ModuleCa
       arguments: [`uri=${documentURI}`],
     };
 
-    const response = await this.handler.sendRequest<ExecuteCommandParams, ModuleCallsResponse, void>(
+    const response = await this.client.sendRequest<ExecuteCommandParams, ModuleCallsResponse, void>(
       ExecuteCommandRequest.type,
       params,
     );

--- a/src/providers/moduleProviders.ts
+++ b/src/providers/moduleProviders.ts
@@ -122,17 +122,15 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
       return [];
     }
 
-    return Object.entries(response.provider_requirements)
-      .map(
-        ([provider, details]) =>
-          new ModuleProviderItem(
-            provider,
-            details.display_name,
-            details.version_constraint,
-            response.installed_providers[provider],
-            details.docs_link,
-          ),
-      )
-      .filter((m) => Boolean(m.requiredVersion));
+    return Object.entries(response.provider_requirements).map(
+      ([provider, details]) =>
+        new ModuleProviderItem(
+          provider,
+          details.display_name,
+          details.version_constraint,
+          response.installed_providers[provider],
+          details.docs_link,
+        ),
+    );
   }
 }

--- a/src/providers/moduleProviders.ts
+++ b/src/providers/moduleProviders.ts
@@ -45,7 +45,7 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
   private readonly didChangeTreeData = new vscode.EventEmitter<void | ModuleProviderItem>();
   public readonly onDidChangeTreeData = this.didChangeTreeData.event;
 
-  constructor(ctx: vscode.ExtensionContext, private handler: LanguageClient) {
+  constructor(ctx: vscode.ExtensionContext, private client: LanguageClient) {
     ctx.subscriptions.push(
       vscode.commands.registerCommand('terraform.providers.refreshList', () => this.refresh()),
       vscode.window.onDidChangeActiveTextEditor(async (event: vscode.TextEditor | undefined) => {
@@ -96,13 +96,13 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
 
     const editor = activeEditor.document.uri;
     const documentURI = Utils.dirname(editor);
-    if (this.handler === undefined) {
+    if (this.client === undefined) {
       return [];
     }
-    await this.handler.onReady();
+    await this.client.onReady();
 
     // const commandSupported = this.handler.clientSupportsCommand(`terraform-ls.module.providers`);
-    const commandSupported = this.handler.initializeResult?.capabilities.executeCommandProvider?.commands.includes(
+    const commandSupported = this.client.initializeResult?.capabilities.executeCommandProvider?.commands.includes(
       'terraform-ls.module.providers',
     );
     if (!commandSupported) {
@@ -114,7 +114,7 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
       arguments: [`uri=${documentURI}`],
     };
 
-    const response = await this.handler.sendRequest<ExecuteCommandParams, ModuleProvidersResponse, void>(
+    const response = await this.client.sendRequest<ExecuteCommandParams, ModuleProvidersResponse, void>(
       ExecuteCommandRequest.type,
       params,
     );

--- a/src/utils/clientHelpers.ts
+++ b/src/utils/clientHelpers.ts
@@ -1,8 +1,8 @@
-import { Executable, ServerOptions } from 'vscode-languageclient/node';
-import { config } from './utils/vscode';
-import { ServerPath } from './utils/serverPath';
+import { Executable } from 'vscode-languageclient/node';
+import { config } from './vscode';
+import { ServerPath } from './serverPath';
 
-export async function getServerOptions(lsPath: ServerPath): Promise<ServerOptions> {
+export async function getServerExecutable(lsPath: ServerPath): Promise<Executable> {
   const cmd = await lsPath.resolvedPathToBinary();
   const serverArgs = config('terraform').get<string[]>('languageServer.args', []);
 
@@ -11,17 +11,16 @@ export async function getServerOptions(lsPath: ServerPath): Promise<ServerOption
     args: serverArgs,
     options: {},
   };
-  const serverOptions: ServerOptions = {
-    run: executable,
-    debug: executable,
-  };
 
-  // this.outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
-
-  return serverOptions;
+  return executable;
 }
 
 export function getInitializationOptions() {
+  /*
+    This is basically a set of settings masquerading as a function. The intention
+    here is to make room for this to be added to a configuration builder when
+    we tackle #791
+  */
   const rootModulePaths = config('terraform-ls').get<string[]>('rootModules', []);
   const terraformExecPath = config('terraform-ls').get<string>('terraformExecPath', '');
   const terraformExecTimeout = config('terraform-ls').get<string>('terraformExecTimeout', '');

--- a/src/utils/serverPath.ts
+++ b/src/utils/serverPath.ts
@@ -3,7 +3,7 @@ import * as vscode from 'vscode';
 import * as which from 'which';
 
 const INSTALL_FOLDER_NAME = 'bin';
-export const CUSTOM_BIN_PATH_OPTION_NAME = 'languageServer.pathToBinary';
+const CUSTOM_BIN_PATH_OPTION_NAME = 'languageServer.pathToBinary';
 
 export class ServerPath {
   private customBinPath: string | undefined;
@@ -12,22 +12,15 @@ export class ServerPath {
     this.customBinPath = vscode.workspace.getConfiguration('terraform').get(CUSTOM_BIN_PATH_OPTION_NAME);
   }
 
-  public installPath(): string {
+  private installPath(): string {
     return path.join(this.context.extensionPath, INSTALL_FOLDER_NAME);
-  }
-
-  // legacyBinPath represents old location where LS was installed.
-  // We only use it to ensure that old installations are removed
-  // from there after LS is installed into the new path.
-  public legacyBinPath(): string {
-    return path.resolve(this.context.asAbsolutePath('lsp'), this.binName());
   }
 
   public hasCustomBinPath(): boolean {
     return !!this.customBinPath;
   }
 
-  public binPath(): string {
+  private binPath(): string {
     if (this.customBinPath) {
       return this.customBinPath;
     }
@@ -35,7 +28,7 @@ export class ServerPath {
     return path.resolve(this.installPath(), this.binName());
   }
 
-  public binName(): string {
+  private binName(): string {
     if (this.customBinPath) {
       return path.basename(this.customBinPath);
     }


### PR DESCRIPTION
Register a client side command that terraform-ls can call to initiate a refresh of the Module Providers view.

This introduces a StaticFeature which registers a handler for the `client.refreshModuleProviders` request. The terraform-ls already has mechanisms allowing it to detect state changes which affect the data returned from `module.providers` via hooks https://github.com/hashicorp/terraform-ls/blob/2027413c03c7242f51bee327b201d538fbefc975/internal/state/hooks.go#L3-L11. These hooks were configured to send this command in [](link) when the data has changed.

This depends on https://github.com/hashicorp/vscode-terraform/pull/1082, which should be merged first.