### PR TITLE
Add copyright headers automagically instead of failing a check on PRs

### DIFF
--- a/.github/workflows/add-copyright-headers.yml
+++ b/.github/workflows/add-copyright-headers.yml
@@ -18,7 +18,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.3.0
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # https://github.com/actions/checkout/releases/tag/v3.5.2
         with:
           ref: ${{ github.event.pull_request.head.ref }}
           repository: ${{ github.event.pull_request.head.repo.full_name }}

--- a/.github/workflows/add-copyright-headers.yml
+++ b/.github/workflows/add-copyright-headers.yml
@@ -1,0 +1,41 @@
+name: "Add Copyright Headers"
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+  workflow_dispatch: {}
+
+jobs:
+  add-copyright-headers:
+    runs-on: ubuntu-latest
+    env:
+      HEAD_REF: ${{ github.event.pull_request.head.ref }}
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # v3.3.0
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+      - name: Set git identity
+        run: |-
+          git config user.name "hashicorp-copywrite[bot]"
+          git config user.email "110428419+hashicorp-copywrite[bot]@users.noreply.github.com"
+      - name: Setup Copywrite tool
+        uses: hashicorp/setup-copywrite@867a1a2a064a0626db322392806428f7dc59cb3e # v1.1.2
+      - name: Add headers using Copywrite tool
+        run: copywrite headers
+      - name: Check if there are any changes
+        id: get_changes
+        run: echo "changed=$(git status --porcelain | wc -l)" >> $GITHUB_OUTPUT
+      - name: Push changes
+        if: steps.get_changes.outputs.changed != 0
+        run: |-
+          git add .
+          git commit -s -m "[COMPLIANCE] Add required copyright headers"
+          git push origin HEAD:$HEAD_REF

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,17 +19,6 @@ on:
       - '**.md'
 
 jobs:
-  copywrite:
-    runs-on: ubuntu-latest
-    timeout-minutes: 3
-    steps:
-      - name: Checkout Repo
-        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab # https://github.com/actions/checkout/releases/tag/v3.5.2
-      - name: Install copywrite
-        uses: hashicorp/setup-copywrite@v1.1.2
-      - name: Validate Header Compliance
-        run: copywrite headers --plan
-
   lint:
     runs-on: ubuntu-latest
     timeout-minutes: 3


### PR DESCRIPTION
This is a solution we've been trialing on the CDK team and it's working well for us so I figured I'd propose it to this team as well.

Rather than failing a check on PRs if the copyright headers are missing (which is potentially annoying to community contributors who then either have to manually copy-paste the headers or install HashiCorp's copywrite tool), this adds a new commit on any PRs that are missing the headers that adds them in automagically. (If no headers are missing then it does nothing.)