### PR TITLE
Correct invalid json in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,7 +216,7 @@ To enable automatic formatting, it is recommended that the following be added to
   "editor.defaultFormatter": "hashicorp.terraform",
   "editor.formatOnSave": true,
   "editor.formatOnSaveMode": "file"
-}
+},
 "[terraform-vars]": {
   "editor.defaultFormatter": "hashicorp.terraform",
   "editor.formatOnSave": true,


### PR DESCRIPTION
Copy pasted this snippet into .vscode/settings.json and it wasn't a valid json due to a missing comma, adding that.