### PR TITLE
Update `set-output` in CI workflow

### DIFF
--- a/.github/workflows/preview.yml
+++ b/.github/workflows/preview.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
     inputs:
       langserver:
-        description: 'The terraform-ls version to use. If not specified will use version in package.json'
+        description: "The terraform-ls version to use. If not specified will use version in package.json"
         required: false
         type: string
 
@@ -54,12 +54,8 @@ jobs:
           ./build/preview
         env:
           LANGUAGE_SERVER_VERSION: ${{ github.event.inputs.langserver }}
-      - name: Read extension version
-        id: ext-version
-        run: |
-          content=`cat ./package.json | jq -r .version`
-          echo "::set-output name=content::$content"
-      - uses: actions/setup-node@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
         with:
           node-version-file: ".nvmrc"
       - name: Install dependencies

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,7 +6,7 @@ permissions:
 on:
   push:
     tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+*'
+      - "v[0-9]+.[0-9]+.[0-9]+*"
 
 jobs:
   build:
@@ -47,19 +47,18 @@ jobs:
         uses: actions/checkout@v3
       - name: Read extension version
         id: ext-version
-        run: |
-          content=`cat ./package.json | jq -r .version`
-          echo "::set-output name=content::$content"
+        run: echo "VERSION=$(cat ./package.json | jq -r .version)" >> $GITHUB_OUTPUT
       - name: Ensure version matches with tag
-        if: ${{ github.ref != format('refs/tags/v{0}', steps.ext-version.outputs.content) }}
+        if: ${{ github.ref != format('refs/tags/v{0}', steps.ext-version.outputs.VERSION) }}
         run: |
           echo "Version mismatch!"
           echo "Received ref: ${{ github.ref }}"
-          echo "Expected ref: refs/tags/v${{ steps.ext-version.outputs.content }}"
+          echo "Expected ref: refs/tags/v${{ steps.ext-version.outputs.VERSION }}"
           exit 1
-      - uses: actions/setup-node@v3
+      - name: Setup Node
+        uses: actions/setup-node@v3
         with:
-          node-version-file: '.nvmrc'
+          node-version-file: ".nvmrc"
       - name: Install dependencies
         run: npm ci
         env:


### PR DESCRIPTION
This PR updates the publishing workflows and replaces the deprecated `set-output` command:

> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/Show less

In the preview workflow the extension version wasn't used, so I've removed the read.