### PR TITLE
Use `npm ci` for installing dependencies inside CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - name: npm install
-        run: npm install
+        run: npm ci
       - name: lint
         run: npm run lint
       - name: format


### PR DESCRIPTION
To make sure we're doing a clean install of the dependencies and pick any inconsistencies between the `package.json` and lockfile.