### PR TITLE
github: Update issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -6,22 +6,10 @@ labels: bug
 
 ## Versions
 
-This bug is reproducible in:
- - [ ] the **latest** version of the extension (below)
- - [ ] the **latest** version of the language server (below)
-
 ### Extension
+
 <!--
 Find this in the VS Code UI: Extensions Pane -> Installed -> HashiCorp Terraform
--->
-```
-
-```
-
-### Language Server
-<!--
-Find this from the first few lines of relevant Output pane:
-View -> Output -> terraform-ls
 -->
 ```
 

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -6,22 +6,9 @@ labels: enhancement
 
 ## Versions
 
-This feature does not yet exist in:
- - [ ] the **latest** version of the extension (below)
- - [ ] the **latest** version of the language server (below)
-
 ### Extension
 <!--
 Find this in the VS Code UI: Extensions Pane -> Installed -> HashiCorp Terraform
--->
-```
-
-```
-
-### Language Server
-<!--
-Find this from the first few lines of relevant Output pane:
-View -> Output -> terraform-ls
 -->
 ```
 


### PR DESCRIPTION
This proposes two changes:

1. Removes the tickboxes - it doesn't seem to bring much value as anecdotally many people just leave it out
2. LS is now bundled with the extension, so we no longer need to ask for the version as it's implied from extension version.
