### PR TITLE
Bump vscode from 1.61.1 to 1.65.2

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -60,7 +60,7 @@ jobs:
       fail-fast: false
       matrix:
         vscode:
-          - '1.61.2'
+          - '1.65.2'
           - 'insiders'
           - 'stable'
         os:

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ The Terraform VS Code extension bundles the [Terraform Language Server](https://
 
 The extension does require the following to be installed before use:
 
-- VS Code v1.61 or greater
+- VS Code v1.65 or greater
 - Terraform v0.12 or greater
 
 ## Platform Support

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/jest": "^27.0.3",
         "@types/mocha": "^9.0.0",
         "@types/node": "^16.11.7",
-        "@types/vscode": "^1.61.1",
+        "@types/vscode": "^1.65.2",
         "@types/which": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^5.9.0",
         "@typescript-eslint/parser": "^5.9.0",
@@ -44,7 +44,7 @@
       "engines": {
         "node": "~16.X",
         "npm": "~8.X",
-        "vscode": "^1.61.0"
+        "vscode": "^1.65.2"
       }
     },
     "node_modules/@babel/code-frame": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "engines": {
     "npm": "~8.X",
     "node": "~16.X",
-    "vscode": "^1.61.0"
+    "vscode": "^1.65.2"
   },
   "langServer": {
     "version": "0.28.1"
@@ -615,7 +615,7 @@
     "@types/jest": "^27.0.3",
     "@types/mocha": "^9.0.0",
     "@types/node": "^16.11.7",
-    "@types/vscode": "^1.61.1",
+    "@types/vscode": "^1.65.2",
     "@types/which": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^5.9.0",
     "@typescript-eslint/parser": "^5.9.0",


### PR DESCRIPTION
This raises the minimum supported VS Code version from 1.61.1 to 1.65.2
