### PR TITLE
Terraform Version LanguageStatusItem

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -22,6 +22,7 @@ import { getInitializationOptions, migrateLegacySettings, previewExtensionPresen
 import { TerraformLSCommands } from './commands/terraformls';
 import { TerraformCommands } from './commands/terraform';
 import { ExtensionErrorHandler } from './handlers/errorHandler';
+import { TerraformVersionFeature } from './features/terraformVersion';
 
 const id = 'terraform';
 const brand = `HashiCorp Terraform`;
@@ -94,6 +95,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
     new ModuleCallsFeature(client, new ModuleCallsDataProvider(context, client, reporter)),
     new TelemetryFeature(client, reporter),
     new ShowReferencesFeature(client),
+    new TerraformVersionFeature(client, reporter, outputChannel),
   ]);
 
   // these need the LS to function, so are only registered if enabled

--- a/src/features/terraformVersion.ts
+++ b/src/features/terraformVersion.ts
@@ -1,0 +1,82 @@
+import * as vscode from 'vscode';
+import * as terraform from '../terraform';
+import { ClientCapabilities, ServerCapabilities, StaticFeature } from 'vscode-languageclient';
+import { getActiveTextEditor } from '../utils/vscode';
+import { ExperimentalClientCapabilities } from './types';
+import { Utils } from 'vscode-uri';
+import TelemetryReporter from '@vscode/extension-telemetry';
+import { LanguageClient } from 'vscode-languageclient/node';
+
+export class TerraformVersionFeature implements StaticFeature {
+  private disposables: vscode.Disposable[] = [];
+
+  private clientTerraformVersionCommandId = 'client.refreshTerraformVersion';
+
+  private terraformStatus = vscode.languages.createLanguageStatusItem('terraform.status', [
+    { language: 'terraform' },
+    { language: 'terraform-vars' },
+  ]);
+
+  constructor(
+    private client: LanguageClient,
+    private reporter: TelemetryReporter,
+    private outputChannel: vscode.OutputChannel,
+  ) {
+    this.terraformStatus.name = 'Terraform';
+    this.terraformStatus.detail = 'Terraform Version';
+    this.disposables.push(this.terraformStatus);
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities & ExperimentalClientCapabilities): void {
+    capabilities.experimental = capabilities.experimental || {};
+    capabilities.experimental.refreshTerraformVersionCommandId = this.clientTerraformVersionCommandId;
+  }
+
+  public async initialize(capabilities: ServerCapabilities): Promise<void> {
+    if (!capabilities.experimental?.refreshTerraformVersion) {
+      this.outputChannel.appendLine("Server doesn't support client.refreshTerraformVersion");
+      return;
+    }
+
+    await this.client.onReady();
+
+    const handler = this.client.onRequest(this.clientTerraformVersionCommandId, async () => {
+      const editor = getActiveTextEditor();
+      if (editor === undefined) {
+        return;
+      }
+
+      const moduleDir = Utils.dirname(editor.document.uri);
+
+      try {
+        const response = await terraform.terraformVersion(moduleDir.toString(), this.client, this.reporter);
+        this.terraformStatus.text = response.discovered_version;
+      } catch (error) {
+        let message = 'Unknown Error';
+        if (error instanceof Error) {
+          message = error.message;
+        } else if (typeof error === 'string') {
+          message = error;
+        }
+
+        /*
+         We do not want to pop an error window because the user cannot do anything
+         at this point. An error here likely means we cannot communicate with the LS,
+         which means it's already shut down.
+         Instead we log to the outputchannel so when the user copies the log we can
+         see this errored here.
+        */
+        this.outputChannel.appendLine(message);
+      }
+    });
+
+    this.disposables.push(handler);
+  }
+
+  public dispose(): void {
+    this.disposables.forEach((d: vscode.Disposable, index, things) => {
+      d.dispose();
+      things.splice(index, 1);
+    });
+  }
+}

--- a/src/features/terraformVersion.ts
+++ b/src/features/terraformVersion.ts
@@ -50,7 +50,7 @@ export class TerraformVersionFeature implements StaticFeature {
 
       try {
         const response = await terraform.terraformVersion(moduleDir.toString(), this.client, this.reporter);
-        this.terraformStatus.text = response.discovered_version;
+        this.terraformStatus.text = response.discovered_version || 'N/A';
       } catch (error) {
         let message = 'Unknown Error';
         if (error instanceof Error) {

--- a/src/features/terraformVersion.ts
+++ b/src/features/terraformVersion.ts
@@ -12,7 +12,11 @@ export class TerraformVersionFeature implements StaticFeature {
 
   private clientTerraformVersionCommandId = 'client.refreshTerraformVersion';
 
-  private terraformStatus = vscode.languages.createLanguageStatusItem('terraform.status', [
+  private installedVersion = vscode.languages.createLanguageStatusItem('terraform.installedVersion', [
+    { language: 'terraform' },
+    { language: 'terraform-vars' },
+  ]);
+  private requiredVersion = vscode.languages.createLanguageStatusItem('terraform.requiredVersion', [
     { language: 'terraform' },
     { language: 'terraform-vars' },
   ]);
@@ -22,9 +26,14 @@ export class TerraformVersionFeature implements StaticFeature {
     private reporter: TelemetryReporter,
     private outputChannel: vscode.OutputChannel,
   ) {
-    this.terraformStatus.name = 'Terraform';
-    this.terraformStatus.detail = 'Terraform Version';
-    this.disposables.push(this.terraformStatus);
+    this.installedVersion.name = 'TerraformInstalledVersion';
+    this.installedVersion.detail = 'Installed Version';
+
+    this.requiredVersion.name = 'TerraformRequiredVersion';
+    this.requiredVersion.detail = 'Required Version';
+
+    this.disposables.push(this.installedVersion);
+    this.disposables.push(this.requiredVersion);
   }
 
   public fillClientCapabilities(capabilities: ClientCapabilities & ExperimentalClientCapabilities): void {
@@ -50,7 +59,8 @@ export class TerraformVersionFeature implements StaticFeature {
 
       try {
         const response = await terraform.terraformVersion(moduleDir.toString(), this.client, this.reporter);
-        this.terraformStatus.text = response.discovered_version || 'N/A';
+        this.installedVersion.text = response.discovered_version || 'N/A';
+        this.requiredVersion.text = response.required_version || 'N/A';
       } catch (error) {
         let message = 'Unknown Error';
         if (error instanceof Error) {

--- a/src/features/terraformVersion.ts
+++ b/src/features/terraformVersion.ts
@@ -59,8 +59,8 @@ export class TerraformVersionFeature implements StaticFeature {
 
       try {
         const response = await terraform.terraformVersion(moduleDir.toString(), this.client, this.reporter);
-        this.installedVersion.text = response.discovered_version || 'N/A';
-        this.requiredVersion.text = response.required_version || 'N/A';
+        this.installedVersion.text = response.discovered_version || 'unknown';
+        this.requiredVersion.text = response.required_version || 'any';
       } catch (error) {
         let message = 'Unknown Error';
         if (error instanceof Error) {

--- a/src/features/types.ts
+++ b/src/features/types.ts
@@ -7,5 +7,6 @@ export interface ExperimentalClientCapabilities {
     showReferencesCommandId?: string;
     refreshModuleProvidersCommandId?: string;
     refreshModuleCallsCommandId?: string;
+    refreshTerraformVersionCommandId?: string;
   };
 }

--- a/src/terraform.ts
+++ b/src/terraform.ts
@@ -42,7 +42,25 @@ interface ModuleProvidersResponse {
     [provider: string]: string;
   };
 }
+
+export interface TerraformInfoResponse {
+  v: number;
+  required_version: string;
+  discovered_version: string;
+}
 /* eslint-enable @typescript-eslint/naming-convention */
+
+export async function terraformVersion(
+  moduleUri: string,
+  client: LanguageClient,
+  reporter: TelemetryReporter,
+): Promise<TerraformInfoResponse> {
+  const command = 'terraform-ls.module.terraform';
+
+  const response = await execWorkspaceLSCommand<TerraformInfoResponse>(command, moduleUri, client, reporter);
+
+  return response;
+}
 
 export async function moduleCallers(
   moduleUri: string,

--- a/src/terraform.ts
+++ b/src/terraform.ts
@@ -45,8 +45,8 @@ interface ModuleProvidersResponse {
 
 export interface TerraformInfoResponse {
   v: number;
-  required_version: string;
-  discovered_version: string;
+  required_version?: string;
+  discovered_version?: string;
 }
 /* eslint-enable @typescript-eslint/naming-convention */
 


### PR DESCRIPTION
This uses a StaticFeature to provide a LanguageStatusItem that displays the version of terraform that terraform-ls knows about.


![tf_version_statusitem](https://user-images.githubusercontent.com/272569/213249562-a10ac609-173f-4be1-bfc8-5c611e16014e.gif)
