### PR TITLE
Refactor main entry point

### DIFF
--- a/src/commands/terraform.ts
+++ b/src/commands/terraform.ts
@@ -1,0 +1,32 @@
+import TelemetryReporter from '@vscode/extension-telemetry';
+import * as vscode from 'vscode';
+import { LanguageClient } from 'vscode-languageclient/node';
+import * as terraform from '../terraform';
+
+export class TerraformCommands implements vscode.Disposable {
+  private commands: vscode.Disposable[];
+
+  constructor(private client: LanguageClient, private reporter: TelemetryReporter) {
+    this.commands = [
+      vscode.commands.registerCommand('terraform.init', async () => {
+        await terraform.initAskUserCommand(this.client, this.reporter);
+      }),
+      vscode.commands.registerCommand('terraform.initCurrent', async () => {
+        await terraform.initCurrentOpenFileCommand(this.client, this.reporter);
+      }),
+      vscode.commands.registerCommand('terraform.apply', async () => {
+        await terraform.command('apply', this.client, this.reporter, true);
+      }),
+      vscode.commands.registerCommand('terraform.plan', async () => {
+        await terraform.command('plan', this.client, this.reporter, true);
+      }),
+      vscode.commands.registerCommand('terraform.validate', async () => {
+        await terraform.command('validate', this.client, this.reporter);
+      }),
+    ];
+  }
+
+  dispose() {
+    this.commands.forEach((c) => c.dispose());
+  }
+}

--- a/src/commands/terraformls.ts
+++ b/src/commands/terraformls.ts
@@ -1,0 +1,42 @@
+import * as vscode from 'vscode';
+import { config, getScope } from '../utils/vscode';
+
+export class TerraformLSCommands implements vscode.Disposable {
+  private commands: vscode.Disposable[];
+
+  constructor() {
+    this.commands = [
+      vscode.workspace.onDidChangeConfiguration(async (event: vscode.ConfigurationChangeEvent) => {
+        if (event.affectsConfiguration('terraform') || event.affectsConfiguration('terraform-ls')) {
+          const reloadMsg = 'Reload VSCode window to apply language server changes';
+          const selected = await vscode.window.showInformationMessage(reloadMsg, 'Reload');
+          if (selected === 'Reload') {
+            vscode.commands.executeCommand('workbench.action.reloadWindow');
+          }
+        }
+      }),
+      vscode.commands.registerCommand('terraform.enableLanguageServer', async () => {
+        if (config('terraform').get('languageServer.enable') === true) {
+          return;
+        }
+
+        const scope: vscode.ConfigurationTarget = getScope('terraform', 'languageServer.enable');
+
+        await config('terraform').update('languageServer.enable', true, scope);
+      }),
+      vscode.commands.registerCommand('terraform.disableLanguageServer', async () => {
+        if (config('terraform').get('languageServer.enable') === false) {
+          return;
+        }
+
+        const scope: vscode.ConfigurationTarget = getScope('terraform', 'languageServer.enable');
+
+        await config('terraform').update('languageServer.enable', false, scope);
+      }),
+    ];
+  }
+
+  dispose() {
+    this.commands.forEach((c) => c.dispose());
+  }
+}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -135,13 +135,10 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }
   });
 
-  const moduleProvidersDataProvider = new ModuleProvidersDataProvider(context, client, reporter);
-  const moduleCallsDataProvider = new ModuleCallsDataProvider(context, client, reporter);
-
   const features: StaticFeature[] = [
     new CustomSemanticTokens(client, manifest),
-    new ModuleProvidersFeature(client, moduleProvidersDataProvider),
-    new ModuleCallsFeature(client, moduleCallsDataProvider),
+    new ModuleProvidersFeature(client, new ModuleProvidersDataProvider(context, client, reporter)),
+    new ModuleCallsFeature(client, new ModuleCallsDataProvider(context, client, reporter)),
   ];
   if (vscode.env.isTelemetryEnabled) {
     features.push(new TelemetryFeature(client, reporter));
@@ -158,8 +155,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     new GenerateBugReportCommand(context),
     new TerraformLSCommands(),
     new TerraformCommands(client, reporter),
-    vscode.window.registerTreeDataProvider('terraform.modules', moduleCallsDataProvider),
-    vscode.window.registerTreeDataProvider('terraform.providers', moduleProvidersDataProvider),
   );
 
   await startLanguageServer(context);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -6,7 +6,6 @@ import {
   LanguageClientOptions,
   RevealOutputChannelOn,
   State,
-  StaticFeature,
   CloseAction,
   ErrorAction,
 } from 'vscode-languageclient/node';
@@ -135,20 +134,13 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }
   });
 
-  const features: StaticFeature[] = [
+  client.registerFeatures([
     new CustomSemanticTokens(client, manifest),
     new ModuleProvidersFeature(client, new ModuleProvidersDataProvider(context, client, reporter)),
     new ModuleCallsFeature(client, new ModuleCallsDataProvider(context, client, reporter)),
-  ];
-  if (vscode.env.isTelemetryEnabled) {
-    features.push(new TelemetryFeature(client, reporter));
-  }
-  const codeLensReferenceCount = config('terraform').get<boolean>('codelens.referenceCount');
-  if (codeLensReferenceCount) {
-    features.push(new ShowReferencesFeature(client));
-  }
-
-  client.registerFeatures(features);
+    new TelemetryFeature(client, reporter),
+    new ShowReferencesFeature(client),
+  ]);
 
   // these need the LS to function, so are only registered if enabled
   context.subscriptions.push(

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -79,7 +79,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     }),
   );
 
-  if (!enabled()) {
+  if (config('terraform').get<boolean>('languageServer.enable') === false) {
     reporter.sendTelemetryEvent('disabledTerraformLS');
     return;
   }
@@ -252,8 +252,4 @@ async function stopLanguageServer() {
       vscode.window.showErrorMessage(error);
     }
   }
-}
-
-function enabled(): boolean {
-  return config('terraform').get('languageServer.enable', false);
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -153,11 +153,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 }
 
 export async function deactivate(): Promise<void> {
-  if (client === undefined) {
-    return;
-  }
-
-  return client.stop();
+  stopLanguageServer();
 }
 
 async function startLanguageServer(ctx: vscode.ExtensionContext) {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -29,7 +29,7 @@ const documentSelector: DocumentSelector = [
   { scheme: 'file', language: 'terraform' },
   { scheme: 'file', language: 'terraform-vars' },
 ];
-export const outputChannel = vscode.window.createOutputChannel(brand);
+const outputChannel = vscode.window.createOutputChannel(brand);
 
 let reporter: TelemetryReporter;
 let client: LanguageClient;
@@ -55,7 +55,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   if (lsPath.hasCustomBinPath()) {
     reporter.sendTelemetryEvent('usePathToBinary');
   }
-  const serverOptions = await getServerOptions(lsPath);
+  const serverOptions = await getServerOptions(lsPath, outputChannel);
 
   const initializationOptions = getInitializationOptions();
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -11,17 +11,18 @@ import {
   CloseAction,
   ErrorAction,
 } from 'vscode-languageclient/node';
-import { getInitializationOptions, getServerOptions } from './utils/clientHelpers';
+import { getServerOptions } from './utils/clientHelpers';
 import { GenerateBugReportCommand } from './commands/generateBugReport';
 import { ModuleCallsDataProvider } from './providers/moduleCalls';
 import { ModuleProvidersDataProvider } from './providers/moduleProviders';
 import { ServerPath } from './utils/serverPath';
-import { config, deleteSetting, getScope, migrate, warnIfMigrate } from './utils/vscode';
+import { config, getScope } from './utils/vscode';
 import { TelemetryFeature } from './features/telemetry';
 import { ShowReferencesFeature } from './features/showReferences';
 import { CustomSemanticTokens } from './features/semanticTokens';
 import { ModuleProvidersFeature } from './features/moduleProviders';
 import { ModuleCallsFeature } from './features/moduleCalls';
+import { getInitializationOptions, migrateLegacySettings, previewExtensionPresent } from './settings';
 
 const id = 'terraform';
 const brand = `HashiCorp Terraform`;
@@ -44,7 +45,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     return undefined;
   }
 
-  // migrate pre-2.24.0 settings
   await migrateLegacySettings(context);
 
   // Subscriptions
@@ -256,117 +256,4 @@ async function stopLanguageServer() {
 
 function enabled(): boolean {
   return config('terraform').get('languageServer.enable', false);
-}
-
-async function migrateLegacySettings(ctx: vscode.ExtensionContext) {
-  // User has asked not to check if settings need to be migrated, so return
-  if (ctx.globalState.get('terraform.disableSettingsMigration', false)) {
-    return;
-  }
-
-  // If any of the following list needs to be migrated, ask user if they want
-  // to migrate. This is a blunt force approach, but we don't intend to keep
-  // checking this forever
-  const warnMigration = warnIfMigrate([
-    { section: 'terraform', name: 'languageServer.external' },
-    { section: 'terraform', name: 'languageServer.pathToBinary' },
-    { section: 'terraform-ls', name: 'rootModules' },
-    { section: 'terraform-ls', name: 'excludeRootModules' },
-    { section: 'terraform-ls', name: 'ignoreDirectoryNames' },
-    { section: 'terraform-ls', name: 'terraformExecPath' },
-    { section: 'terraform-ls', name: 'terraformExecTimeout' },
-    { section: 'terraform-ls', name: 'terraformLogFilePath' },
-    { section: 'terraform-ls', name: 'experimentalFeatures' },
-  ]);
-  if (warnMigration === false) {
-    return;
-  }
-
-  const messageText =
-    'Automatic migration will change your settings file!' +
-    '\n\nTo read more about the this change click "More Info" and delay changing anything';
-  // Prompt the user if they want to migrate. If the choose no, then return
-  // and they are left to migrate the settings themselves.
-  // If they choose yes, then automatically migrate the settings
-  // Lastly user can be directed to our README for more information about this
-  const choice = await vscode.window.showInformationMessage(
-    'Terraform Extension settings have moved in the latest update',
-    {
-      detail: messageText,
-      modal: false,
-    },
-    { title: 'More Info' },
-    { title: 'Migrate' },
-    { title: 'Open Settings' },
-    { title: 'Suppress' },
-  );
-  if (choice === undefined) {
-    return;
-  }
-
-  switch (choice.title) {
-    case 'Suppress':
-      ctx.globalState.update('terraform.disableSettingsMigration', true);
-      return;
-    case 'Open Settings':
-      await vscode.commands.executeCommand('workbench.action.openSettings', '@ext:hashicorp.terraform');
-      return;
-    case 'More Info':
-      await vscode.commands.executeCommand(
-        'vscode.open',
-        vscode.Uri.parse('https://github.com/hashicorp/vscode-terraform/blob/v2.24.0/docs/settings-migration.md'),
-      );
-      await migrateLegacySettings(ctx);
-      return;
-    case 'Migrate':
-    // migrate below
-  }
-
-  await migrate('terraform', 'languageServer.external', 'languageServer.enable');
-  await migrate('terraform', 'languageServer.pathToBinary', 'languageServer.path');
-
-  // We need to move args and ignoreSingleFileWarning out of the JSON object format
-  await migrate('terraform', 'languageServer.args', 'languageServer.args');
-  await migrate('terraform', 'languageServer.ignoreSingleFileWarning', 'languageServer.ignoreSingleFileWarning');
-  await deleteSetting('terraform', 'languageServer');
-
-  // This simultaneously moves terraform-ls to terraform as well as migrate setting names
-  await migrate('terraform-ls', 'rootModules', 'languageServer.rootModules');
-  await migrate('terraform-ls', 'excludeRootModules', 'languageServer.indexing.ignorePaths');
-  await migrate('terraform-ls', 'ignoreDirectoryNames', 'languageServer.indexing.ignoreDirectoryNames');
-  await migrate('terraform-ls', 'terraformExecPath', 'languageServer.terraform.path');
-  await migrate('terraform-ls', 'terraformExecTimeout', 'languageServer.terraform.timeout');
-  await migrate('terraform-ls', 'terraformLogFilePath', 'languageServer.terraform.logFilePath');
-
-  // We need to move prefillRequiredFields and validateOnSave out of the JSON object format as well as
-  // move terraform-ls to terraform
-  await migrate('terraform-ls', 'experimentalFeatures.validateOnSave', 'experimentalFeatures.validateOnSave');
-  await migrate(
-    'terraform-ls',
-    'experimentalFeatures.prefillRequiredFields',
-    'experimentalFeatures.prefillRequiredFields',
-  );
-  await deleteSetting('terraform-ls', 'experimentalFeatures');
-  await vscode.commands.executeCommand('workbench.action.reloadWindow');
-}
-
-function previewExtensionPresent(currentExtensionID: string) {
-  const stable = vscode.extensions.getExtension('hashicorp.terraform');
-  const preview = vscode.extensions.getExtension('hashicorp.terraform-preview');
-
-  const msg = 'Please ensure only one is enabled or installed and reload this window';
-
-  if (currentExtensionID === 'hashicorp.terraform-preview') {
-    if (stable !== undefined) {
-      vscode.window.showErrorMessage('Terraform Preview cannot be used while Terraform Stable is also enabled.' + msg);
-      return true;
-    }
-  } else if (currentExtensionID === 'hashicorp.terraform') {
-    if (preview !== undefined) {
-      vscode.window.showErrorMessage('Terraform Stable cannot be used while Terraform Preview is also enabled.' + msg);
-      return true;
-    }
-  }
-
-  return false;
 }

--- a/src/features/moduleCalls.ts
+++ b/src/features/moduleCalls.ts
@@ -18,6 +18,8 @@ export class ModuleCallsFeature implements StaticFeature {
   }
 
   public async initialize(capabilities: ServerCapabilities): Promise<void> {
+    this.disposables.push(vscode.window.registerTreeDataProvider('terraform.modules', this.view));
+
     if (!capabilities.experimental?.refreshModuleCalls) {
       console.log('Server does not support client.refreshModuleCalls');
       return;

--- a/src/features/moduleProviders.ts
+++ b/src/features/moduleProviders.ts
@@ -18,6 +18,8 @@ export class ModuleProvidersFeature implements StaticFeature {
   }
 
   public async initialize(capabilities: ServerCapabilities): Promise<void> {
+    this.disposables.push(vscode.window.registerTreeDataProvider('terraform.providers', this.view));
+
     if (!capabilities.experimental?.refreshModuleProviders) {
       console.log("Server doesn't support client.refreshModuleProviders");
       return;

--- a/src/features/showReferences.ts
+++ b/src/features/showReferences.ts
@@ -40,7 +40,7 @@ export class ShowReferencesFeature implements StaticFeature {
       return;
     }
 
-    const codeLensReferenceCount = config('terraform').get<boolean>('codelens.referenceCount');
+    const codeLensReferenceCount = config('terraform').get<boolean>('codelens.referenceCount', false);
     if (codeLensReferenceCount === false) {
       return;
     }

--- a/src/features/showReferences.ts
+++ b/src/features/showReferences.ts
@@ -7,6 +7,7 @@ import {
   ServerCapabilities,
   StaticFeature,
 } from 'vscode-languageclient';
+import { config } from '../utils/vscode';
 
 import { ExperimentalClientCapabilities } from './types';
 
@@ -36,6 +37,11 @@ export class ShowReferencesFeature implements StaticFeature {
 
   public initialize(capabilities: ServerCapabilities): void {
     if (!capabilities.experimental?.referenceCountCodeLens) {
+      return;
+    }
+
+    const codeLensReferenceCount = config('terraform').get<boolean>('codelens.referenceCount');
+    if (codeLensReferenceCount === false) {
       return;
     }
 

--- a/src/handlers/errorHandler.ts
+++ b/src/handlers/errorHandler.ts
@@ -1,0 +1,51 @@
+import * as vscode from 'vscode';
+import { CloseAction, ErrorAction, ErrorHandler, Message } from 'vscode-languageclient';
+
+export class ExtensionErrorHandler implements ErrorHandler {
+  constructor(private outputChannel: vscode.OutputChannel) {}
+  error(error: Error, message: Message | undefined, count: number | undefined): ErrorAction {
+    vscode.window.showErrorMessage(`Terraform LS connection error: (${count})\n${error.message}\n${message?.jsonrpc}`);
+
+    return ErrorAction.Continue;
+  }
+  closed(): CloseAction {
+    this.outputChannel.appendLine(
+      `Failure to start terraform-ls. Please check your configuration settings and reload this window`,
+    );
+
+    vscode.window
+      .showErrorMessage(
+        'Failure to start terraform-ls. Please check your configuration settings and reload this window',
+        {
+          detail: '',
+          modal: false,
+        },
+        { title: 'Open Settings' },
+        { title: 'Open Logs' },
+        { title: 'More Info' },
+      )
+      .then(async (choice) => {
+        if (choice === undefined) {
+          return;
+        }
+
+        switch (choice.title) {
+          case 'Open Logs':
+            this.outputChannel.show();
+            break;
+          case 'Open Settings':
+            await vscode.commands.executeCommand('workbench.action.openSettings', '@ext:hashicorp.terraform');
+            break;
+          case 'More Info':
+            await vscode.commands.executeCommand(
+              'vscode.open',
+              vscode.Uri.parse('https://github.com/hashicorp/vscode-terraform#troubleshooting'),
+            );
+            break;
+        }
+      });
+
+    // Tell VS Code to stop attempting to start
+    return CloseAction.DoNotRestart;
+  }
+}

--- a/src/handlers/errorHandler.ts
+++ b/src/handlers/errorHandler.ts
@@ -3,12 +3,12 @@ import { CloseAction, ErrorAction, ErrorHandler, Message } from 'vscode-language
 
 export class ExtensionErrorHandler implements ErrorHandler {
   constructor(private outputChannel: vscode.OutputChannel) {}
-  error(error: Error, message: Message | undefined, count: number | undefined): ErrorAction {
+  error(error: Error, message: Message | undefined, count: number | undefined) {
     vscode.window.showErrorMessage(`Terraform LS connection error: (${count})\n${error.message}\n${message?.jsonrpc}`);
 
     return ErrorAction.Continue;
   }
-  closed(): CloseAction {
+  closed() {
     this.outputChannel.appendLine(
       `Failure to start terraform-ls. Please check your configuration settings and reload this window`,
     );

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -1,0 +1,175 @@
+import * as vscode from 'vscode';
+import { config, deleteSetting, migrate, warnIfMigrate } from './utils/vscode';
+
+export interface InitializationOptions {
+  indexing?: IndexingOptions;
+  experimentalFeatures?: ExperimentalFeatures;
+  ignoreSingleFileWarning?: boolean;
+  terraform?: TerraformOptions;
+}
+
+export interface TerraformOptions {
+  path: string;
+  timeout: string;
+  logFilePath: string;
+}
+
+export interface IndexingOptions {
+  ignoreDirectoryNames: string[];
+  ignorePaths: string[];
+}
+
+export interface ExperimentalFeatures {
+  validateOnSave: boolean;
+  prefillRequiredFields: boolean;
+}
+
+export function getInitializationOptions() {
+  /*
+    This is basically a set of settings masquerading as a function. The intention
+    here is to make room for this to be added to a configuration builder when
+    we tackle #791
+  */
+  const terraform = config('terraform').get<TerraformOptions>('languageServer.terraform', {
+    path: '',
+    timeout: '',
+    logFilePath: '',
+  });
+  const indexing = config('terraform').get<IndexingOptions>('languageServer.indexing', {
+    ignoreDirectoryNames: [],
+    ignorePaths: [],
+  });
+  const ignoreSingleFileWarning = config('terraform').get<boolean>('languageServer.ignoreSingleFileWarning', false);
+  const experimentalFeatures = config('terraform').get<ExperimentalFeatures>('experimentalFeatures');
+
+  // deprecated
+  const rootModulePaths = config('terraform').get<string[]>('languageServer.rootModules', []);
+  if (rootModulePaths.length > 0 && indexing.ignorePaths.length > 0) {
+    throw new Error(
+      'Only one of rootModules and indexing.ignorePaths can be set at the same time, please remove the conflicting config and reload',
+    );
+  }
+
+  const initializationOptions: InitializationOptions = {
+    experimentalFeatures,
+    ignoreSingleFileWarning,
+    terraform,
+    ...(rootModulePaths.length > 0 && { rootModulePaths }),
+    indexing,
+  };
+
+  return initializationOptions;
+}
+
+export async function migrateLegacySettings(ctx: vscode.ExtensionContext) {
+  // User has asked not to check if settings need to be migrated, so return
+  if (ctx.globalState.get('terraform.disableSettingsMigration', false)) {
+    return;
+  }
+
+  // If any of the following list needs to be migrated, ask user if they want
+  // to migrate. This is a blunt force approach, but we don't intend to keep
+  // checking this forever
+  const warnMigration = warnIfMigrate([
+    { section: 'terraform', name: 'languageServer.external' },
+    { section: 'terraform', name: 'languageServer.pathToBinary' },
+    { section: 'terraform-ls', name: 'rootModules' },
+    { section: 'terraform-ls', name: 'excludeRootModules' },
+    { section: 'terraform-ls', name: 'ignoreDirectoryNames' },
+    { section: 'terraform-ls', name: 'terraformExecPath' },
+    { section: 'terraform-ls', name: 'terraformExecTimeout' },
+    { section: 'terraform-ls', name: 'terraformLogFilePath' },
+    { section: 'terraform-ls', name: 'experimentalFeatures' },
+  ]);
+  if (warnMigration === false) {
+    return;
+  }
+
+  const messageText =
+    'Automatic migration will change your settings file!' +
+    '\n\nTo read more about the this change click "More Info" and delay changing anything';
+  // Prompt the user if they want to migrate. If the choose no, then return
+  // and they are left to migrate the settings themselves.
+  // If they choose yes, then automatically migrate the settings
+  // Lastly user can be directed to our README for more information about this
+  const choice = await vscode.window.showInformationMessage(
+    'Terraform Extension settings have moved in the latest update',
+    {
+      detail: messageText,
+      modal: false,
+    },
+    { title: 'More Info' },
+    { title: 'Migrate' },
+    { title: 'Open Settings' },
+    { title: 'Suppress' },
+  );
+  if (choice === undefined) {
+    return;
+  }
+
+  switch (choice.title) {
+    case 'Suppress':
+      ctx.globalState.update('terraform.disableSettingsMigration', true);
+      return;
+    case 'Open Settings':
+      await vscode.commands.executeCommand('workbench.action.openSettings', '@ext:hashicorp.terraform');
+      return;
+    case 'More Info':
+      await vscode.commands.executeCommand(
+        'vscode.open',
+        vscode.Uri.parse('https://github.com/hashicorp/vscode-terraform/blob/v2.24.0/docs/settings-migration.md'),
+      );
+      await migrateLegacySettings(ctx);
+      return;
+    case 'Migrate':
+    // migrate below
+  }
+
+  await migrate('terraform', 'languageServer.external', 'languageServer.enable');
+  await migrate('terraform', 'languageServer.pathToBinary', 'languageServer.path');
+
+  // We need to move args and ignoreSingleFileWarning out of the JSON object format
+  await migrate('terraform', 'languageServer.args', 'languageServer.args');
+  await migrate('terraform', 'languageServer.ignoreSingleFileWarning', 'languageServer.ignoreSingleFileWarning');
+  await deleteSetting('terraform', 'languageServer');
+
+  // This simultaneously moves terraform-ls to terraform as well as migrate setting names
+  await migrate('terraform-ls', 'rootModules', 'languageServer.rootModules');
+  await migrate('terraform-ls', 'excludeRootModules', 'languageServer.indexing.ignorePaths');
+  await migrate('terraform-ls', 'ignoreDirectoryNames', 'languageServer.indexing.ignoreDirectoryNames');
+  await migrate('terraform-ls', 'terraformExecPath', 'languageServer.terraform.path');
+  await migrate('terraform-ls', 'terraformExecTimeout', 'languageServer.terraform.timeout');
+  await migrate('terraform-ls', 'terraformLogFilePath', 'languageServer.terraform.logFilePath');
+
+  // We need to move prefillRequiredFields and validateOnSave out of the JSON object format as well as
+  // move terraform-ls to terraform
+  await migrate('terraform-ls', 'experimentalFeatures.validateOnSave', 'experimentalFeatures.validateOnSave');
+  await migrate(
+    'terraform-ls',
+    'experimentalFeatures.prefillRequiredFields',
+    'experimentalFeatures.prefillRequiredFields',
+  );
+  await deleteSetting('terraform-ls', 'experimentalFeatures');
+  await vscode.commands.executeCommand('workbench.action.reloadWindow');
+}
+
+export function previewExtensionPresent(currentExtensionID: string) {
+  const stable = vscode.extensions.getExtension('hashicorp.terraform');
+  const preview = vscode.extensions.getExtension('hashicorp.terraform-preview');
+
+  const msg = 'Please ensure only one is enabled or installed and reload this window';
+
+  if (currentExtensionID === 'hashicorp.terraform-preview') {
+    if (stable !== undefined) {
+      vscode.window.showErrorMessage('Terraform Preview cannot be used while Terraform Stable is also enabled.' + msg);
+      return true;
+    }
+  } else if (currentExtensionID === 'hashicorp.terraform') {
+    if (preview !== undefined) {
+      vscode.window.showErrorMessage('Terraform Stable cannot be used while Terraform Preview is also enabled.' + msg);
+      return true;
+    }
+  }
+
+  return false;
+}

--- a/src/utils/clientHelpers.ts
+++ b/src/utils/clientHelpers.ts
@@ -49,66 +49,6 @@ export async function getServerOptions(lsPath: ServerPath): Promise<ServerOption
   return serverOptions;
 }
 
-interface InitializationOptions {
-  indexing?: IndexingOptions;
-  experimentalFeatures?: ExperimentalFeatures;
-  ignoreSingleFileWarning?: boolean;
-  terraform?: TerraformOptions;
-}
-
-interface TerraformOptions {
-  path: string;
-  timeout: string;
-  logFilePath: string;
-}
-
-interface IndexingOptions {
-  ignoreDirectoryNames: string[];
-  ignorePaths: string[];
-}
-
-interface ExperimentalFeatures {
-  validateOnSave: boolean;
-  prefillRequiredFields: boolean;
-}
-
-export function getInitializationOptions() {
-  /*
-    This is basically a set of settings masquerading as a function. The intention
-    here is to make room for this to be added to a configuration builder when
-    we tackle #791
-  */
-  const terraform = config('terraform').get<TerraformOptions>('languageServer.terraform', {
-    path: '',
-    timeout: '',
-    logFilePath: '',
-  });
-  const indexing = config('terraform').get<IndexingOptions>('languageServer.indexing', {
-    ignoreDirectoryNames: [],
-    ignorePaths: [],
-  });
-  const ignoreSingleFileWarning = config('terraform').get<boolean>('languageServer.ignoreSingleFileWarning', false);
-  const experimentalFeatures = config('terraform').get<ExperimentalFeatures>('experimentalFeatures');
-
-  // deprecated
-  const rootModulePaths = config('terraform').get<string[]>('languageServer.rootModules', []);
-  if (rootModulePaths.length > 0 && indexing.ignorePaths.length > 0) {
-    throw new Error(
-      'Only one of rootModules and indexing.ignorePaths can be set at the same time, please remove the conflicting config and reload',
-    );
-  }
-
-  const initializationOptions: InitializationOptions = {
-    experimentalFeatures,
-    ignoreSingleFileWarning,
-    terraform,
-    ...(rootModulePaths.length > 0 && { rootModulePaths }),
-    indexing,
-  };
-
-  return initializationOptions;
-}
-
 export function clientSupportsCommand(initializeResult: InitializeResult | undefined, cmdName: string): boolean {
   if (!initializeResult) {
     return false;

--- a/src/utils/clientHelpers.ts
+++ b/src/utils/clientHelpers.ts
@@ -3,9 +3,11 @@ import * as vscode from 'vscode';
 import { Executable, InitializeResult, ServerOptions } from 'vscode-languageclient/node';
 import { config } from './vscode';
 import { ServerPath } from './serverPath';
-import { outputChannel } from '../extension';
 
-export async function getServerOptions(lsPath: ServerPath): Promise<ServerOptions> {
+export async function getServerOptions(
+  lsPath: ServerPath,
+  outputChannel: vscode.OutputChannel,
+): Promise<ServerOptions> {
   let serverOptions: ServerOptions;
 
   const port = config('terraform').get<number>('languageServer.tcp.port');
@@ -29,13 +31,13 @@ export async function getServerOptions(lsPath: ServerPath): Promise<ServerOption
       };
     };
 
-    outputChannel?.appendLine(`Connecting to language server via TCP at localhost:${port}`);
+    outputChannel.appendLine(`Connecting to language server via TCP at localhost:${port}`);
     return serverOptions;
   }
 
   const cmd = await lsPath.resolvedPathToBinary();
   const serverArgs = config('terraform').get<string[]>('languageServer.args', []);
-  outputChannel?.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
+  outputChannel.appendLine(`Launching language server: ${cmd} ${serverArgs.join(' ')}`);
   const executable: Executable = {
     command: cmd,
     args: serverArgs,


### PR DESCRIPTION
## Goals

- Centralize and standardize command registration and enablement
- Centralize and standardize feature registration and enablement
- Extract functionality to dedicated files
- Eliminate cyclic imports
- Dispose disposables properly

## Implementation

- Extract settings.ts

This moves all setting related functions to a new file called settings.ts. This is in preparation for a more formal settings infrastructure.

- Remove enabled function

This prefers direct detection of the setting rather than the function. This is in preparation for a more formal settings management in the future.

- Extract Terraform command registration

This extracts registering Terraform commands to a central class. This cleans up extension.ts from having lots of registrations, enables a central place to keep track of terraform-ls execution related commands, and enables centralized progress reporting in a future commit.

- Extract view providers registration

This commit centralizes the registration of the view providers inside the StaticFeature classes. This simplifies the creation of these elements, centralizes the many moving parts, and ensures all disposable components are disposed properly.

- Extract StaticFeature registrations

This simplifies registering all the custom StaticFeatures by moving the enabling logic to inside each class. This moves the decision logic closest to the point of use instead of a place separate from the class. It also follows the API intention of using the initialize function to determine if the feature is initialized or not.

This also ensures the telemetry handler is disposed as the class is disposed, to ensure the LanguageClient is closed properly.

- Cleanup deactivation

- Extract error handler

This extracts the error handling logic into a dedicated class instead of having the entire set inside the extension.ts file.

- Resolve cyclic dependency on outputChannel

This removes the export on outputChannel and makes it a function parameter to prevent extension.ts exporting it while also importing clientHelpers.ts, which imports from extension.ts.



