### PR TITLE
Automatically refresh Terraform Providers View when providers change in open document

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.23.0] (Unreleased)
+
+ENHANCEMENTS:
+
+ - Automatically refresh Terraform Providers View when providers change in open document ([#1084](https://github.com/hashicorp/vscode-terraform/pull/1084)) / [terraform-ls#902](https://github.com/hashicorp/terraform-ls/pull/902))
+
 ## [2.22.0] (2022-04-19)
 
 BREAKING CHANGES:

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -21,6 +21,7 @@ import { config, getActiveTextEditor, isTerraformFile } from './utils/vscode';
 import { TelemetryFeature } from './features/telemetry';
 import { ShowReferencesFeature } from './features/showReferences';
 import { CustomSemanticTokens } from './features/semanticTokens';
+import { ModuleProvidersFeature } from './features/moduleProviders';
 
 const id = 'terraform';
 const brand = `HashiCorp Terraform`;
@@ -132,7 +133,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }
   });
 
-  const features: StaticFeature[] = [new CustomSemanticTokens(client, manifest)];
+  const moduleDataProvider = new ModuleProvidersDataProvider(context, client);
+
+  const features: StaticFeature[] = [
+    new CustomSemanticTokens(client, manifest),
+    new ModuleProvidersFeature(client, moduleDataProvider),
+  ];
   if (vscode.env.isTelemetryEnabled) {
     features.push(new TelemetryFeature(client, reporter));
   }
@@ -166,7 +172,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
     }),
     vscode.window.registerTreeDataProvider('terraform.modules', new ModuleCallsDataProvider(context, client)),
-    vscode.window.registerTreeDataProvider('terraform.providers', new ModuleProvidersDataProvider(context, client)),
+    vscode.window.registerTreeDataProvider('terraform.providers', moduleDataProvider),
     vscode.window.onDidChangeVisibleTextEditors(async (editors: readonly vscode.TextEditor[]) => {
       const textEditor = editors.find((ed) => !!ed.viewColumn);
       if (textEditor?.document === undefined) {

--- a/src/features/moduleProviders.ts
+++ b/src/features/moduleProviders.ts
@@ -19,7 +19,7 @@ export class ModuleProvidersFeature implements StaticFeature {
 
   public async initialize(capabilities: ServerCapabilities): Promise<void> {
     if (!capabilities.experimental?.refreshModuleProviders) {
-      console.log('Server doesnt support client.refreshModuleProviders');
+      console.log('Server doesn't support client.refreshModuleProviders');
       return;
     }
 

--- a/src/features/moduleProviders.ts
+++ b/src/features/moduleProviders.ts
@@ -19,7 +19,7 @@ export class ModuleProvidersFeature implements StaticFeature {
 
   public async initialize(capabilities: ServerCapabilities): Promise<void> {
     if (!capabilities.experimental?.refreshModuleProviders) {
-      console.log('Server doesn't support client.refreshModuleProviders');
+      console.log("Server doesn't support client.refreshModuleProviders");
       return;
     }
 

--- a/src/features/moduleProviders.ts
+++ b/src/features/moduleProviders.ts
@@ -1,0 +1,37 @@
+import * as vscode from 'vscode';
+import { BaseLanguageClient, ClientCapabilities, ServerCapabilities, StaticFeature } from 'vscode-languageclient';
+import { ModuleProvidersDataProvider } from '../providers/moduleProviders';
+import { ExperimentalClientCapabilities } from './types';
+
+export const CLIENT_MODULE_PROVIDERS_CMD_ID = 'client.refreshModuleProviders';
+
+export class ModuleProvidersFeature implements StaticFeature {
+  private disposables: vscode.Disposable[] = [];
+
+  constructor(private client: BaseLanguageClient, private view: ModuleProvidersDataProvider) {}
+
+  public fillClientCapabilities(capabilities: ClientCapabilities & ExperimentalClientCapabilities): void {
+    if (!capabilities['experimental']) {
+      capabilities['experimental'] = {};
+    }
+    capabilities['experimental']['refereshModuleProvidersCommandId'] = CLIENT_MODULE_PROVIDERS_CMD_ID;
+  }
+
+  public async initialize(capabilities: ServerCapabilities): Promise<void> {
+    if (!capabilities.experimental?.refreshModuleProviders) {
+      console.log('Server doesnt support client.refreshModuleProviders');
+      return;
+    }
+
+    await this.client.onReady();
+
+    const d = this.client.onRequest(CLIENT_MODULE_PROVIDERS_CMD_ID, () => {
+      this.view?.refresh();
+    });
+    this.disposables.push(d);
+  }
+
+  public dispose(): void {
+    this.disposables.forEach((d: vscode.Disposable) => d.dispose());
+  }
+}

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -5,5 +5,6 @@ export interface ExperimentalClientCapabilities {
   experimental: {
     telemetryVersion?: number;
     showReferencesCommandId?: string;
+    refereshModuleProvidersCommandId?: string;
   };
 }

--- a/src/providers/moduleProviders.ts
+++ b/src/providers/moduleProviders.ts
@@ -120,17 +120,15 @@ export class ModuleProvidersDataProvider implements vscode.TreeDataProvider<Modu
       return [];
     }
 
-    return Object.entries(response.provider_requirements)
-      .map(
-        ([provider, details]) =>
-          new ModuleProviderItem(
-            provider,
-            details.display_name,
-            details.version_constraint,
-            response.installed_providers[provider],
-            details.docs_link,
-          ),
-      )
-      .filter((m) => Boolean(m.requiredVersion));
+    return Object.entries(response.provider_requirements).map(
+      ([provider, details]) =>
+        new ModuleProviderItem(
+          provider,
+          details.display_name,
+          details.version_constraint,
+          response.installed_providers[provider],
+          details.docs_link,
+        ),
+    );
   }
 }


### PR DESCRIPTION
This introduces a StaticFeature which registers a handler for the `client.refreshModuleProviders` request which terraform-ls can call to refresh the data shown in the Terraform Providers view. The terraform-ls server was modified to send `client.refreshModuleProviders` requests in https://github.com/hashicorp/terraform-ls/pull/902

