### PR TITLE
bump zodios to `v10.9.2` and update incorrect API schemas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MPL-2.0",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.4.9",
-        "@zodios/core": "^10.9.0",
+        "@zodios/core": "^10.9.2",
         "@zodios/plugins": "^10.6.0",
         "axios": "^1.4.0",
         "vscode-languageclient": "8.1.0",
@@ -2620,9 +2620,9 @@
       "dev": true
     },
     "node_modules/@zodios/core": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/@zodios/core/-/core-10.9.0.tgz",
-      "integrity": "sha512-vfj1vbVuA+S7sRX7nSzkW4cf35R1AFFHHYfCb1rUdEHWlBrc7YLjbjoQiijHEVloCX97TtuVrzSYCU0yu8bmrQ==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/@zodios/core/-/core-10.9.2.tgz",
+      "integrity": "sha512-aY8FgE6Y+91oBaMfTnqibGoHO62OiKKHoiQAq76PYJbU7InFeWsSRhpnBwpibWopRjz45AlqojxKo3QeSAYC7w==",
       "peerDependencies": {
         "axios": "^0.x || ^1.0.0",
         "zod": "^3.x"
@@ -13951,9 +13951,9 @@
       "dev": true
     },
     "@zodios/core": {
-      "version": "10.9.0",
-      "resolved": "https://registry.npmjs.org/@zodios/core/-/core-10.9.0.tgz",
-      "integrity": "sha512-vfj1vbVuA+S7sRX7nSzkW4cf35R1AFFHHYfCb1rUdEHWlBrc7YLjbjoQiijHEVloCX97TtuVrzSYCU0yu8bmrQ==",
+      "version": "10.9.2",
+      "resolved": "https://registry.npmjs.org/@zodios/core/-/core-10.9.2.tgz",
+      "integrity": "sha512-aY8FgE6Y+91oBaMfTnqibGoHO62OiKKHoiQAq76PYJbU7InFeWsSRhpnBwpibWopRjz45AlqojxKo3QeSAYC7w==",
       "requires": {}
     },
     "@zodios/plugins": {

--- a/package.json
+++ b/package.json
@@ -666,7 +666,7 @@
   },
   "dependencies": {
     "@vscode/extension-telemetry": "^0.4.9",
-    "@zodios/core": "^10.9.0",
+    "@zodios/core": "^10.9.2",
     "@zodios/plugins": "^10.6.0",
     "axios": "^1.4.0",
     "vscode-languageclient": "8.1.0",

--- a/src/providers/tfc/workspaceProvider.ts
+++ b/src/providers/tfc/workspaceProvider.ts
@@ -5,7 +5,6 @@
 
 import * as vscode from 'vscode';
 import axios from 'axios';
-import { z } from 'zod';
 
 import { RunTreeDataProvider } from './runProvider';
 import { apiClient } from '../../terraformCloud';

--- a/src/providers/tfc/workspaceProvider.ts
+++ b/src/providers/tfc/workspaceProvider.ts
@@ -119,7 +119,7 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
       for (let index = 0; index < workspaces.length; index++) {
         const workspace = workspaces[index];
 
-        const project = projects.find((p) => p.id === workspace.relationships.project.data.id);
+        const project = projects.find((p) => p.id === workspace.relationships['project']?.data?.id);
         const projectName = project ? project.attributes.name : '';
 
         const lastRunId = workspace.relationships['latest-run']?.data?.id;
@@ -181,12 +181,12 @@ export class WorkspaceTreeItem extends vscode.TreeItem {
     }
 
     const lockedTxt = this.attributes.locked ? '$(lock) Locked' : '$(unlock) Unlocked';
-    const vscText = this.attributes['vcs-repo-identifier']
-      ? `$(source-control) [${this.attributes['vcs-repo-identifier']}](${this.attributes['vcs-repo']['repository-http-url']})`
-      : '';
+    const vscText =
+      this.attributes['vcs-repo-identifier'] && this.attributes['vcs-repo']
+        ? `$(source-control) [${this.attributes['vcs-repo-identifier']}](${this.attributes['vcs-repo']['repository-http-url']})`
+        : '';
 
-    // TODO(fix): the date does not get parsed as Date via zod schema
-    const updatedAt = RelativeTimeFormat(z.coerce.date().parse(this.attributes['updated-at']));
+    const updatedAt = RelativeTimeFormat(this.attributes['updated-at']);
     const text = `
 ## [${this.attributes.name}](${this.weblink})
 

--- a/src/terraformCloud/run.ts
+++ b/src/terraformCloud/run.ts
@@ -45,7 +45,7 @@ export const TRIGGER_REASON: { [id: string]: string } = {
   inconclusive: 'unable to detect changed files',
   git_tag: 'automatically triggered run',
 };
-const triggerReasons = Object.keys(TRIGGER_REASON);
+const triggerReasons = Object.keys(TRIGGER_REASON) as [string, ...string[]];
 
 export const RUN_SOURCE: { [id: string]: string } = {
   terraform: 'CLI',
@@ -57,14 +57,14 @@ export const RUN_SOURCE: { [id: string]: string } = {
   'tfe-run-trigger': 'run trigger',
   'tfe-ui': 'UI',
 };
-const runSources = Object.keys(RUN_SOURCE);
+const runSources = Object.keys(RUN_SOURCE) as [string, ...string[]];
 
 export const runAttributes = z.object({
   'created-at': z.coerce.date(),
   message: z.string(),
-  source: z.enum([runSources[0], ...runSources]),
+  source: z.enum(runSources),
   status: runStatus,
-  'trigger-reason': z.enum([triggerReasons[0], ...triggerReasons]),
+  'trigger-reason': z.enum(triggerReasons),
   'terraform-version': z.string(),
 });
 export type RunAttributes = z.infer<typeof runAttributes>;
@@ -134,7 +134,7 @@ export const CONFIGURATION_SOURCE: { [id: string]: string } = {
   tfeAPI: 'API',
   module: 'No-code Module',
 };
-const cfgSources = Object.keys(CONFIGURATION_SOURCE);
+const cfgSources = Object.keys(CONFIGURATION_SOURCE) as [string, ...string[]];
 
 const configurationVersionRelationships = z.object({
   'ingress-attributes': relationship,
@@ -143,7 +143,7 @@ const configurationVersionRelationships = z.object({
 // include=configuration_version (implied from .ingress_attributes too)
 // See https://developer.hashicorp.com/terraform/cloud-docs/api-docs/configuration-versions#show-a-configuration-version
 const configurationVersionAttributes = z.object({
-  source: z.enum([cfgSources[0], ...cfgSources]).nullish(),
+  source: z.enum(cfgSources).nullish(),
 });
 export type ConfigurationVersionAttributes = z.infer<typeof configurationVersionAttributes>;
 const configurationVersion = z.object({

--- a/src/terraformCloud/workspace.ts
+++ b/src/terraformCloud/workspace.ts
@@ -17,40 +17,45 @@ const included = z.object({
 });
 
 const workspaceAttributes = z.object({
-  description: z.string(),
+  description: z.string().nullable(),
   environment: z.string(),
   'execution-mode': executionModes,
   name: z.string(),
   source: z.string(),
-  'updated-at': z.date(),
-  'run-failures': z.number(),
+  'updated-at': z.coerce.date(),
+  'run-failures': z.number().nullable(),
   'resource-count': z.number(),
   'terraform-version': z.string(),
-  locked: z.string(),
-  'vcs-repo-identifier': z.string(),
-  'vcs-repo': z.object({
-    'repository-http-url': z.string(),
-  }),
-  'auto-apply': z.string(),
+  locked: z.boolean(),
+  'vcs-repo-identifier': z.string().nullable(),
+  'vcs-repo': z
+    .object({
+      'repository-http-url': z.string(),
+    })
+    .nullable(),
+  'auto-apply': z.boolean(),
+});
+
+const relationship = z
+  .object({
+    data: z
+      .object({
+        id: z.string(),
+        type: z.string(),
+      })
+      .nullable(),
+  })
+  .nullish();
+
+const workspaceRelationships = z.object({
+  'latest-run': relationship,
+  project: relationship,
 });
 
 const workspace = z.object({
   id: z.string(),
   attributes: workspaceAttributes,
-  relationships: z.object({
-    'latest-run': z.object({
-      data: z.object({
-        id: z.string(),
-        type: z.string(),
-      }),
-    }),
-    project: z.object({
-      data: z.object({
-        id: z.string(),
-        type: z.string(),
-      }),
-    }),
-  }),
+  relationships: workspaceRelationships,
   links: z.object({
     self: z.string(),
     'self-html': z.string(),


### PR DESCRIPTION
This is to reflect the patch upstream https://github.com/ecyrbe/zodios/pull/471

I ran the schemas through all the data we have available in our shared org and they all comply.