### PR TITLE
dependabot: Ignore minor & patch updates for some dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,11 @@ updates:
     schedule:
       interval: "daily"
     labels: ["dependencies"]
+    ignore:
+      - dependency-name: "@types/*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
+      - dependency-name: "@typescript-eslint/*"
+        update-types: ["version-update:semver-minor", "version-update:semver-patch"]
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
Due to the nature of some dependencies, in particular `@types/*` and `@typescript-eslint/*` we receive an overwhelming amount of PRs almost daily from dependabot.

Given the nature of these dependencies, it's not critical that we update so frequently, so this patch aims to ignore any minor or patch releases for these "noisy" dependencies.

See https://github.com/hashicorp/vscode-terraform/pulls?page=1&q=is%3Apr+author%3Aapp%2Fdependabot+is%3Aclosed

Docs: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#ignore