### PR TITLE
github: Adjust settings of the stale workflow

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -14,16 +14,30 @@ jobs:
     steps:
     - uses: actions/stale@6f05e4244c9a0b2ed3401882b05d701dd0a7289b # https://github.com/actions/stale/releases/tag/v7.0.0
       with:
-        days-before-stale: '-1'
-        days-before-close: '90'
         only-labels: 'waiting-response'
+
+        days-before-stale: 30
         stale-issue-label: 'stale'
         stale-issue-message: |
-          Marking this issue as stale due to inactivity. This helps our maintainers find and focus on the active issues. If this issue receives no comments in the next 90 days it will automatically be closed. Maintainers can also remove the stale label.
+          Marking this issue as stale due to inactivity over the last 30 days. This helps our maintainers find and focus on the active issues. If this issue receives no comments in the next **30 days** it will automatically be closed. Maintainers can also remove the stale label.
 
-          If this issue was automatically closed and you feel this issue should be reopened, we encourage creating a new issue linking back to this one for added context. Thank you!
+          Thank you for understanding.
         stale-pr-label: 'stale'
         stale-pr-message: |
-          Marking this pull request as stale due to inactivity. This helps our maintainers find and focus on the active pull requests. If this pull request receives no comments in the next 90 days it will automatically be closed. Maintainers can also remove the stale label.
+          Marking this pull request as stale due to inactivity over the last 30 days. This helps our maintainers find and focus on the active pull requests. If this pull request receives no comments in the next **30 days** it will automatically be closed. Maintainers can also remove the stale label.
 
-          If this pull request was automatically closed and you feel this pull request should be reopened, we encourage creating a new pull request linking back to this one for added context. Thank you!
+          Thank you for understanding.
+
+        days-before-close: 30
+        close-issue-message: |
+          Closing this issue due to its staleness.
+
+          If the issue was automatically closed and you feel it should be reopened, we encourage creating a new one linking back to this one for added context.
+
+          Thank you!
+        close-pr-message: |
+          Closing this pull request due to its staleness.
+
+          If the pull request was automatically closed and you feel it should be reopened, we encourage creating a new one linking back to this one for added context.
+
+          Thank you!


### PR DESCRIPTION
This PR proposes a few changes to the `stale` GHA workflow, which was effectively unused due to one of the settings set more conservatively.

Specifically, we set `days-before-stale: '-1'` which means that the bot would never attempt to mark issues as stale by itself. That first step was left to us, but I think nobody even realised this is the case and so nobody ever assigned `stale` label to an issue/PR.

With some older issues being accumulated in the repo, I wanted to update the settings, such that we can more proactively tackle the backlog and communicate expectations to the contributors/reporters.

 - all automation remains scoped to just issues labelled `waiting-response`
 - bot will automatically label an issue/PR as `stale` after 30 days of no response and comment with an updated message, which also states the inactivity period
 - bot will automatically close an issue/PR if it was `stale` for over 30 days and received no response, and comments with a message explaining why

If there's an agreement on this approach, we can roll this out also in https://github.com/hashicorp/terraform-ls and possibly other repositories we maintain.