### PR TITLE
Store all session data in `vscode.SecretStorage`

### DIFF
--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -106,7 +106,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
   }
 
   get onDidChangeSessions(): vscode.Event<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent> {
-    // TODO: What does this do?
+    // Expose our internal event emitter to the outer world
     return this._onDidChangeSessions.event;
   }
 
@@ -115,6 +115,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
   async getSessions(scopes?: string[] | undefined): Promise<readonly vscode.AuthenticationSession[]> {
     try {
       const session = await this.sessionPromise;
+      this.logger.info('Successfully fetched Terraform Cloud session.');
       return session ? [session] : [];
     } catch (error) {
       if (error instanceof Error) {
@@ -170,8 +171,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
   // This function is called when the end user signs out of the account.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async removeSession(_sessionId: string): Promise<void> {
-    // TODO: check if we need clear this.sessionPromise
-    const session = await this.sessionHandler.get();
+    const session = await this.sessionPromise;
     if (!session) {
       return;
     }

--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -23,21 +23,66 @@ class TerraformCloudSession implements vscode.AuthenticationSession {
   constructor(public readonly accessToken: string, public account: vscode.AuthenticationSessionAccountInformation) {}
 }
 
-export class TerraformCloudAuthenticationProvider implements vscode.AuthenticationProvider, vscode.Disposable {
+class InvalidToken extends Error {
+  constructor() {
+    super('Invalid token');
+  }
+}
+
+class TerraformCloudSessionHandler {
+  private sessionKey = 'HashiCorpTerraformCloudSession';
+
+  constructor(private readonly secretStorage: vscode.SecretStorage) {}
+
+  async get(): Promise<TerraformCloudSession | undefined> {
+    const rawSession = await this.secretStorage.get(this.sessionKey);
+    if (!rawSession) {
+      return undefined;
+    }
+    const session: TerraformCloudSession = JSON.parse(rawSession);
+    return session;
+  }
+
+  async store(token: string): Promise<TerraformCloudSession> {
+    try {
+      const user = await earlyApiClient.getUser({
+        headers: {
+          authorization: `Bearer ${token}`,
+        },
+      });
+
+      const session = new TerraformCloudSession(token, {
+        label: user.data.attributes.username,
+        id: user.data.id,
+      });
+
+      await this.secretStorage.store(this.sessionKey, JSON.stringify(session));
+      return session;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === 401) {
+        throw new InvalidToken();
+      }
+      throw error;
+    }
+  }
+
+  async delete(): Promise<void> {
+    return this.secretStorage.delete(this.sessionKey);
+  }
+}
+
+export class TerraformCloudAuthenticationProvider implements vscode.AuthenticationProvider {
   static providerLabel = 'HashiCorp Terraform Cloud';
   static providerID = 'HashiCorpTerraformCloud';
-  private static secretKey = 'HashiCorpTerraformCloud';
   private logger: vscode.LogOutputChannel;
-
-  // this property is used to determine if the token has been changed in another window of VS Code.
-  private currentToken: string | undefined;
-  private initializedDisposable: vscode.Disposable | undefined;
+  private sessionHandler: TerraformCloudSessionHandler;
 
   private _onDidChangeSessions =
     new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
 
   constructor(private readonly secretStorage: vscode.SecretStorage, private readonly ctx: vscode.ExtensionContext) {
     this.logger = vscode.window.createOutputChannel('HashiCorp Authentication', { log: true });
+    this.sessionHandler = new TerraformCloudSessionHandler(this.secretStorage);
     ctx.subscriptions.push(
       vscode.commands.registerCommand('terraform.cloud.login', async () => {
         const session = await vscode.authentication.getSession(TerraformCloudAuthenticationProvider.providerID, [], {
@@ -49,61 +94,27 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
   }
 
   get onDidChangeSessions(): vscode.Event<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent> {
+    // TODO: What does this do?
     return this._onDidChangeSessions.event;
   }
 
   // This function is called first when `vscode.authentication.getSessions` is called.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async getSessions(scopes?: string[] | undefined): Promise<readonly vscode.AuthenticationSession[]> {
-    this.ensureInitialized();
-
-    this.logger.info('Reading sessions from storage...');
-    const token = await this.cacheTokenFromStorage();
-
-    if (token === undefined) {
-      this.logger.info('No stored sessions!');
-      return [];
-    }
-
-    this.logger.info('Got stored sessions!');
-
     try {
-      // TODO: replace with secretStorage.get when all session data is in secretStorage
-      const user = await earlyApiClient.getUser({
-        headers: {
-          authorization: `Bearer ${token}`,
-        },
-      });
-      this.logger.info('Got user info');
-
-      return token
-        ? [
-            new TerraformCloudSession(token, {
-              label: user.data.attributes.username,
-              id: user.data.attributes.email,
-            }),
-          ]
-        : [];
+      const session = await this.sessionHandler.get();
+      return session ? [session] : [];
     } catch (error) {
       if (error instanceof Error) {
         vscode.window.showErrorMessage(error.message);
       } else if (typeof error === 'string') {
         vscode.window.showErrorMessage(error);
       }
-
-      // TODO: Handle 401 auth errors here
       return [];
     }
   }
 
-  // This function is called after `this.getSessions` is called and only when:
-  // - `this.getSessions` returns nothing but `createIfNone` was set to `true` in `vscode.authentication.getSessions`
-  // - `vscode.authentication.getSessions` was called with `forceNewSession: true`
-  // - The end user initiates the "silent" auth flow via the Accounts menu
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async createSession(_scopes: readonly string[]): Promise<vscode.AuthenticationSession> {
-    this.ensureInitialized();
-
     // Prompt for the UAT.
     const token = await vscode.window.showInputBox({
       ignoreFocusOut: true,
@@ -111,35 +122,22 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
       prompt: 'Enter an HashiCorp Terraform User Access Token (UAT).',
       password: true,
     });
-
-    // Note: this example doesn't do any validation of the token beyond making sure it's not empty.
     if (!token) {
       this.logger.error('User did not provide a UAT');
       throw new Error('UAT is required');
     }
 
     try {
-      const user = await earlyApiClient.getUser({
-        headers: {
-          authorization: `Bearer ${token}`,
-        },
-      });
+      const session = await this.sessionHandler.store(token);
+      this.logger.info('Successfully logged in to Terraform Cloud');
 
-      // Don't set `currentToken` here, since we want to fire the proper events in the `checkForUpdates` call
-      await this.secretStorage.store(TerraformCloudAuthenticationProvider.secretKey, token);
-      this.logger.info('Successfully logged in to HashiCorp Terraform');
-
-      const session = new TerraformCloudSession(token, {
-        label: user.data.attributes.username,
-        id: user.data.attributes.email,
-      });
-
+      // Notify VSCode's UI
       this._onDidChangeSessions.fire({ added: [session], removed: [], changed: [] });
-      // label is what is display in the UI
+
       return session;
     } catch (error) {
-      if (axios.isAxiosError(error) && error.response?.status === 401) {
-        vscode.window.showErrorMessage('Invalid token supplied, please try again');
+      if (error instanceof InvalidToken) {
+        vscode.window.showErrorMessage(`${error.message}. Please try again`);
         return this.createSession(_scopes);
       } else if (error instanceof Error) {
         vscode.window.showErrorMessage(error.message);
@@ -156,74 +154,15 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
   // This function is called when the end user signs out of the account.
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   async removeSession(_sessionId: string): Promise<void> {
-    this.logger.info('Detecting current logged in session');
-    const session = (await this.getSessions())[0];
+    const session = await this.sessionHandler.get();
+    if (!session) {
+      return;
+    }
 
     this.logger.info('Removing current session');
-    await this.secretStorage.delete(TerraformCloudAuthenticationProvider.secretKey);
+    await this.sessionHandler.delete();
 
+    // Notify VSCode's UI
     this._onDidChangeSessions.fire({ added: [], removed: [session], changed: [] });
-  }
-
-  private async ensureInitialized(): Promise<void> {
-    if (this.initializedDisposable !== undefined) {
-      return;
-    }
-
-    await this.cacheTokenFromStorage();
-
-    this.initializedDisposable = vscode.Disposable.from(
-      // This onDidChange event happens when the secret storage changes in _any window_ since
-      // secrets are shared across all open windows.
-      this.secretStorage.onDidChange((e) => {
-        if (e.key === TerraformCloudAuthenticationProvider.secretKey) {
-          this.logger.info('Authentication secret storage change');
-          void this.checkForUpdates();
-        }
-      }),
-      // This fires when the user initiates a "silent" auth flow via the Accounts menu.
-      vscode.authentication.onDidChangeSessions((e) => {
-        if (e.provider.id === TerraformCloudAuthenticationProvider.providerID) {
-          this.logger.info('Authentication provider change');
-          void this.checkForUpdates();
-        }
-      }),
-    );
-  }
-
-  // This is a crucial function that handles whether or not the token has changed in
-  // a different window of VS Code and sends the necessary event if it has.
-  private async checkForUpdates(): Promise<void> {
-    const added: vscode.AuthenticationSession[] = [];
-    const removed: vscode.AuthenticationSession[] = [];
-    const changed: vscode.AuthenticationSession[] = [];
-
-    const previousToken = this.currentToken;
-    const session = (await this.getSessions())[0];
-
-    if (session?.accessToken && !previousToken) {
-      this.logger.info('Session added');
-      added.push(session);
-    } else if (!session?.accessToken && previousToken) {
-      this.logger.info('Session removed');
-      removed.push(session);
-    } else if (session?.accessToken !== previousToken) {
-      this.logger.info('Session changed');
-      changed.push(session);
-    } else {
-      return;
-    }
-
-    await this.cacheTokenFromStorage();
-    this._onDidChangeSessions.fire({ added: added, removed: removed, changed: changed });
-  }
-
-  private async cacheTokenFromStorage() {
-    this.currentToken = await this.secretStorage.get(TerraformCloudAuthenticationProvider.secretKey);
-    return this.currentToken;
-  }
-
-  dispose() {
-    this.initializedDisposable?.dispose();
   }
 }


### PR DESCRIPTION
Depends on https://github.com/hashicorp/vscode-terraform/issues/1397

(can be repointed to `f-tfc` once that PR is merged)

--- 

## Implementation Notes

I know most of the existing logic was copied from https://github.com/microsoft/vscode-extension-samples/blob/main/authenticationprovider-sample/src/authProvider.ts and so these notes/questions apply to that implementation too.

I may be wrong but according to my understanding we should not need all that event listening logic.

I don't know where exactly the data in `SecretStorage` is actually stored (disk, OS keychain, ...?) but I could imagine that the data there may somehow get removed without the sessions getting removed, which would then leave us in inconsistent state? Aside from such seemingly rare scenario I do not see the use case for `SecretStorage.onDidChange`.

Similarly I don't see how the authentication sessions could ever change without our `createSession()` or `removeSession()` being called, regardless of which window do the events come from. Yes, multiple windows will maintain multiple instances of our extension, but if all the state is maintained in `SecretStorage`, which itself is shared between the windows, and firing `vscode.AuthenticationProviderAuthenticationSessionsChangeEvent` impacts all windows too, then we should be safe, right?