### PR TITLE
handle exception reporting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## [Unreleased]
+
+INTERNAL
+
+- Reduce duplicate error telemetry [#1230](https://github.com/hashicorp/vscode-terraform/pull/1230)
+
+
 ## [2.24.2] (2022-09-07)
 
 ENHANCEMENTS
@@ -9,6 +16,7 @@ BUG FIXES:
  - fix: Improve IntelliSense accuracy by tracking provider schema versions (bug introduced in 2.24.0) ([terraform-ls#1060](https://github.com/hashicorp/terraform-ls/pull/1060))
  - Don't query the Terraform Registry for module sources starting with `.` in completion ([terraform-ls#1062](https://github.com/hashicorp/terraform-ls/pull/1062))
  - fix race condition (panic) in schema merging ([terraform-schema#137](https://github.com/hashicorp/terraform-schema/pull/137))
+
 INTERNAL
 
 - Improve error telemetry [#1215](https://github.com/hashicorp/vscode-terraform/pull/1215)

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import { GenerateBugReportCommand } from './commands/generateBugReport';
 import { ModuleCallsDataProvider } from './providers/moduleCalls';
 import { ModuleProvidersDataProvider } from './providers/moduleProviders';
 import { ServerPath } from './utils/serverPath';
-import { config, handleLanguageClientStart } from './utils/vscode';
+import { config, handleLanguageClientStart as handleLanguageClientStartError } from './utils/vscode';
 import { TelemetryFeature } from './features/telemetry';
 import { ShowReferencesFeature } from './features/showReferences';
 import { CustomSemanticTokens } from './features/semanticTokens';
@@ -123,7 +123,7 @@ async function startLanguageServer(ctx: vscode.ExtensionContext) {
       console.log(`Multi-folder support: ${multiFoldersSupported}`);
     }
   } catch (error) {
-    await handleLanguageClientStart(error, ctx, reporter);
+    await handleLanguageClientStartError(error, ctx, reporter);
   }
 }
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -12,7 +12,7 @@ import { GenerateBugReportCommand } from './commands/generateBugReport';
 import { ModuleCallsDataProvider } from './providers/moduleCalls';
 import { ModuleProvidersDataProvider } from './providers/moduleProviders';
 import { ServerPath } from './utils/serverPath';
-import { config, handleLanguageClientStart as handleLanguageClientStartError } from './utils/vscode';
+import { config, handleLanguageClientStartError } from './utils/vscode';
 import { TelemetryFeature } from './features/telemetry';
 import { ShowReferencesFeature } from './features/showReferences';
 import { CustomSemanticTokens } from './features/semanticTokens';

--- a/src/handlers/errorHandler.ts
+++ b/src/handlers/errorHandler.ts
@@ -12,7 +12,6 @@ export class ExtensionErrorHandler implements ErrorHandler {
     return ErrorAction.Continue;
   }
   closed() {
-    this.reporter.sendTelemetryException(new Error('Failure to start terraform-ls'));
     this.outputChannel.appendLine(
       `Failure to start terraform-ls. Please check your configuration settings and reload this window`,
     );

--- a/src/utils/vscode.ts
+++ b/src/utils/vscode.ts
@@ -163,7 +163,7 @@ export function isTerraformFile(document?: vscode.TextDocument): boolean {
   return false;
 }
 
-export async function handleLanguageClientStart(
+export async function handleLanguageClientStartError(
   error: unknown,
   ctx: vscode.ExtensionContext,
   reporter: TelemetryReporter,


### PR DESCRIPTION
This removes the duplicate exception telemetry from ExtensionErrorHandler as the LanguageClient start exception handler already sends a exception telemetry event.