### PR TITLE
Handle Invalid WSL Uri

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,14 @@ To provide the extension with an up-to-date schema for the Terraform providers u
 1. Open any folder or VS Code workspace containing Terraform files. 
 1. Open the Command Palette and run `Terraform: init current folder` or perform a `terraform init` from the terminal.
 
+### Remote Extension support
+
+The Visual Studio Code [Remote - WSL extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl) lets you use the Windows Subsystem for Linux (WSL) as your full-time development environment right from VS Code. You can author Terraform configuration files in a Linux-based environment, use Linux-specific toolchains and utilities from the comfort of Windows.
+
+The Remote WSL extension runs the [HashiCorp Extension](https://marketplace.visualstudio.com/items?itemName=HashiCorp.terraform) and other extensions directly in WSL so you can edit files located in WSL or the mounted Windows filesystem (for example /mnt/c) without worrying about pathing issues, binary compatibility, or other cross-OS challenges.
+
+For a detailed walkthrough for how to get started using WSL and VS Code, see https://code.visualstudio.com/docs/remote/wsl-tutorial.
+
 ## Configuration
 
 The extension does not require any initial configuration and should work out of the box. To take advantage of additional VS Code features or experimental extension features you can configure settings to customize behavior.

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,10 +2,8 @@ import * as vscode from 'vscode';
 import TelemetryReporter from '@vscode/extension-telemetry';
 import {
   DocumentSelector,
-  InitializeError,
   LanguageClient,
   LanguageClientOptions,
-  ResponseError,
   RevealOutputChannelOn,
   State,
 } from 'vscode-languageclient/node';
@@ -24,8 +22,6 @@ import { getInitializationOptions, migrateLegacySettings, previewExtensionPresen
 import { TerraformLSCommands } from './commands/terraformls';
 import { TerraformCommands } from './commands/terraform';
 import { ExtensionErrorHandler } from './handlers/errorHandler';
-import { report } from 'process';
-import { strict } from 'assert';
 
 const id = 'terraform';
 const brand = `HashiCorp Terraform`;

--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -217,7 +217,9 @@ export async function handleLanguageClientStart(
       case 'More Info':
         await vscode.commands.executeCommand(
           'vscode.open',
-          vscode.Uri.parse('https://github.com/hashicorp/vscode-terraform/blob/v2.24.0/docs/remote-extension-usage.md'),
+          vscode.Uri.parse(
+            'https://github.com/hashicorp/vscode-terraform/blob/v2.24.0/README.md#remote-extension-support',
+          ),
         );
     }
   } else {

--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -180,7 +180,7 @@ export async function handleLanguageClientStart(
     reporter.sendTelemetryException(new Error(error));
   }
 
-  if (message.startsWith('INVALID_URI_WSL')) {
+  if (message === 'INVALID_URI_WSL') {
     // handle in startLanguageServer()
     if (ctx.globalState.get<boolean>('terraform.disableWSLNotification') === true) {
       return;
@@ -188,7 +188,8 @@ export async function handleLanguageClientStart(
 
     const messageText =
       'It looks like you opened a WSL url using a Windows UNC path' +
-      ' outside of the Remote WSL extension. The HashiCorp Terraform Extension cannot work with this URL. Would you like to reopen this folder' +
+      ' outside of the [Remote WSL extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-wsl).' +
+      ' The HashiCorp Terraform Extension works seamlessly with the Remote WSL Extension, but cannot work with this URL. Would you like to reopen this folder' +
       ' in the WSL Extension?';
 
     const choice = await vscode.window.showErrorMessage(


### PR DESCRIPTION
This adds logic to handle UNC WSL Paths that will not work in terraform-ls. It prompts the user to switch to the Remote WSL extension or allows the user to ignore the prompt.

Needs https://github.com/hashicorp/terraform-ls/pull/1057 to fully function