### PR TITLE
Remove default activation events

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,12 +48,9 @@
     "url": "https://github.com/hashicorp/vscode-terraform.git"
   },
   "activationEvents": [
-    "onLanguage:terraform",
-    "onLanguage:terraform-vars",
     "onView:terraform-modules",
     "workspaceContains:**/*.tf",
-    "workspaceContains:**/*.tfvars",
-    "onCommand:terraform.enableLanguageServer"
+    "workspaceContains:**/*.tfvars"
   ],
   "main": "./out/extension",
   "browser": "./out/web/extension",


### PR DESCRIPTION
Beginning with VS Code 1.74.0, languages and commands contributed by the extension do not require a corresponding onLanguage or onCommand activation event declaration for the extension to be activated.