### PR TITLE
Automatically refresh Terraform Module Calls View

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -175,7 +175,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       }
     }),
     vscode.window.registerTreeDataProvider('terraform.modules', moduleCallsDataProvider),
-    vscode.window.registerTreeDataProvider('terraform.providers', moduleDataProvider),
+    vscode.window.registerTreeDataProvider('terraform.providers', moduleProvidersDataProvider),
     vscode.window.onDidChangeVisibleTextEditors(async (editors: readonly vscode.TextEditor[]) => {
       const textEditor = editors.find((ed) => !!ed.viewColumn);
       if (textEditor?.document === undefined) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import { TelemetryFeature } from './features/telemetry';
 import { ShowReferencesFeature } from './features/showReferences';
 import { CustomSemanticTokens } from './features/semanticTokens';
 import { ModuleProvidersFeature } from './features/moduleProviders';
+import { ModuleCallsFeature } from './features/moduleCalls';
 
 const id = 'terraform';
 const brand = `HashiCorp Terraform`;
@@ -134,10 +135,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   });
 
   const moduleDataProvider = new ModuleProvidersDataProvider(context, client);
+  const moduleCallsDataProvider = new ModuleCallsDataProvider(context, client);
 
   const features: StaticFeature[] = [
     new CustomSemanticTokens(client, manifest),
     new ModuleProvidersFeature(client, moduleDataProvider),
+    new ModuleCallsFeature(client, moduleCallsDataProvider),
   ];
   if (vscode.env.isTelemetryEnabled) {
     features.push(new TelemetryFeature(client, reporter));
@@ -171,7 +174,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         await execWorkspaceCommand(client, requestParams);
       }
     }),
-    vscode.window.registerTreeDataProvider('terraform.modules', new ModuleCallsDataProvider(context, client)),
+    vscode.window.registerTreeDataProvider('terraform.modules', moduleCallsDataProvider),
     vscode.window.registerTreeDataProvider('terraform.providers', moduleDataProvider),
     vscode.window.onDidChangeVisibleTextEditors(async (editors: readonly vscode.TextEditor[]) => {
       const textEditor = editors.find((ed) => !!ed.viewColumn);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -134,12 +134,12 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }
   });
 
-  const moduleDataProvider = new ModuleProvidersDataProvider(context, client);
+  const moduleProvidersDataProvider = new ModuleProvidersDataProvider(context, client);
   const moduleCallsDataProvider = new ModuleCallsDataProvider(context, client);
 
   const features: StaticFeature[] = [
     new CustomSemanticTokens(client, manifest),
-    new ModuleProvidersFeature(client, moduleDataProvider),
+    new ModuleProvidersFeature(client, moduleProvidersDataProvider),
     new ModuleCallsFeature(client, moduleCallsDataProvider),
   ];
   if (vscode.env.isTelemetryEnabled) {

--- a/src/features/moduleCalls.ts
+++ b/src/features/moduleCalls.ts
@@ -14,7 +14,7 @@ export class ModuleCallsFeature implements StaticFeature {
     if (!capabilities['experimental']) {
       capabilities['experimental'] = {};
     }
-    capabilities['experimental']['refereshModuleCallsCommandId'] = CLIENT_MODULE_CALLS_CMD_ID;
+    capabilities['experimental']['refreshModuleCallsCommandId'] = CLIENT_MODULE_CALLS_CMD_ID;
   }
 
   public async initialize(capabilities: ServerCapabilities): Promise<void> {

--- a/src/features/moduleCalls.ts
+++ b/src/features/moduleCalls.ts
@@ -1,0 +1,37 @@
+import * as vscode from 'vscode';
+import { BaseLanguageClient, ClientCapabilities, ServerCapabilities, StaticFeature } from 'vscode-languageclient';
+import { ModuleCallsDataProvider } from '../providers/moduleCalls';
+import { ExperimentalClientCapabilities } from './types';
+
+const CLIENT_MODULE_CALLS_CMD_ID = 'client.refreshModuleCalls';
+
+export class ModuleCallsFeature implements StaticFeature {
+  private disposables: vscode.Disposable[] = [];
+
+  constructor(private client: BaseLanguageClient, private view: ModuleCallsDataProvider) {}
+
+  public fillClientCapabilities(capabilities: ClientCapabilities & ExperimentalClientCapabilities): void {
+    if (!capabilities['experimental']) {
+      capabilities['experimental'] = {};
+    }
+    capabilities['experimental']['refereshModuleCallsCommandId'] = CLIENT_MODULE_CALLS_CMD_ID;
+  }
+
+  public async initialize(capabilities: ServerCapabilities): Promise<void> {
+    if (!capabilities.experimental?.refreshModuleCalls) {
+      console.log('Server does not support client.refreshModuleCalls');
+      return;
+    }
+
+    await this.client.onReady();
+
+    const d = this.client.onRequest(CLIENT_MODULE_CALLS_CMD_ID, () => {
+      this.view?.refresh();
+    });
+    this.disposables.push(d);
+  }
+
+  public dispose(): void {
+    this.disposables.forEach((d: vscode.Disposable) => d.dispose());
+  }
+}

--- a/src/features/moduleProviders.ts
+++ b/src/features/moduleProviders.ts
@@ -14,7 +14,7 @@ export class ModuleProvidersFeature implements StaticFeature {
     if (!capabilities['experimental']) {
       capabilities['experimental'] = {};
     }
-    capabilities['experimental']['refereshModuleProvidersCommandId'] = CLIENT_MODULE_PROVIDERS_CMD_ID;
+    capabilities['experimental']['refreshModuleProvidersCommandId'] = CLIENT_MODULE_PROVIDERS_CMD_ID;
   }
 
   public async initialize(capabilities: ServerCapabilities): Promise<void> {

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -6,5 +6,6 @@ export interface ExperimentalClientCapabilities {
     telemetryVersion?: number;
     showReferencesCommandId?: string;
     refereshModuleProvidersCommandId?: string;
+    refereshModuleCallsCommandId?: string;
   };
 }

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -5,7 +5,7 @@ export interface ExperimentalClientCapabilities {
   experimental: {
     telemetryVersion?: number;
     showReferencesCommandId?: string;
-    refereshModuleProvidersCommandId?: string;
-    refereshModuleCallsCommandId?: string;
+    refreshModuleProvidersCommandId?: string;
+    refreshModuleCallsCommandId?: string;
   };
 }


### PR DESCRIPTION
This commit automatically refreshes the Terraform Module Calls View when providers change in open document.

This introduces a StaticFeature which registers a handler for the `client.refreshModuleCalls` request which terraform-ls can call to refresh the data shown in the Terraform Module Calls view. The terraform-ls server was modified to send `client.refreshModuleCalls` requests in https://github.com/hashicorp/terraform-ls/pull/909
