### PR TITLE
ci: fix typo in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Package VSIX
         run: npm run package -- --target=${{ matrix.vsce_target }}
       - name: Upload vsix as artifact
-        uses: actions/upload-artifact@@83fd05a356d7e2593de66fc9913b3002723633cb # https://github.com/actions/upload-artifact/releases/tag/v3.1.1
+        uses: actions/upload-artifact@83fd05a356d7e2593de66fc9913b3002723633cb # https://github.com/actions/upload-artifact/releases/tag/v3.1.1
         with:
           name: ${{ matrix.vsce_target }}
           path: "*.vsix"


### PR DESCRIPTION
Unsure why this wasn't caught within the PR - I guess GitHub doesn't validate the workflow files automatically until they're in `main` 🤷🏻 (except of course for the ones which run as part of the PR submission)

https://github.com/hashicorp/vscode-terraform/actions/runs/3713995911