### PR TITLE
deps: bump syntax to 0.4.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "version": "0.30.1"
   },
   "syntax": {
-    "version": "0.4.0"
+    "version": "0.4.1"
   },
   "qna": "https://discuss.hashicorp.com/c/terraform-core/terraform-editor-integrations/46",
   "bugs": {


### PR DESCRIPTION
This is to bring in https://github.com/hashicorp/syntax/pull/49