### PR TITLE
Implement Terraform Cloud Authentication Provider

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.4.9",
+        "axios": "^1.4.0",
         "vscode-languageclient": "8.1.0",
         "vscode-uri": "^3.0.2",
         "which": "^2.0.2"
@@ -21,7 +22,7 @@
         "@types/jest": "^27.0.3",
         "@types/mocha": "^9.1.1",
         "@types/node": "^16.11.7",
-        "@types/vscode": "1.75.1",
+        "@types/vscode": "^1.75.1",
         "@types/webpack-env": "^1.18.0",
         "@types/which": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^5.9.0",
@@ -730,6 +731,15 @@
         "yauzl": "^2.10.0"
       }
     },
+    "node_modules/@hashicorp/js-releases/node_modules/axios": {
+      "version": "0.25.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+      "dev": true,
+      "dependencies": {
+        "follow-redirects": "^1.14.7"
+      }
+    },
     "node_modules/@humanwhocodes/config-array": {
       "version": "0.11.8",
       "resolved": "https://registry.npmjs.org/@humanwhocodes/config-array/-/config-array-0.11.8.tgz",
@@ -1427,9 +1437,9 @@
       "dev": true
     },
     "node_modules/@types/node": {
-      "version": "16.11.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.31.tgz",
-      "integrity": "sha512-wh/d0pcu/Ie2mqTIqh4tjd0mLAB4JWxOjHQtLN20HS7sjMHiV4Afr+90hITTyZcxowwha5wjv32jGEn1zkEFMg==",
+      "version": "16.18.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
+      "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==",
       "dev": true
     },
     "node_modules/@types/prettier": {
@@ -2320,8 +2330,7 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "node_modules/available-typed-arrays": {
       "version": "1.0.5",
@@ -2336,12 +2345,26 @@
       }
     },
     "node_modules/axios": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
-      "dev": true,
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "dependencies": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/azure-devops-node-api": {
@@ -3048,7 +3071,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -3555,7 +3577,6 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -4535,10 +4556,9 @@
       "dev": true
     },
     "node_modules/follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
-      "dev": true,
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
       "funding": [
         {
           "type": "individual",
@@ -6890,7 +6910,6 @@
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
       "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-      "dev": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -6899,7 +6918,6 @@
       "version": "2.1.34",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
       "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-      "dev": true,
       "dependencies": {
         "mime-db": "1.51.0"
       },
@@ -7885,6 +7903,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/psl": {
       "version": "1.8.0",
@@ -10460,6 +10483,17 @@
         "openpgp": "5.1.0",
         "semver": "^7.3.5",
         "yauzl": "^2.10.0"
+      },
+      "dependencies": {
+        "axios": {
+          "version": "0.25.0",
+          "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
+          "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
+          "dev": true,
+          "requires": {
+            "follow-redirects": "^1.14.7"
+          }
+        }
       }
     },
     "@humanwhocodes/config-array": {
@@ -11054,9 +11088,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "16.11.31",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.11.31.tgz",
-      "integrity": "sha512-wh/d0pcu/Ie2mqTIqh4tjd0mLAB4JWxOjHQtLN20HS7sjMHiV4Afr+90hITTyZcxowwha5wjv32jGEn1zkEFMg==",
+      "version": "16.18.25",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-16.18.25.tgz",
+      "integrity": "sha512-rUDO6s9Q/El1R1I21HG4qw/LstTHCPO/oQNAwI/4b2f9EWvMnqt4d3HJwPMawfZ3UvodB8516Yg+VAq54YM+eA==",
       "dev": true
     },
     "@types/prettier": {
@@ -11745,8 +11779,7 @@
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-      "dev": true
+      "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
     "available-typed-arrays": {
       "version": "1.0.5",
@@ -11755,12 +11788,25 @@
       "dev": true
     },
     "axios": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.25.0.tgz",
-      "integrity": "sha512-cD8FOb0tRH3uuEe6+evtAbgJtfxr7ly3fQjYcMcuPlgkwVS9xboaVIpcDV+cYQe+yGykgwZCs1pzjntcGa6l5g==",
-      "dev": true,
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.4.0.tgz",
+      "integrity": "sha512-S4XCWMEmzvo64T9GfvQDOXgYRDJ/wsSZc7Jvdgx5u1sd0JwsuPLqb3SYmusag+edF6ziyMensPVqLTSc1PiSEA==",
       "requires": {
-        "follow-redirects": "^1.14.7"
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
       }
     },
     "azure-devops-node-api": {
@@ -12311,7 +12357,6 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-      "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
       }
@@ -12705,8 +12750,7 @@
     "delayed-stream": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-      "dev": true
+      "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
     },
     "delegates": {
       "version": "1.0.0",
@@ -13426,10 +13470,9 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.14.9",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.14.9.tgz",
-      "integrity": "sha512-MQDfihBQYMcyy5dhRDJUHcw7lb2Pv/TuE6xP1vyraLukNDHKbDxDNaOE3NbCAdKQApno+GPRyo1YAp89yCjK4w==",
-      "dev": true
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "for-each": {
       "version": "0.3.3",
@@ -15205,14 +15248,12 @@
     "mime-db": {
       "version": "1.51.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.51.0.tgz",
-      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g==",
-      "dev": true
+      "integrity": "sha512-5y8A56jg7XVQx2mbv1lu49NR4dokRnhZYTtL+KGfaa27uq4pSTXkwQkFJl4pkRMyNFz/EtYDSkiiEHx3F7UN6g=="
     },
     "mime-types": {
       "version": "2.1.34",
       "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.34.tgz",
       "integrity": "sha512-6cP692WwGIs9XXdOO4++N+7qjqv0rqxxVvJ3VHPh/Sc9mVZcQP+ZGhkKiTvWMQRr2tbHkJP/Yn7Y0npb3ZBs4A==",
-      "dev": true,
       "requires": {
         "mime-db": "1.51.0"
       }
@@ -15949,6 +15990,11 @@
         "kleur": "^3.0.3",
         "sisteransi": "^1.0.5"
       }
+    },
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "psl": {
       "version": "1.8.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "@types/jest": "^27.0.3",
         "@types/mocha": "^9.1.1",
         "@types/node": "^16.11.7",
-        "@types/vscode": "^1.75.1",
+        "@types/vscode": "~1.75.1",
         "@types/webpack-env": "^1.18.0",
         "@types/which": "^2.0.1",
         "@typescript-eslint/eslint-plugin": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -708,7 +708,7 @@
     "@types/jest": "^27.0.3",
     "@types/mocha": "^9.1.1",
     "@types/node": "^16.11.7",
-    "@types/vscode": "^1.75.1",
+    "@types/vscode": "~1.75.1",
     "@types/webpack-env": "^1.18.0",
     "@types/which": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^5.9.0",

--- a/package.json
+++ b/package.json
@@ -459,6 +459,18 @@
         }
       },
       {
+        "title": "Terraform Cloud",
+        "order": 3,
+        "properties": {
+          "terraform.cloud.hostname": {
+            "order": 0,
+            "type": "string",
+            "description": "Terraform Cloud instance",
+            "default": "app.terraform.io"
+          }
+        }
+      },
+      {
         "title": "Experimental Features",
         "order": 4,
         "properties": {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "url": "https://github.com/hashicorp/vscode-terraform.git"
   },
   "activationEvents": [
+    "onAuthenticationRequest:terraform",
     "onLanguage:terraform",
     "onLanguage:terraform-vars",
     "onView:terraform-modules",
@@ -58,6 +59,12 @@
   "main": "./out/extension",
   "browser": "./out/web/extension",
   "contributes": {
+    "authentication": [
+      {
+        "id": "terraformcloud",
+        "label": "HashiCorp Terraform Cloud"
+      }
+    ],
     "languages": [
       {
         "id": "terraform",
@@ -511,6 +518,10 @@
     ],
     "commands": [
       {
+        "command": "terraform.cloud.login",
+        "title": "Terraform Cloud: Login"
+      },
+      {
         "command": "terraform.generateBugReport",
         "title": "Terraform: Generate Bug Report"
       },
@@ -685,6 +696,7 @@
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.4.9",
+    "axios": "^1.4.0",
     "vscode-languageclient": "8.1.0",
     "vscode-uri": "^3.0.2",
     "which": "^2.0.2"
@@ -696,7 +708,7 @@
     "@types/jest": "^27.0.3",
     "@types/mocha": "^9.1.1",
     "@types/node": "^16.11.7",
-    "@types/vscode": "1.75.1",
+    "@types/vscode": "^1.75.1",
     "@types/webpack-env": "^1.18.0",
     "@types/which": "^2.0.1",
     "@typescript-eslint/eslint-plugin": "^5.9.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,6 +32,7 @@ import { getInitializationOptions, migrateLegacySettings } from './settings';
 import { TerraformLSCommands } from './commands/terraformls';
 import { TerraformCommands } from './commands/terraform';
 import { TerraformVersionFeature } from './features/terraformVersion';
+import { TerraformCloudAuthenticationProvider } from './providers/authenticationProvider';
 
 const id = 'terraform';
 const brand = `HashiCorp Terraform`;
@@ -55,6 +56,15 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   // always register commands needed to control terraform-ls
   context.subscriptions.push(new TerraformLSCommands());
+
+  context.subscriptions.push(
+    vscode.authentication.registerAuthenticationProvider(
+      TerraformCloudAuthenticationProvider.providerID,
+      TerraformCloudAuthenticationProvider.providerLabel,
+      new TerraformCloudAuthenticationProvider(context.secrets, context),
+      { supportsMultipleAccounts: false },
+    ),
+  );
 
   if (config('terraform').get<boolean>('languageServer.enable') === false) {
     reporter.sendTelemetryEvent('disabledTerraformLS');

--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -36,7 +36,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
 
   constructor(private readonly secretStorage: vscode.SecretStorage, private readonly ctx: vscode.ExtensionContext) {
-    this.logger = vscode.window.createOutputChannel('HashiCorp Terraform Cloud Authentication', { log: true });
+    this.logger = vscode.window.createOutputChannel('HashiCorp Authentication', { log: true });
     ctx.subscriptions.push(
       vscode.commands.registerCommand('terraform.cloud.login', async () => {
         const session = await vscode.authentication.getSession(TerraformCloudAuthenticationProvider.providerID, [], {

--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -1,0 +1,223 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import * as vscode from 'vscode';
+import { getUser } from './tfc';
+
+class TerraformCloudSession implements vscode.AuthenticationSession {
+  // This id isn't used for anything yet, so we set it to a constant
+  readonly id = TerraformCloudAuthenticationProvider.providerID;
+
+  // In the future, we may use the UAT permissions as scopes
+  // but right now have no use fior them, so we have an empty array here.
+  readonly scopes = [];
+
+  /**
+   *
+   * @param accessToken The personal access token to use for authentication
+   * @param account The user account for the specified token
+   */
+  constructor(public readonly accessToken: string, public account: vscode.AuthenticationSessionAccountInformation) {}
+}
+
+export class TerraformCloudAuthenticationProvider implements vscode.AuthenticationProvider, vscode.Disposable {
+  static providerLabel = 'HashiCorp Terraform Cloud';
+  static providerID = 'HashiCorpTerraformCloud';
+  private static secretKey = 'HashiCorpTerraformCloud';
+  private logger: vscode.LogOutputChannel;
+
+  // this property is used to determine if the token has been changed in another window of VS Code.
+  private currentToken: Promise<string | undefined> | undefined;
+  private initializedDisposable: vscode.Disposable | undefined;
+
+  private _onDidChangeSessions =
+    new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
+
+  constructor(private readonly secretStorage: vscode.SecretStorage, private readonly ctx: vscode.ExtensionContext) {
+    this.logger = vscode.window.createOutputChannel('HashiCorp Terraform Cloud Authentication', { log: true });
+    ctx.subscriptions.push(
+      vscode.commands.registerCommand('terraform.cloud.login', async () => {
+        const session = await vscode.authentication.getSession(TerraformCloudAuthenticationProvider.providerID, [], {
+          createIfNone: true,
+        });
+        vscode.window.showInformationMessage(`Hello ${session.account.label}`);
+      }),
+    );
+  }
+
+  get onDidChangeSessions(): vscode.Event<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent> {
+    return this._onDidChangeSessions.event;
+  }
+
+  // This function is called first when `vscode.authentication.getSessions` is called.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async getSessions(scopes?: string[] | undefined): Promise<readonly vscode.AuthenticationSession[]> {
+    this.ensureInitialized();
+
+    this.logger.info('Reading sessions from storage...');
+    const token = await this.cacheTokenFromStorage();
+
+    if (token === undefined) {
+      this.logger.info('No stored sessions!');
+      return [];
+    }
+
+    this.logger.info('Got stored sessions!');
+
+    try {
+      // temporary TFC access method here
+      // will be replaced by TFC REST API wrapper
+      const user = await getUser(token);
+      this.logger.info('Got user info');
+
+      return token
+        ? [
+            new TerraformCloudSession(token, {
+              label: user.data.attributes.username,
+              id: user.data.attributes.email,
+            }),
+          ]
+        : [];
+    } catch (error) {
+      if (error instanceof Error) {
+        vscode.window.showErrorMessage(error.message);
+      } else if (typeof error === 'string') {
+        vscode.window.showErrorMessage(error);
+      }
+
+      // TODO: Handle 401 auth errors here
+      return [];
+    }
+  }
+
+  // This function is called after `this.getSessions` is called and only when:
+  // - `this.getSessions` returns nothing but `createIfNone` was set to `true` in `vscode.authentication.getSessions`
+  // - `vscode.authentication.getSessions` was called with `forceNewSession: true`
+  // - The end user initiates the "silent" auth flow via the Accounts menu
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async createSession(_scopes: readonly string[]): Promise<vscode.AuthenticationSession> {
+    this.ensureInitialized();
+
+    // Prompt for the UAT.
+    const token = await vscode.window.showInputBox({
+      ignoreFocusOut: true,
+      placeHolder: 'User access token',
+      prompt: 'Enter an HashiCorp Terraform User Access Token (UAT).',
+      password: true,
+    });
+
+    // Note: this example doesn't do any validation of the token beyond making sure it's not empty.
+    if (!token) {
+      this.logger.error('User did not provide a UAT');
+      throw new Error('UAT is required');
+    }
+
+    try {
+      // temporary TFC access method here
+      // will be replaced by TFC REST API wrapper
+      const user = await getUser(token);
+
+      // Don't set `currentToken` here, since we want to fire the proper events in the `checkForUpdates` call
+      await this.secretStorage.store(TerraformCloudAuthenticationProvider.secretKey, token);
+      this.logger.info('Successfully logged in to HashiCorp Terraform');
+
+      const session = new TerraformCloudSession(token, {
+        label: user.data.attributes.username,
+        id: user.data.attributes.email,
+      });
+
+      this._onDidChangeSessions.fire({ added: [session], removed: [], changed: [] });
+      // label is what is display in the UI
+      return session;
+    } catch (error) {
+      if (error instanceof Error) {
+        vscode.window.showErrorMessage(error.message);
+        this.logger.error(error.message);
+      } else if (typeof error === 'string') {
+        vscode.window.showErrorMessage(error);
+        this.logger.error(error);
+      }
+
+      // TODO: Handle 401 auth errors here
+      throw error;
+    }
+  }
+
+  // This function is called when the end user signs out of the account.
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async removeSession(_sessionId: string): Promise<void> {
+    this.logger.info('Detecting current logged in session');
+    const session = (await this.getSessions())[0];
+
+    this.logger.info('Removing current session');
+    await this.secretStorage.delete(TerraformCloudAuthenticationProvider.secretKey);
+
+    this._onDidChangeSessions.fire({ added: [], removed: [session], changed: [] });
+  }
+
+  private ensureInitialized(): void {
+    if (this.initializedDisposable !== undefined) {
+      return;
+    }
+
+    void this.cacheTokenFromStorage();
+
+    this.initializedDisposable = vscode.Disposable.from(
+      // This onDidChange event happens when the secret storage changes in _any window_ since
+      // secrets are shared across all open windows.
+      this.secretStorage.onDidChange((e) => {
+        if (e.key === TerraformCloudAuthenticationProvider.secretKey) {
+          this.logger.info('Authentication secret storage change');
+          void this.checkForUpdates();
+        }
+      }),
+      // This fires when the user initiates a "silent" auth flow via the Accounts menu.
+      vscode.authentication.onDidChangeSessions((e) => {
+        if (e.provider.id === TerraformCloudAuthenticationProvider.providerID) {
+          this.logger.info('Authentication provider change');
+          void this.checkForUpdates();
+        }
+      }),
+    );
+  }
+
+  // This is a crucial function that handles whether or not the token has changed in
+  // a different window of VS Code and sends the necessary event if it has.
+  private async checkForUpdates(): Promise<void> {
+    const added: vscode.AuthenticationSession[] = [];
+    const removed: vscode.AuthenticationSession[] = [];
+    const changed: vscode.AuthenticationSession[] = [];
+
+    const previousToken = await this.currentToken;
+    const session = (await this.getSessions())[0];
+
+    if (session?.accessToken && !previousToken) {
+      this.logger.info('Session added');
+      added.push(session);
+    } else if (!session?.accessToken && previousToken) {
+      this.logger.info('Session removed');
+      removed.push(session);
+    } else if (session?.accessToken !== previousToken) {
+      this.logger.info('Session changed');
+      changed.push(session);
+    } else {
+      return;
+    }
+
+    void this.cacheTokenFromStorage();
+    this._onDidChangeSessions.fire({ added: added, removed: removed, changed: changed });
+  }
+
+  private cacheTokenFromStorage() {
+    this.currentToken = this.secretStorage.get(TerraformCloudAuthenticationProvider.secretKey) as Promise<
+      string | undefined
+    >;
+    return this.currentToken;
+  }
+
+  dispose() {
+    this.initializedDisposable?.dispose();
+  }
+}

--- a/src/providers/tfc.ts
+++ b/src/providers/tfc.ts
@@ -1,0 +1,83 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import axios from 'axios';
+import { config } from '../utils/vscode';
+
+export async function getUser(token: string): Promise<UserResponse> {
+  try {
+    const url = config('terraform').get<boolean>('cloud.hostname');
+    // 👇️ const data: GetUsersResponse
+    const { data, status } = await axios.get<UserResponse>(`https://${url}/api/v2/account/details`, {
+      headers: {
+        authorization: `Bearer ${token}`,
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        'Content-Type': 'application/vnd.api+json',
+      },
+    });
+
+    // console.log(JSON.stringify(data, null, 4));
+
+    // 👇️ "response status is: 200"
+    console.log('response status is: ', status);
+
+    return data;
+  } catch (error) {
+    if (axios.isAxiosError(error)) {
+      console.log('error message: ', error.message);
+      // return error.message;
+      throw error;
+    } else {
+      console.log('unexpected error: ', error);
+      throw error;
+    }
+  }
+}
+
+export interface UserResponse {
+  data: Data;
+}
+
+export interface Data {
+  id: string;
+  type: string;
+  attributes: Attributes;
+  relationships: Relationships;
+  links: Links2;
+}
+
+export interface Attributes {
+  username: string;
+  'is-service-account': boolean;
+  'avatar-url': string;
+  'v2-only': boolean;
+  'is-site-admin': boolean;
+  'is-sso-login': boolean;
+  email: string;
+  'unconfirmed-email': any;
+  permissions: Permissions;
+}
+
+export interface Permissions {
+  'can-create-organizations': boolean;
+  'can-change-email': boolean;
+  'can-change-username': boolean;
+}
+
+export interface Relationships {
+  'authentication-tokens': AuthenticationTokens;
+}
+
+export interface AuthenticationTokens {
+  links: Links;
+}
+
+export interface Links {
+  related: string;
+}
+
+export interface Links2 {
+  self: string;
+}


### PR DESCRIPTION
This implements the `vscode.AuthenticationProvider` interface and creates a TFC specific provider. This handles listing existing sessions, creating and removing sessions.

Storing sessions/tokens will be improved by https://github.com/hashicorp/vscode-terraform/issues/1397. Currently it only securely stores the token. Future improvement can be done to prevent looking up user data every time the session is reloaded.

The TFC instance to target is defaulted to `app.terraform.io` with a configuration setting to override. This was added in https://github.com/hashicorp/vscode-terraform/issues/1398. Future work should discover whether detecting the TFC instance from the configuration available in the current working space is desirable.

One of the primary ways a user will trigger authentication will be through the VS Code Command palette commands, so https://github.com/hashicorp/vscode-terraform/issues/1399 is added here to finish out the login workflow.

This currently only supports one logged in user at a time. In the future, this may be extended to support multiple user tokens.

Closes https://github.com/hashicorp/vscode-terraform/issues/1396, https://github.com/hashicorp/vscode-terraform/issues/1398