### PR TITLE
fix: avoid sending command ID when codelens is disabled

### DIFF
--- a/src/features/showReferences.ts
+++ b/src/features/showReferences.ts
@@ -25,10 +25,14 @@ const VSCODE_SHOW_REFERENCES = 'editor.action.showReferences';
 
 export class ShowReferencesFeature implements StaticFeature {
   private registeredCommands: vscode.Disposable[] = [];
+  private isEnabled = config('terraform').get<boolean>('codelens.referenceCount', false);
 
   constructor(private _client: BaseLanguageClient) {}
 
   public fillClientCapabilities(capabilities: ClientCapabilities & ExperimentalClientCapabilities): void {
+    if (this.isEnabled === false) {
+      return;
+    }
     if (!capabilities['experimental']) {
       capabilities['experimental'] = {};
     }
@@ -40,8 +44,7 @@ export class ShowReferencesFeature implements StaticFeature {
       return;
     }
 
-    const codeLensReferenceCount = config('terraform').get<boolean>('codelens.referenceCount', false);
-    if (codeLensReferenceCount === false) {
+    if (this.isEnabled === false) {
       return;
     }
 


### PR DESCRIPTION
The language server will enable reference count code lens when it receives the `experimental.showReferencesCommandId`, which we seem to send always, i.e. we always enable it. Consequently we (correctly) don't register the command, so upon clicking to the code lens, it errors out:

<img width="342" alt="Screenshot 2022-08-09 at 12 48 51" src="https://user-images.githubusercontent.com/287584/183639906-8a71abfc-9257-4d94-80b1-3213456546e3.png">

This makes it so that the client only sends that command ID when the feature is actually enabled.