### PR TITLE
deps: Bump @vscode/vsce to 2.18.x

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -28,7 +28,7 @@
         "@typescript-eslint/parser": "^5.9.0",
         "@vscode/test-electron": "^2.0.1",
         "@vscode/test-web": "^0.0.29",
-        "@vscode/vsce": "^2.16.0",
+        "@vscode/vsce": "^2.18.0",
         "assert": "^2.0.0",
         "chai": "^4.3.4",
         "eslint": "^8.6.0",

--- a/package.json
+++ b/package.json
@@ -692,7 +692,7 @@
     "@typescript-eslint/parser": "^5.9.0",
     "@vscode/test-electron": "^2.0.1",
     "@vscode/test-web": "^0.0.29",
-    "@vscode/vsce": "^2.16.0",
+    "@vscode/vsce": "^2.18.0",
     "assert": "^2.0.0",
     "chai": "^4.3.4",
     "eslint": "^8.6.0",


### PR DESCRIPTION
Currently pending https://github.com/microsoft/vscode-vsce/pull/858 and release.

--- 

This is to address https://github.com/advisories/GHSA-776f-qx25-q3cc

AFAICT we should not need to mention this as "vulnerability" from end-user perspective in the Changelog, since the package is only used at release time and the content (XML) is already treated as trusted (vsix).

Sadly Microsoft stopped publishing changelogs since `2.15.0`.

https://github.com/microsoft/vscode-vsce/compare/v2.16.0...v2.18.1