### PR TITLE
Add telemetry for TFC integration

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -56,7 +56,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   // always register commands needed to control terraform-ls
   context.subscriptions.push(new TerraformLSCommands());
 
-  context.subscriptions.push(new TerraformCloudFeature(context));
+  context.subscriptions.push(new TerraformCloudFeature(context, reporter));
   // This triggers a badge to appear in the User Account icon.
   // TODO: remove this when workspace views land
   await vscode.authentication.getSession(TerraformCloudAuthenticationProvider.providerID, [], {

--- a/src/providers/tfc/runProvider.ts
+++ b/src/providers/tfc/runProvider.ts
@@ -112,7 +112,9 @@ export class RunTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeI
         },
       });
 
-      this.reporter.sendTelemetryEvent('tfc-fetch-runs', undefined, { count: runs.data.length });
+      this.reporter.sendTelemetryEvent('tfc-fetch-runs', undefined, {
+        totalCount: runs.meta.pagination['total-count'],
+      });
 
       if (runs.data.length === 0) {
         return [{ label: `No runs found for ${this.activeWorkspace.attributes.name}` }];

--- a/src/providers/tfc/workspaceProvider.ts
+++ b/src/providers/tfc/workspaceProvider.ts
@@ -112,7 +112,9 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
         },
       });
 
-      this.reporter.sendTelemetryEvent('tfc-fetch-workspaces', undefined, { count: workspaceResponse.data.length });
+      this.reporter.sendTelemetryEvent('tfc-fetch-workspaces', undefined, {
+        totalCount: workspaceResponse.meta.pagination['total-count'],
+      });
 
       // TODO? we could skip this request if a project filter is set,
       // but with the addition of more filters, we could still get

--- a/src/providers/tfc/workspaceProvider.ts
+++ b/src/providers/tfc/workspaceProvider.ts
@@ -5,6 +5,7 @@
 
 import * as vscode from 'vscode';
 import axios from 'axios';
+import TelemetryReporter from '@vscode/extension-telemetry';
 
 import { RunTreeDataProvider } from './runProvider';
 import { apiClient } from '../../terraformCloud';
@@ -23,20 +24,29 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
   // TODO: get from settings or somewhere global
   private baseUrl = 'https://app.staging.terraform.io/app';
 
-  constructor(private ctx: vscode.ExtensionContext, private runDataProvider: RunTreeDataProvider) {
+  constructor(
+    private ctx: vscode.ExtensionContext,
+    private runDataProvider: RunTreeDataProvider,
+    private reporter: TelemetryReporter,
+  ) {
     this.ctx.subscriptions.push(
       vscode.commands.registerCommand('terraform.cloud.workspaces.refresh', (workspaceItem: WorkspaceTreeItem) => {
+        this.reporter.sendTelemetryEvent('tfc-workspaces-refresh');
         this.refresh();
         this.runDataProvider.refresh(workspaceItem);
       }),
       vscode.commands.registerCommand(
         'terraform.cloud.workspaces.viewInBrowser',
         (workspaceItem: WorkspaceTreeItem) => {
+          this.reporter.sendTelemetryEvent('tfc-workspaces-viewInBrowser');
           const runURL = `${this.baseUrl}/${workspaceItem.organization}/workspaces/${workspaceItem.attributes.name}`;
           vscode.env.openExternal(vscode.Uri.parse(runURL));
         },
       ),
-      vscode.commands.registerCommand('terraform.cloud.workspaces.filterByProject', () => this.filterByProject()),
+      vscode.commands.registerCommand('terraform.cloud.workspaces.filterByProject', () => {
+        this.reporter.sendTelemetryEvent('tfc-workspaces-filter');
+        this.filterByProject();
+      }),
     );
   }
 
@@ -101,6 +111,8 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
           ...(this.projectFilter && { 'filter[project][id]': this.projectFilter }),
         },
       });
+
+      this.reporter.sendTelemetryEvent('tfc-fetch-workspaces', undefined, { count: workspaceResponse.data.length });
 
       // TODO? we could skip this request if a project filter is set,
       // but with the addition of more filters, we could still get


### PR DESCRIPTION
This PR uses the built-in telemetry feature to collect anonymous TFC usage information.

We track
* **Auth related**
  * Login
    * With existing token
    * With stored token
    * With opening the browser  
  * Login success
  * Login fail
  * Logout
* **Organization related**
  * Open organization picker
  * Select Create Organization
  * Select Refresh Organization
* **Workspaces related**
  * Refresh
  * Filter
  * Open in browser
  * Successful fetch 
* **Runs related**
  * Refresh
  * Open in browser
  * Successful fetch 