### PR TITLE
Fix silent login workflow

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,15 +56,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // always register commands needed to control terraform-ls
   context.subscriptions.push(new TerraformLSCommands());
 
-  context.subscriptions.push(
-    vscode.authentication.registerAuthenticationProvider(
-      TerraformCloudAuthenticationProvider.providerID,
-      TerraformCloudAuthenticationProvider.providerLabel,
-      new TerraformCloudAuthenticationProvider(context.secrets, context),
-      { supportsMultipleAccounts: false },
-    ),
-  );
-
   context.subscriptions.push(new TerraformCloudFeature(context));
   // This triggers a badge to appear in the User Account icon.
   // TODO: remove this when workspace views land

--- a/src/features/terraformCloud.ts
+++ b/src/features/terraformCloud.ts
@@ -53,14 +53,9 @@ export class TerraformCloudFeature implements vscode.Disposable {
 
     const authProvider = new TerraformCloudAuthenticationProvider(context.secrets, context, this.statusBar);
     authProvider.onDidChangeSessions(async (event) => {
-      console.log(event);
-      if (event) {
-        if (event.added) {
-          console.log('signed in');
-
-          await vscode.commands.executeCommand('terraform.cloud.organization.picker');
-          this.statusBar.show();
-        }
+      if (event && event.added) {
+        await vscode.commands.executeCommand('terraform.cloud.organization.picker');
+        this.statusBar.show();
       }
     });
 

--- a/src/features/terraformCloud.ts
+++ b/src/features/terraformCloud.ts
@@ -9,46 +9,6 @@ import { RunTreeDataProvider } from '../providers/tfc/runProvider';
 import { TerraformCloudAuthenticationProvider } from '../providers/authenticationProvider';
 import { apiClient } from '../terraformCloud';
 
-export class OrganizationStatusBar implements vscode.Disposable {
-  private organizationStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
-
-  constructor(private context: vscode.ExtensionContext) {
-    this.organizationStatusBar.name = 'TFCOrganizationBar';
-    this.organizationStatusBar.command = {
-      command: 'terraform.cloud.organization.picker',
-      title: 'Choose your Terraform Cloud Organization',
-    };
-  }
-
-  dispose() {
-    this.organizationStatusBar.dispose();
-  }
-
-  public async show(organization?: string) {
-    if (organization) {
-      await this.context.workspaceState.update('terraform.cloud.organization', organization);
-    } else {
-      organization = this.context.workspaceState.get('terraform.cloud.organization', '');
-    }
-
-    if (organization) {
-      this.organizationStatusBar.text = organization;
-    }
-
-    this.organizationStatusBar.show();
-  }
-
-  public async reset() {
-    await this.context.workspaceState.update('terraform.cloud.organization', undefined);
-    this.organizationStatusBar.text = '';
-    this.organizationStatusBar.hide();
-  }
-
-  public hide() {
-    this.organizationStatusBar.hide();
-  }
-}
-
 export class TerraformCloudFeature implements vscode.Disposable {
   private statusBar: OrganizationStatusBar;
 
@@ -163,5 +123,45 @@ export class TerraformCloudFeature implements vscode.Disposable {
 
   dispose() {
     this.statusBar.dispose();
+  }
+}
+
+export class OrganizationStatusBar implements vscode.Disposable {
+  private organizationStatusBar = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Left, 0);
+
+  constructor(private context: vscode.ExtensionContext) {
+    this.organizationStatusBar.name = 'TFCOrganizationBar';
+    this.organizationStatusBar.command = {
+      command: 'terraform.cloud.organization.picker',
+      title: 'Choose your Terraform Cloud Organization',
+    };
+  }
+
+  dispose() {
+    this.organizationStatusBar.dispose();
+  }
+
+  public async show(organization?: string) {
+    if (organization) {
+      await this.context.workspaceState.update('terraform.cloud.organization', organization);
+    } else {
+      organization = this.context.workspaceState.get('terraform.cloud.organization', '');
+    }
+
+    if (organization) {
+      this.organizationStatusBar.text = organization;
+    }
+
+    this.organizationStatusBar.show();
+  }
+
+  public async reset() {
+    await this.context.workspaceState.update('terraform.cloud.organization', undefined);
+    this.organizationStatusBar.text = '';
+    this.organizationStatusBar.hide();
+  }
+
+  public hide() {
+    this.organizationStatusBar.hide();
   }
 }

--- a/src/features/terraformCloud.ts
+++ b/src/features/terraformCloud.ts
@@ -53,7 +53,7 @@ export class TerraformCloudFeature implements vscode.Disposable {
 
     const authProvider = new TerraformCloudAuthenticationProvider(context.secrets, context, this.statusBar);
     authProvider.onDidChangeSessions(async (event) => {
-      if (event && event.added) {
+      if (event && event.added && event.added.length > 0) {
         await vscode.commands.executeCommand('terraform.cloud.organization.picker');
         this.statusBar.show();
       }
@@ -67,8 +67,6 @@ export class TerraformCloudFeature implements vscode.Disposable {
         { supportsMultipleAccounts: false },
       ),
     );
-
-    this.statusBar.show();
 
     const runDataProvider = new RunTreeDataProvider(this.context);
     const runView = vscode.window.createTreeView('terraform.cloud.runs', {

--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -101,11 +101,6 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
           createIfNone: true,
         });
         vscode.window.showInformationMessage(`Hello ${session.account.label}`);
-
-        const org = this.ctx.workspaceState.get('terraform.cloud.organization', '');
-        if (org === '') {
-          await vscode.commands.executeCommand('terraform.cloud.organization.picker');
-        }
       }),
     );
 

--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -8,7 +8,6 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import axios from 'axios';
 import { earlyApiClient } from '../terraformCloud';
-import { OrganizationStatusBar } from '../features/terraformCloud';
 
 // TODO: replace with production URL
 const TerraformCloudHost = 'app.staging.terraform.io';
@@ -88,11 +87,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
   private _onDidChangeSessions =
     new vscode.EventEmitter<vscode.AuthenticationProviderAuthenticationSessionsChangeEvent>();
 
-  constructor(
-    private readonly secretStorage: vscode.SecretStorage,
-    private readonly ctx: vscode.ExtensionContext,
-    private statusBar: OrganizationStatusBar,
-  ) {
+  constructor(private readonly secretStorage: vscode.SecretStorage, private readonly ctx: vscode.ExtensionContext) {
     this.logger = vscode.window.createOutputChannel('HashiCorp Authentication', { log: true });
     this.sessionHandler = new TerraformCloudSessionHandler(this.secretStorage, this.sessionKey);
     ctx.subscriptions.push(
@@ -182,10 +177,6 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
 
     this.logger.info('Removing current session');
     await this.sessionHandler.delete();
-
-    await this.ctx.workspaceState.update('terraform.cloud.organization', '');
-
-    this.statusBar.reset();
 
     // Notify VSCode's UI
     this._onDidChangeSessions.fire({ added: [], removed: [session], changed: [] });

--- a/src/terraformCloud/index.ts
+++ b/src/terraformCloud/index.ts
@@ -54,7 +54,7 @@ export const tokenPluginId = apiClient.use(
     getToken: async () => {
       // TODO: Consider passing it as a dependency instead of global access to make testing easier
       const session = await vscode.authentication.getSession(TerraformCloudAuthenticationProvider.providerID, [], {
-        createIfNone: false,
+        createIfNone: true,
       });
       return session ? session.accessToken : undefined;
     },

--- a/src/terraformCloud/index.ts
+++ b/src/terraformCloud/index.ts
@@ -54,9 +54,9 @@ export const tokenPluginId = apiClient.use(
     getToken: async () => {
       // TODO: Consider passing it as a dependency instead of global access to make testing easier
       const session = await vscode.authentication.getSession(TerraformCloudAuthenticationProvider.providerID, [], {
-        createIfNone: true,
+        createIfNone: false,
       });
-      return session.accessToken;
+      return session ? session.accessToken : undefined;
     },
   }),
 );


### PR DESCRIPTION
This adjusts the silent login workflow to call the organization picker at the correct times.

A user can login either using our command palatte command or by clicking the User Account icon and selecting our provider (called a silent login flow by the docs). This silent flow creates the session but does not call our organization picker. The organization picker needs to call out to TFC to get a list of organizations to choose from, which requires authentication to TFC. Authentication to TFC requires the apiClient to have a token, which it asks using getSession.

We can't add the organization picker in createSession because it would call getSession before createSession finishes, leaving no session for getSession to find. This creates a chicken-and-the-egg scenario. To add further complication, we show the chosen organization in the statusbar, which needs to be updated on login, on change, and on logout. This was only happening on login previously.

This change extracts the statusbar to a class and encapsulates the logic for handling setting the status during login, change, and logout.

It also ensures that on logout, it clears the organization from the context so it is not remembered when the user logs in next.

Finally, the onDidChangeSessions event is used to determine when a new login event is triggered, so that we can prompt the organization picker. Since the event is triggered as createSession returns, there is a enough time for a session to be stored for getSession to return a session to apiClient.
