### PR TITLE
Scope languageServer enablement commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -530,6 +530,22 @@
           "when": "config.terraform.languageServer.enable == true"
         },
         {
+          "command": "terraform.init",
+          "when": "config.terraform.languageServer.enable == true"
+        },
+        {
+          "command": "terraform.initCurrent",
+          "when": "config.terraform.languageServer.enable == true"
+        },
+        {
+          "command": "terraform.validate",
+          "when": "config.terraform.languageServer.enable == true"
+        },
+        {
+          "command": "terraform.plan",
+          "when": "config.terraform.languageServer.enable == true"
+        },
+        {
           "command": "terraform.modules.refreshList",
           "when": "false"
         },

--- a/package.json
+++ b/package.json
@@ -522,6 +522,14 @@
     "menus": {
       "commandPalette": [
         {
+          "command": "terraform.enableLanguageServer",
+          "when": "config.terraform.languageServer.enable == false"
+        },
+        {
+          "command": "terraform.disableLanguageServer",
+          "when": "config.terraform.languageServer.enable == true"
+        },
+        {
           "command": "terraform.modules.refreshList",
           "when": "false"
         },


### PR DESCRIPTION
This adds a when clause to only offer to enable the language server if it's disabled, or to disable if it's enabled. It also only shows commands that require the language server if the language server is enabled.

Enabled:

![image](https://user-images.githubusercontent.com/272569/179027353-729018e3-cd02-49e6-afee-9942565945ce.png)

Disabled:

![image](https://user-images.githubusercontent.com/272569/179027378-ce09ae1c-6fc3-4246-af4e-f1a217eed8f4.png)


