### PR TITLE
Workspace View Detail

### DIFF
--- a/src/providers/tfc/helpers.ts
+++ b/src/providers/tfc/helpers.ts
@@ -1,0 +1,47 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import * as vscode from 'vscode';
+
+export function GetRunStatusIcon(status: string): vscode.ThemeIcon {
+  switch (status) {
+    // in progress
+    case 'pending':
+    case 'fetching':
+    case 'pre_plan_running':
+    case 'queuing':
+    case 'planning':
+    case 'cost_estimating':
+    case 'policy_checking':
+    case 'apply_queued':
+    case 'applying':
+    case 'post_plan_running':
+    case 'plan_queued':
+      return new vscode.ThemeIcon('sync~spin');
+
+    case 'fetching_completed':
+    case 'pre_plan_completed':
+    case 'planned':
+    case 'cost_estimated':
+    case 'policy_override':
+    case 'policy_checked':
+    case 'confirmed':
+    case 'post_plan_completed':
+    case 'planned_and_finished':
+      return new vscode.ThemeIcon('pass');
+    case 'policy_soft_failed':
+      return new vscode.ThemeIcon('warning');
+    case 'applied':
+      return new vscode.ThemeIcon('pass-filled');
+    case 'discarded':
+    case 'canceled':
+    case 'force_canceled':
+      return new vscode.ThemeIcon('discard');
+    case 'errored':
+      return new vscode.ThemeIcon('error');
+  }
+
+  return new vscode.ThemeIcon('indent');
+}

--- a/src/providers/tfc/runProvider.ts
+++ b/src/providers/tfc/runProvider.ts
@@ -9,6 +9,7 @@ import { TerraformCloudAuthenticationProvider } from '../authenticationProvider'
 import axios from 'axios';
 import { RunAttributes } from '../../terraformCloud/run';
 import { WorkspaceTreeItem } from './workspaceProvider';
+import { GetRunStatusIcon } from './helpers';
 
 export class RunTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeItem>, vscode.Disposable {
   private readonly didChangeTreeData = new vscode.EventEmitter<void | vscode.TreeItem>();
@@ -120,7 +121,7 @@ export class RunTreeItem extends vscode.TreeItem {
     this.id = id;
 
     this.workspaceName = workspaceName;
-    this.iconPath = this.getStatusIcon(attributes.status);
+    this.iconPath = GetRunStatusIcon(attributes.status);
     this.description = `${attributes['trigger-reason']} ${attributes['created-at']}`;
     this.tooltip = new vscode.MarkdownString(`
 ### \`${workspaceName}\`
@@ -136,45 +137,5 @@ ___
 | **Source**              | ${attributes.source}|
 | **Terraform**         | ${attributes['terraform-version']}|
 `);
-  }
-
-  private getStatusIcon(status: string): vscode.ThemeIcon {
-    switch (status) {
-      // in progress
-      case 'pending':
-      case 'fetching':
-      case 'pre_plan_running':
-      case 'queuing':
-      case 'planning':
-      case 'cost_estimating':
-      case 'policy_checking':
-      case 'apply_queued':
-      case 'applying':
-      case 'post_plan_running':
-      case 'plan_queued':
-        return new vscode.ThemeIcon('sync~spin');
-
-      case 'fetching_completed':
-      case 'pre_plan_completed':
-      case 'planned':
-      case 'cost_estimated':
-      case 'policy_override':
-      case 'policy_checked':
-      case 'confirmed':
-      case 'post_plan_completed':
-      case 'planned_and_finished':
-        return new vscode.ThemeIcon('pass');
-      case 'policy_soft_failed':
-        return new vscode.ThemeIcon('warning');
-      case 'applied':
-        return new vscode.ThemeIcon('pass-filled');
-      case 'discarded':
-      case 'canceled':
-      case 'force_canceled':
-        return new vscode.ThemeIcon('discard');
-      case 'errored':
-        return new vscode.ThemeIcon('error');
-    }
-    return new vscode.ThemeIcon('indent');
   }
 }

--- a/src/providers/tfc/runProvider.ts
+++ b/src/providers/tfc/runProvider.ts
@@ -58,7 +58,7 @@ export class RunTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeI
     }
 
     try {
-      return this.getRuns(this.activeWorkspace.id, this.activeWorkspace.name);
+      return this.getRuns(this.activeWorkspace.id, this.activeWorkspace.attributes.name);
     } catch (error) {
       return [];
     }

--- a/src/providers/tfc/workspaceProvider.ts
+++ b/src/providers/tfc/workspaceProvider.ts
@@ -91,8 +91,9 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
           organization_name: organization,
         },
         queries: {
-          'filter[project][id]': this.projectFilter,
-          include: 'current_run',
+          include: ['current_run'],
+          // Include query parameter only if project filter is set
+          ...(this.projectFilter && { 'filter[project][id]': this.projectFilter }),
         },
       });
 

--- a/src/terraformCloud/filter.ts
+++ b/src/terraformCloud/filter.ts
@@ -14,3 +14,12 @@ export const projectFilterParams = makeParameters([
     schema: z.string().optional(),
   },
 ]);
+
+export const currentRunParams = makeParameters([
+  {
+    name: 'include',
+    type: 'Query',
+    description: 'Includes related resources when specified',
+    schema: z.string().optional(),
+  },
+]);

--- a/src/terraformCloud/filter.ts
+++ b/src/terraformCloud/filter.ts
@@ -15,11 +15,14 @@ export const projectFilterParams = makeParameters([
   },
 ]);
 
-export const currentRunParams = makeParameters([
+export const workspaceIncludeParams = makeParameters([
   {
     name: 'include',
     type: 'Query',
-    description: 'Includes related resources when specified',
-    schema: z.string().optional(),
+    description: 'Includes related resources for workspaces when specified',
+    schema: z
+      .array(z.enum(['current_run']))
+      .transform((x) => x?.join(','))
+      .optional(),
   },
 ]);

--- a/src/terraformCloud/run.ts
+++ b/src/terraformCloud/run.ts
@@ -39,7 +39,7 @@ const runStates = z.enum([
 
 const triggerReasons = z.enum(['unknown', 'manual', 'disabled', 'matched', 'inconclusive', 'git_tag']);
 
-const runAttributes = z.object({
+export const runAttributes = z.object({
   'created-at': z.date(),
   message: z.string(),
   source: z.string(),

--- a/src/terraformCloud/workspace.ts
+++ b/src/terraformCloud/workspace.ts
@@ -5,7 +5,7 @@
 
 import { makeApi } from '@zodios/core';
 import { z } from 'zod';
-import { currentRunParams, projectFilterParams } from './filter';
+import { workspaceIncludeParams, projectFilterParams } from './filter';
 import { paginationMeta, paginationParams } from './pagination';
 import { runAttributes } from './run';
 
@@ -72,7 +72,7 @@ export const workspaceEndpoints = makeApi([
     alias: 'listWorkspaces',
     description: 'List workspaces in the organization',
     response: workspaces,
-    parameters: [...paginationParams, ...projectFilterParams, ...currentRunParams],
+    parameters: [...paginationParams, ...projectFilterParams, ...workspaceIncludeParams],
   },
   {
     method: 'get',

--- a/src/terraformCloud/workspace.ts
+++ b/src/terraformCloud/workspace.ts
@@ -16,25 +16,27 @@ const included = z.object({
   attributes: runAttributes,
 });
 
+const workspaceAttributes = z.object({
+  description: z.string(),
+  environment: z.string(),
+  'execution-mode': executionModes,
+  name: z.string(),
+  source: z.string(),
+  'updated-at': z.date(),
+  'run-failures': z.number(),
+  'resource-count': z.number(),
+  'terraform-version': z.string(),
+  locked: z.string(),
+  'vcs-repo-identifier': z.string(),
+  'vcs-repo': z.object({
+    'repository-http-url': z.string(),
+  }),
+  'auto-apply': z.string(),
+});
+
 const workspace = z.object({
   id: z.string(),
-  attributes: z.object({
-    description: z.string(),
-    environment: z.string(),
-    'execution-mode': executionModes,
-    name: z.string(),
-    source: z.string(),
-    'updated-at': z.date(),
-    'run-failures': z.number(),
-    'resource-count': z.number(),
-    'terraform-version': z.string(),
-    locked: z.string(),
-    'vcs-repo-identifier': z.string(),
-    'vcs-repo': z.object({
-      'repository-http-url': z.string(),
-    }),
-    'auto-apply': z.string(),
-  }),
+  attributes: workspaceAttributes,
   relationships: z.object({
     'latest-run': z.object({
       data: z.object({
@@ -56,6 +58,7 @@ const workspace = z.object({
 });
 
 export type Workspace = z.infer<typeof workspace>;
+export type WorkspaceAttributes = z.infer<typeof workspaceAttributes>;
 
 const workspaces = z.object({
   data: z.array(workspace),

--- a/src/terraformCloud/workspace.ts
+++ b/src/terraformCloud/workspace.ts
@@ -5,10 +5,16 @@
 
 import { makeApi } from '@zodios/core';
 import { z } from 'zod';
-import { projectFilterParams } from './filter';
+import { currentRunParams, projectFilterParams } from './filter';
 import { paginationMeta, paginationParams } from './pagination';
+import { runAttributes } from './run';
 
 const executionModes = z.enum(['remote', 'local', 'agent']);
+
+const included = z.object({
+  id: z.string(),
+  attributes: runAttributes,
+});
 
 const workspace = z.object({
   id: z.string(),
@@ -20,8 +26,22 @@ const workspace = z.object({
     source: z.string(),
     'updated-at': z.date(),
     'run-failures': z.number(),
+    'resource-count': z.number(),
+    'terraform-version': z.string(),
+    locked: z.string(),
+    'vcs-repo-identifier': z.string(),
+    'vcs-repo': z.object({
+      'repository-http-url': z.string(),
+    }),
+    'auto-apply': z.string(),
   }),
   relationships: z.object({
+    'latest-run': z.object({
+      data: z.object({
+        id: z.string(),
+        type: z.string(),
+      }),
+    }),
     project: z.object({
       data: z.object({
         id: z.string(),
@@ -29,13 +49,20 @@ const workspace = z.object({
       }),
     }),
   }),
+  links: z.object({
+    self: z.string(),
+    'self-html': z.string(),
+  }),
 });
+
+export type Workspace = z.infer<typeof workspace>;
 
 const workspaces = z.object({
   data: z.array(workspace),
   meta: z.object({
     pagination: paginationMeta,
   }),
+  included: z.array(included).optional(),
 });
 
 export const workspaceEndpoints = makeApi([
@@ -45,7 +72,7 @@ export const workspaceEndpoints = makeApi([
     alias: 'listWorkspaces',
     description: 'List workspaces in the organization',
     response: workspaces,
-    parameters: [...paginationParams, ...projectFilterParams],
+    parameters: [...paginationParams, ...projectFilterParams, ...currentRunParams],
   },
   {
     method: 'get',


### PR DESCRIPTION
This improves the detail shown when hovering over a Workspace Tree item in the Workspace view. This detail includes number o resources, terraform version, last updated date, VCS url, execution mode and auto apply state.

This also adds a status icon to the item, so that the status of the last run shows as the status of the workspace, just like the TFC website.

More information about the last run status could have been added to the hover, but this makes the hover box large enough it can be clipped when the editor zoom is large. This information is already shown in the Run view, so is not absolutely needed here. If that information is useful, it can be added to the item by adding child nodes.

<img width="812" alt="image" src="https://github.com/hashicorp/vscode-terraform/assets/272569/971e73dd-f5a7-4c0d-96de-85a80c1c9410">
