### PR TITLE
TFC Login command

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -66,6 +66,11 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   );
 
   context.subscriptions.push(new TerraformCloudFeature(context));
+  // This triggers a badge to appear in the User Account icon.
+  // TODO: remove this when workspace views land
+  await vscode.authentication.getSession(TerraformCloudAuthenticationProvider.providerID, [], {
+    createIfNone: false,
+  });
 
   if (config('terraform').get<boolean>('languageServer.enable') === false) {
     reporter.sendTelemetryEvent('disabledTerraformLS');

--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -242,7 +242,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     }
 
     // TODO: Change to production URL
-    const terraformCloudURL = `https://${TerraformCloudHost}/app/settings/tokens?source=terraform-login`;
+    const terraformCloudURL = `https://${TerraformCloudHost}/app/settings/tokens?source=vscode-terraform`;
     let token: string | undefined;
     switch (choice.label) {
       case 'Open to generate a User token':

--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -242,7 +242,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     }
 
     // TODO: Change to production URL
-    const terraformCloudURL = 'https://app.staging.terraform.io/app/settings/tokens?source=terraform-login';
+    const terraformCloudURL = `https://${TerraformCloudHost}/app/settings/tokens?source=terraform-login`;
     let token: string | undefined;
     switch (choice.label) {
       case 'Open to generate a User token':
@@ -304,7 +304,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
       return cred.token;
     } catch (error) {
       vscode.window.showErrorMessage(
-        'No token found for app.staging.terraform.io. Please login using the Terraform CLI and try again',
+        `No token found for ${TerraformCloudHost}. Please login using the Terraform CLI and try again`,
       );
       return undefined;
     }

--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -9,6 +9,9 @@ import * as vscode from 'vscode';
 import axios from 'axios';
 import { earlyApiClient } from '../terraformCloud';
 
+// TODO: replace with production URL
+const TerraformCloudHost = 'app.staging.terraform.io';
+
 class TerraformCloudSession implements vscode.AuthenticationSession {
   // This id isn't used for anything yet, so we set it to a constant
   readonly id = TerraformCloudAuthenticationProvider.providerID;
@@ -70,7 +73,6 @@ class TerraformCloudSessionHandler {
     return this.secretStorage.delete(this.sessionKey);
   }
 }
-
 export class TerraformCloudAuthenticationProvider implements vscode.AuthenticationProvider, vscode.Disposable {
   static providerLabel = 'HashiCorp Terraform Cloud';
   static providerID = 'HashiCorpTerraformCloud';
@@ -298,7 +300,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     // find app.terraform.io token
     try {
       const data = JSON.parse(text);
-      const cred = data.credentials['app.staging.terraform.io'];
+      const cred = data.credentials[TerraformCloudHost];
       return cred.token;
     } catch (error) {
       vscode.window.showErrorMessage(


### PR DESCRIPTION
This adds a new prompt when the login workflow is initiated that asks the user how they want to authenticate: from the terraform cli config file, generate a new token on the web, or enter it manually.

The user can choose to have the extension read the terraform cli configuration file for the token. This means the user can reuse tokens they already configured to use with TFC without having to copy paste or create new tokens.

This also adds a user prompt to open the TFC website to generate a user token. This reuses the terraform cli login page to prompt the user to generate a new token.

If the user selects to enter an existing token, a new prompt is opened where the user can enter the token.


https://github.com/hashicorp/vscode-terraform/assets/272569/39c5103f-3d3f-440e-a61f-9f2c0439b9d1

