### PR TITLE
Add Terraform version info

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,8 @@ import { ShowReferencesFeature } from './features/showReferences';
 import { CustomSemanticTokens } from './features/semanticTokens';
 import { ModuleProvidersFeature } from './features/moduleProviders';
 import { ModuleCallsFeature } from './features/moduleCalls';
+import { TerraformVersionFeature } from './features/terraformVersion';
+import { report } from 'process';
 
 const id = 'terraform';
 const brand = `HashiCorp Terraform`;
@@ -173,6 +175,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     new CustomSemanticTokens(client, manifest),
     new ModuleProvidersFeature(client, moduleProvidersDataProvider),
     new ModuleCallsFeature(client, moduleCallsDataProvider),
+    new TerraformVersionFeature(client, reporter),
   ];
   if (vscode.env.isTelemetryEnabled) {
     features.push(new TelemetryFeature(client, reporter));
@@ -206,20 +209,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   );
 
   await startLanguageServer(context);
-
-  /*
-   In the future, we can hook this to onDidChange or a similar handler, but currently
-   we only detect Terraform versions at start inside terraform-ls, so it is sufficient to ask once here
-  */
-  const editor = getActiveTextEditor();
-  if (editor !== undefined) {
-    terraform.getTerraformVersion(editor.document.uri, client, reporter);
-  } else {
-    const workspaces = vscode.workspace.workspaceFolders;
-    if (workspaces !== undefined) {
-      terraform.getTerraformVersion(workspaces[0].uri, client, reporter);
-    }
-  }
 }
 
 export async function deactivate(): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,3 +1,4 @@
+import * as tfStatus from './status/terraform';
 import * as terraform from './terraform';
 import * as vscode from 'vscode';
 import TelemetryReporter from '@vscode/extension-telemetry';
@@ -206,6 +207,16 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   );
 
   await startLanguageServer(context);
+
+  /*
+   In the future, we can hook this to onDidChange or a similar handler, but currently
+   we only detect Terraform versions at start inside terraform-ls, so it is sufficient to ask once here
+  */
+  const workspaces = vscode.workspace.workspaceFolders;
+  if (workspaces !== undefined) {
+    const response = await terraform.terraformVersion(workspaces[0].uri.toString(), client, reporter);
+    tfStatus.setTerraformVersion(response.discovered_version);
+  }
 }
 
 export async function deactivate(): Promise<void> {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,14 +16,13 @@ import { GenerateBugReportCommand } from './commands/generateBugReport';
 import { ModuleCallsDataProvider } from './providers/moduleCalls';
 import { ModuleProvidersDataProvider } from './providers/moduleProviders';
 import { ServerPath } from './utils/serverPath';
-import { config, deleteSetting, getActiveTextEditor, getScope, migrate, warnIfMigrate } from './utils/vscode';
+import { config, deleteSetting, getScope, migrate, warnIfMigrate } from './utils/vscode';
 import { TelemetryFeature } from './features/telemetry';
 import { ShowReferencesFeature } from './features/showReferences';
 import { CustomSemanticTokens } from './features/semanticTokens';
 import { ModuleProvidersFeature } from './features/moduleProviders';
 import { ModuleCallsFeature } from './features/moduleCalls';
 import { TerraformVersionFeature } from './features/terraformVersion';
-import { report } from 'process';
 
 const id = 'terraform';
 const brand = `HashiCorp Terraform`;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -214,6 +214,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   const editor = getActiveTextEditor();
   if (editor !== undefined) {
     terraform.getTerraformVersion(editor.document.uri, client, reporter);
+  } else {
+    const workspaces = vscode.workspace.workspaceFolders;
+    if (workspaces !== undefined) {
+      terraform.getTerraformVersion(workspaces[0].uri, client, reporter);
+    }
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,4 +1,3 @@
-import * as tfStatus from './status/terraform';
 import * as terraform from './terraform';
 import * as vscode from 'vscode';
 import TelemetryReporter from '@vscode/extension-telemetry';
@@ -17,7 +16,7 @@ import { GenerateBugReportCommand } from './commands/generateBugReport';
 import { ModuleCallsDataProvider } from './providers/moduleCalls';
 import { ModuleProvidersDataProvider } from './providers/moduleProviders';
 import { ServerPath } from './utils/serverPath';
-import { config, deleteSetting, getScope, migrate, warnIfMigrate } from './utils/vscode';
+import { config, deleteSetting, getActiveTextEditor, getScope, migrate, warnIfMigrate } from './utils/vscode';
 import { TelemetryFeature } from './features/telemetry';
 import { ShowReferencesFeature } from './features/showReferences';
 import { CustomSemanticTokens } from './features/semanticTokens';
@@ -212,10 +211,9 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
    In the future, we can hook this to onDidChange or a similar handler, but currently
    we only detect Terraform versions at start inside terraform-ls, so it is sufficient to ask once here
   */
-  const workspaces = vscode.workspace.workspaceFolders;
-  if (workspaces !== undefined) {
-    const response = await terraform.terraformVersion(workspaces[0].uri.toString(), client, reporter);
-    tfStatus.setTerraformVersion(response.discovered_version);
+  const editor = getActiveTextEditor();
+  if (editor !== undefined) {
+    terraform.getTerraformVersion(editor.document.uri, client, reporter);
   }
 }
 

--- a/src/features/terraformVersion.ts
+++ b/src/features/terraformVersion.ts
@@ -1,0 +1,46 @@
+import * as terraform from '../terraform';
+import * as vscode from 'vscode';
+import { ClientCapabilities, ServerCapabilities, StaticFeature } from 'vscode-languageclient';
+import { ExperimentalClientCapabilities } from './types';
+import TelemetryReporter from '@vscode/extension-telemetry';
+import { LanguageClient } from 'vscode-languageclient/node';
+import { getActiveTextEditor } from '../utils/vscode';
+
+export const CLIENT_TERRAFORM_VERSION_CMD_ID = 'client.refreshTerraformVersion';
+
+export class TerraformVersionFeature implements StaticFeature {
+  private disposables: vscode.Disposable[] = [];
+
+  constructor(private client: LanguageClient, private reporter: TelemetryReporter) {}
+
+  public fillClientCapabilities(capabilities: ClientCapabilities & ExperimentalClientCapabilities): void {
+    if (!capabilities['experimental']) {
+      capabilities['experimental'] = {};
+    }
+    capabilities['experimental']['refreshTerraformVersionCommandId'] = CLIENT_TERRAFORM_VERSION_CMD_ID;
+  }
+
+  public async initialize(capabilities: ServerCapabilities): Promise<void> {
+    if (!capabilities.experimental?.refreshTerraformVersion) {
+      console.log("Server doesn't support client.refreshTerraformVersion");
+      return;
+    }
+
+    await this.client.onReady();
+
+    const d = this.client.onRequest(CLIENT_TERRAFORM_VERSION_CMD_ID, async () => {
+      const editor = getActiveTextEditor();
+      if (editor === undefined) {
+        return;
+      }
+
+      terraform.getTerraformVersion(editor.document.uri, this.client, this.reporter);
+    });
+
+    this.disposables.push(d);
+  }
+
+  public dispose(): void {
+    this.disposables.forEach((d: vscode.Disposable) => d.dispose());
+  }
+}

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -7,5 +7,6 @@ export interface ExperimentalClientCapabilities {
     showReferencesCommandId?: string;
     refreshModuleProvidersCommandId?: string;
     refreshModuleCallsCommandId?: string;
+    refreshTerraformVersionCommandId?: string;
   };
 }

--- a/src/status/terraform.ts
+++ b/src/status/terraform.ts
@@ -1,0 +1,27 @@
+import * as vscode from 'vscode';
+
+const terraformStatus = vscode.languages.createLanguageStatusItem('terraform.status', [
+  { language: 'terraform' },
+  { language: 'terraform-vars' },
+]);
+terraformStatus.name = 'Terraform';
+terraformStatus.detail = 'Terraform';
+terraformStatus.command = {
+  command: 'terraform.commands',
+  title: 'Terraform Commands',
+  tooltip: 'foo',
+};
+
+export function setTerraformState(
+  detail: string,
+  busy: boolean,
+  severity: vscode.LanguageStatusSeverity = vscode.LanguageStatusSeverity.Information,
+) {
+  terraformStatus.busy = busy;
+  terraformStatus.detail = detail;
+  terraformStatus.severity = severity;
+}
+
+export function setTerraformVersion(version: string) {
+  terraformStatus.text = version;
+}

--- a/src/terraform.ts
+++ b/src/terraform.ts
@@ -1,6 +1,12 @@
+import * as tfStatus from './status/terraform';
 import TelemetryReporter from '@vscode/extension-telemetry';
 import * as vscode from 'vscode';
-import { ExecuteCommandParams, ExecuteCommandRequest, LanguageClient } from 'vscode-languageclient/node';
+import {
+  ExecuteCommandParams,
+  ExecuteCommandRequest,
+  LanguageClient,
+  WorkDoneProgress,
+} from 'vscode-languageclient/node';
 import { Utils } from 'vscode-uri';
 import { getActiveTextEditor } from './utils/vscode';
 import { clientSupportsCommand } from './utils/clientHelpers';
@@ -10,6 +16,12 @@ export interface ModuleCaller {
   uri: string;
 }
 
+export interface TerraformInfoResponse {
+  v: number;
+  required_version: string;
+  discovered_version: string;
+  discovered_path: string;
+}
 export interface ModuleCallersResponse {
   v: number;
   callers: ModuleCaller[];
@@ -43,6 +55,18 @@ interface ModuleProvidersResponse {
   };
 }
 /* eslint-enable @typescript-eslint/naming-convention */
+
+export async function terraformVersion(
+  moduleUri: string,
+  client: LanguageClient,
+  reporter: TelemetryReporter,
+): Promise<TerraformInfoResponse> {
+  const command = 'terraform-ls.module.terraform';
+
+  const response = await execWorkspaceLSCommand<TerraformInfoResponse>(command, moduleUri, client, reporter);
+
+  return response;
+}
 
 export async function moduleCallers(
   moduleUri: string,

--- a/src/terraform.ts
+++ b/src/terraform.ts
@@ -20,8 +20,8 @@ export interface TerraformInfoResponse {
   v: number;
   required_version: string;
   discovered_version: string;
-  discovered_path: string;
 }
+
 export interface ModuleCallersResponse {
   v: number;
   callers: ModuleCaller[];

--- a/src/terraform.ts
+++ b/src/terraform.ts
@@ -56,6 +56,27 @@ interface ModuleProvidersResponse {
 }
 /* eslint-enable @typescript-eslint/naming-convention */
 
+export async function getTerraformVersion(
+  moduleUri: vscode.Uri,
+  client: LanguageClient,
+  reporter: TelemetryReporter,
+): Promise<void> {
+  try {
+    const moduleDir = Utils.dirname(moduleUri);
+
+    const response = await terraformVersion(moduleDir.toString(), client, reporter);
+    tfStatus.setTerraformVersion(response.discovered_version);
+  } catch (error) {
+    let message = 'Error requesting terraform version from terraform-ls';
+    if (error instanceof Error) {
+      message = error.message;
+    } else if (typeof error === 'string') {
+      message = error;
+    }
+
+    vscode.window.showErrorMessage(message);
+  }
+}
 export async function terraformVersion(
   moduleUri: string,
   client: LanguageClient,


### PR DESCRIPTION
This commit adds a LanguageStatusItem that shows the discovered Terraform version in the current workspace. This utilizes the LSP request mechanism to automatically show the version when it is discovered for the currently open document.

This requires an open document and does not attempt to query for a folder because LanguageStatusItems only show for open documents. 

Requires https://github.com/hashicorp/terraform-ls/pull/1016