### PR TITLE
Terraform View container

### DIFF
--- a/package.json
+++ b/package.json
@@ -552,20 +552,23 @@
       ]
     },
     "views": {
-      "explorer": [
+      "terraform": [
         {
           "id": "terraform.providers",
-          "name": "Terraform Providers",
-          "icon": "assets/icons/terraform.svg",
-          "visibility": "collapsed",
-          "when": "terraform.showTreeViews"
+          "name": "Terraform Providers"
         },
         {
           "id": "terraform.modules",
-          "name": "Terraform Module Calls",
-          "icon": "assets/icons/terraform.svg",
-          "visibility": "collapsed",
-          "when": "terraform.showTreeViews"
+          "name": "Terraform Module Calls"
+        }
+      ]
+    },
+    "viewsContainers": {
+      "activitybar": [
+        {
+          "id": "terraform",
+          "title": "Terraform",
+          "icon": "assets/icons/terraform.svg"
         }
       ]
     },

--- a/package.json
+++ b/package.json
@@ -555,11 +555,11 @@
       "terraform": [
         {
           "id": "terraform.providers",
-          "name": "Terraform Providers"
+          "name": "Providers"
         },
         {
           "id": "terraform.modules",
-          "name": "Terraform Module Calls"
+          "name": "Module Calls"
         }
       ]
     },
@@ -567,7 +567,7 @@
       "activitybar": [
         {
           "id": "terraform",
-          "title": "Terraform",
+          "title": "HashiCorp Terraform",
           "icon": "assets/icons/terraform.svg"
         }
       ]

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -259,8 +259,6 @@ async function startLanguageServer(ctx: vscode.ExtensionContext) {
       const multiFoldersSupported = initializeResult.capabilities.workspace?.workspaceFolders?.supported;
       console.log(`Multi-folder support: ${multiFoldersSupported}`);
     }
-
-    vscode.commands.executeCommand('setContext', 'terraform.showTreeViews', true);
   } catch (error) {
     console.log(error); // for test failure reporting
     if (error instanceof Error) {
@@ -274,7 +272,6 @@ async function startLanguageServer(ctx: vscode.ExtensionContext) {
 async function stopLanguageServer() {
   try {
     await client?.stop();
-    vscode.commands.executeCommand('setContext', 'terraform.showTreeViews', false);
   } catch (error) {
     console.log(error); // for test failure reporting
     if (error instanceof Error) {


### PR DESCRIPTION
Create a new Terraform [View Container](https://code.visualstudio.com/api/ux-guidelines/views#view-containers) that will house the existing `terraform.providers` and `terraform.modules` views. These views will no longer be inside the Explorer View Container.

![image](https://user-images.githubusercontent.com/272569/177575138-bf6f5e42-65e2-4791-af15-3280c54c105b.png)

This Terraform View Container will support all the built-in mechanisms users expect out of views, most notable of which is the ability to move it to other places in the editor like the new SideBar:

![image](https://user-images.githubusercontent.com/272569/177575386-b3e01482-1bfc-4ec6-a1ab-8d6584fd3335.png)

Or be able to be hidden altogether:

![image](https://user-images.githubusercontent.com/272569/177391056-bc6cf4cb-2d3e-409b-9a6c-e71271f7b20d.png)

This enables us to have a single place to land new views as well as allow the user to customize as they see fit.