### PR TITLE
Set machine scope to path settings

### DIFF
--- a/docs/settings-migration.md
+++ b/docs/settings-migration.md
@@ -121,3 +121,23 @@ The `terraform.experimentalFeatures` setting block has been extracted out to ind
 </table>
 
 For an easy to view table of settings, see the `Contributions` tab when viewing the Terraform Extension in the VS Code Extension Pane.
+
+## Setting Scope
+
+This extension has several settings that allow users to customize an executable path for different functions. These paths can vary depending on where the extension is running. For example: running locally on a Windows desktop, or in a WSL instance, or remotely in a GitHub Codespace or a Remote SSH session. VS Code understands where the extension is "running" and can read settings from the proper location, if the settings are properly scoped.
+
+As of v2.24.0, the extension uses the `machine` scope for the following settings:
+
+```
+terraform.languageServer.path
+terraform.languageServer.args
+terraform.languageServer.tcp.port
+terraform.languageServer.terraform.path
+terraform.languageServer.terraform.logFilePath
+terraform.languageServer.terraform.timeout
+terraform.languageServer.rootModules
+terraform.languageServer.excludeRootModules
+terraform.languageServer.ignoreDirectoryNames
+```
+
+This will allow VS Code to know where to read each setting depending on where the extension is running.

--- a/docs/settings-migration.md
+++ b/docs/settings-migration.md
@@ -124,7 +124,7 @@ For an easy to view table of settings, see the `Contributions` tab when viewing 
 
 ## Setting Scope
 
-This extension has several settings that allow users to customize an executable path for different functions. These paths can vary depending on where the extension is running. For example: running locally on a Windows desktop, or in a WSL instance, or remotely in a GitHub Codespace or a Remote SSH session. VS Code understands where the extension is "running" and can read settings from the proper location, if the settings are properly scoped.
+This extension has several settings that allow users to customize an executable path for different functions. These paths can vary depending on where the extension is running.
 
 As of v2.24.0, the extension uses the `machine` scope for the following settings:
 
@@ -140,4 +140,6 @@ terraform.languageServer.excludeRootModules
 terraform.languageServer.ignoreDirectoryNames
 ```
 
-This will allow VS Code to know where to read each setting depending on where the extension is running.
+> **Note**: This means these settings are no longer able to be configred in the Workspace or Folder setting scopes. For more information about setting scope see the VS Code [setting documentation](https://code.visualstudio.com/docs/getstarted/settings)
+
+This will allow VS Code to know where to read each setting depending on where the extension is running. For example: running locally on a Windows desktop, or in a WSL instance, or remotely in a GitHub Codespace or a Remote SSH session. VS Code understands where the extension is "running" and can read settings from the proper location, if the settings are properly scoped.

--- a/package.json
+++ b/package.json
@@ -293,14 +293,14 @@
           },
           "terraform.languageServer.path": {
             "order": "1",
-            "scope": "machine-overridable",
+            "scope": "machine",
             "type": "string",
             "default": "",
             "description": "Path to the Terraform Language Server binary (optional)"
           },
           "terraform.languageServer.args": {
             "order": "2",
-            "scope": "machine-overridable",
+            "scope": "machine",
             "type": "array",
             "items": {
               "type": "string"
@@ -316,7 +316,7 @@
               "number",
               null
             ],
-            "scope": "machine-overridable",
+            "scope": "machine",
             "default": null,
             "markdownDescription": "Language server TCP port to connect to. This is not compatible with `#terraform.languageServer.path#`. This is used when you want the extension to connect via TCP to an already running language server process."
           },
@@ -412,19 +412,19 @@
         "properties": {
           "terraform.languageServer.terraform.path": {
             "order": 0,
-            "scope": "machine-overridable",
+            "scope": "machine",
             "type": "string",
             "description": "Path to the Terraform binary used by the Terraform Language Server"
           },
           "terraform.languageServer.terraform.timeout": {
             "order": 1,
-            "scope": "machine-overridable",
+            "scope": "machine",
             "type": "string",
             "description": "Overrides Terraform execution timeout (e.g. 30s) used by the Terraform Language Server"
           },
           "terraform.languageServer.terraform.logFilePath": {
             "order": 2,
-            "scope": "machine-overridable",
+            "scope": "machine",
             "type": "string",
             "markdownDescription": "Path to a file (`TF_LOG_PATH`) for Terraform executions to be logged used by the the Terraform Language Server. Support for variables (e.g. timestamp, pid, ppid) via Go template syntax `{{varName}}`"
           }

--- a/package.json
+++ b/package.json
@@ -328,7 +328,7 @@
             "description": "Enable warning when opening a single Terraform file instead of a Terraform folder. Enabling this will prevent the message being sent"
           },
           "terraform.languageServer.rootModules": {
-            "scope": "machine-overridable",
+            "scope": "machine",
             "type": "array",
             "items": {
               "type": "machine"
@@ -338,7 +338,7 @@
             "deprecationMessage": "Deprecated: This setting is not used by the extension and will be removed in a future release"
           },
           "terraform.languageServer.excludeRootModules": {
-            "scope": "machine-overridable",
+            "scope": "machine",
             "type": "array",
             "items": {
               "type": "string"
@@ -348,7 +348,7 @@
             "deprecationMessage": "Deprecated: This setting is not used by the extension and will be removed in a future release"
           },
           "terraform.languageServer.ignoreDirectoryNames": {
-            "scope": "machine-overridable",
+            "scope": "machine",
             "type": "array",
             "items": {
               "type": "string"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -10,7 +10,6 @@ import {
   StaticFeature,
   CloseAction,
   ErrorAction,
-  WorkDoneProgress,
 } from 'vscode-languageclient/node';
 import { getInitializationOptions, getServerOptions } from './utils/clientHelpers';
 import { GenerateBugReportCommand } from './commands/generateBugReport';


### PR DESCRIPTION
This scopes all path related and dependent settings to machine scope. This restricts the settings to only be specified in the User or Remote settings, not workspace or folder settings.

This allows a setting to have different values depending on where VS Code is being run in. For example, if a user runs this extension in Windows locally and in an Ubuntu WSL instance they need to specify two different paths to terraform-ls (if they use a custom install location). They configure a Windows path in their User settings and configure a Linux path in their Remote WSL session. The correct path will be resolved in either session.
