### PR TITLE
Refresh runs when refreshing workspaces

### DIFF
--- a/src/providers/tfc/workspaceProvider.ts
+++ b/src/providers/tfc/workspaceProvider.ts
@@ -14,7 +14,12 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
   public readonly onDidChangeTreeData = this.didChangeTreeData.event;
 
   constructor(private ctx: vscode.ExtensionContext, private runDataProvider: RunTreeDataProvider) {
-    vscode.commands.registerCommand('terraform.cloud.workspaces.refresh', () => this.refresh());
+    this.ctx.subscriptions.push(
+      vscode.commands.registerCommand('terraform.cloud.workspaces.refresh', (workspaceItem: WorkspaceTreeItem) => {
+        this.refresh();
+        this.runDataProvider.refresh(workspaceItem);
+      }),
+    );
   }
 
   refresh(): void {


### PR DESCRIPTION
This commit refreshes the runs view when refreshing the workspace view by adding a call to the runDataProvider.refresh when performing workspaceProvider.refresh.

If a user has selected a workspace, then refreshes the view, the selected workspace tree item is passed to the runDataProvider so that the runs for that workspace are refreshed.

If no workspace is selected, then the runDataProvider is passed undefined, which will clear it's view. The user can then select a workspace to view runs.
