### PR TITLE
ci: Bump `windows-2019` to `windows-latest`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -38,7 +38,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - windows-2019 # temporary pin to avoid timeouts on windows-2022
+          - windows-latest
           - macos-latest
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
@@ -65,7 +65,7 @@ jobs:
           - 'insiders'
           - 'stable'
         os:
-          - windows-2019 # temporary pin to avoid timeouts on windows-2022
+          - windows-latest
           - macos-latest
           - macos-11.0
           - ubuntu-latest


### PR DESCRIPTION
[The issue](https://github.com/hashicorp/vscode-terraform/pull/968), why we pinned the windows version to 2019 should be resolve by now. Let's bump this to latest.