### PR TITLE
Remove package.json from .prettierignore

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,7 +1,6 @@
 snippets/
 syntaxes/
 out/
-package.json
 package-lock.json
 node_modules/
 .vscode-test/


### PR DESCRIPTION
This removes package.json and syntaxes from the .prettierignore file.

We previously wanted package.json to not be formatted because of the addition of the semantic token data, but keeping it formatted is more important that the extra lines that adds.
