### PR TITLE
Bump VS Code from `1.67.2` to `1.75.1`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -72,7 +72,7 @@ jobs:
       fail-fast: false
       matrix:
         vscode:
-          - '1.67.2'
+          - '1.75.1'
           - 'insiders'
           - 'stable'
         os:

--- a/README.md
+++ b/README.md
@@ -121,10 +121,10 @@ The extension provides access to several Terraform commands through the Command 
 
 The Terraform VS Code extension bundles the [Terraform Language Server](https://github.com/hashicorp/terraform-ls) and is a self-contained install.
 
-The extension recommends the following to be installed before use
+The extension does require the following to be installed before use:
 
-- VS Code v1.75 or higher
-- Terraform v0.12 or higher
+- VS Code v1.75 or greater
+- Terraform v0.12 or greater
 
 ## Platform Support
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,7 @@ The Terraform VS Code extension bundles the [Terraform Language Server](https://
 
 The extension does require the following to be installed before use:
 
-- VS Code v1.65 or greater
-- Terraform v0.12 or greater
+- VS Code v1.75 or greater
 
 ## Platform Support
 

--- a/README.md
+++ b/README.md
@@ -121,9 +121,10 @@ The extension provides access to several Terraform commands through the Command 
 
 The Terraform VS Code extension bundles the [Terraform Language Server](https://github.com/hashicorp/terraform-ls) and is a self-contained install.
 
-The extension does require the following to be installed before use:
+The extension recommends the following to be installed before use
 
-- VS Code v1.75 or greater
+- VS Code v1.75 or higher
+- Terraform v0.12 or higher
 
 ## Platform Support
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "@types/jest": "^27.0.3",
         "@types/mocha": "^9.1.1",
         "@types/node": "^16.11.7",
-        "@types/vscode": "^1.67.2",
+        "@types/vscode": "1.75.1",
         "@types/webpack-env": "^1.18.0",
         "@types/which": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^5.9.0",
@@ -50,7 +50,7 @@
       "engines": {
         "node": "~16.X",
         "npm": "~8.X",
-        "vscode": "^1.67.2"
+        "vscode": "^1.75.1"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1454,9 +1454,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
-      "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
+      "version": "1.75.1",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.1.tgz",
+      "integrity": "sha512-emg7wdsTFzdi+elvoyoA+Q8keEautdQHyY5LNmHVM4PTpY8JgOTVADrGVyXGepJ6dVW2OS5/xnLUWh+nZxvdiA==",
       "dev": true
     },
     "node_modules/@types/webpack-env": {
@@ -11081,9 +11081,9 @@
       "dev": true
     },
     "@types/vscode": {
-      "version": "1.74.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.74.0.tgz",
-      "integrity": "sha512-LyeCIU3jb9d38w0MXFwta9r0Jx23ugujkAxdwLTNCyspdZTKUc43t7ppPbCiPoQ/Ivd/pnDFZrb4hWd45wrsgA==",
+      "version": "1.75.1",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.1.tgz",
+      "integrity": "sha512-emg7wdsTFzdi+elvoyoA+Q8keEautdQHyY5LNmHVM4PTpY8JgOTVADrGVyXGepJ6dVW2OS5/xnLUWh+nZxvdiA==",
       "dev": true
     },
     "@types/webpack-env": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "engines": {
     "npm": "~8.X",
     "node": "~16.X",
-    "vscode": "^1.67.2"
+    "vscode": "^1.75.1"
   },
   "langServer": {
     "version": "0.31.1"
@@ -685,7 +685,7 @@
     "@types/jest": "^27.0.3",
     "@types/mocha": "^9.1.1",
     "@types/node": "^16.11.7",
-    "@types/vscode": "^1.67.2",
+    "@types/vscode": "1.75.1",
     "@types/webpack-env": "^1.18.0",
     "@types/which": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^5.9.0",


### PR DESCRIPTION
This raises the minimum required VS Code version from `1.67.2` to `1.75.1`.

About 90% our users are using `>= 1.75`