### PR TITLE
Standardize TFC URL Location

### DIFF
--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -243,7 +243,6 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
       return undefined;
     }
 
-    // TODO: Change to production URL
     const terraformCloudURL = `${TerraformCloudWebUrl}/settings/tokens?source=vscode-terraform`;
     let token: string | undefined;
     switch (choice.label) {

--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -244,7 +244,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     }
 
     // TODO: Change to production URL
-    const terraformCloudURL = `https://${TerraformCloudWebUrl}/settings/tokens?source=vscode-terraform`;
+    const terraformCloudURL = `${TerraformCloudWebUrl}/settings/tokens?source=vscode-terraform`;
     let token: string | undefined;
     switch (choice.label) {
       case 'Open to generate a User token':

--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -8,8 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import axios from 'axios';
 import TelemetryReporter from '@vscode/extension-telemetry';
-
-import { earlyApiClient, TerraformCloudHost } from '../terraformCloud';
+import { earlyApiClient, TerraformCloudHost, TerraformCloudWebUrl } from '../terraformCloud';
 
 class TerraformCloudSession implements vscode.AuthenticationSession {
   // This id isn't used for anything yet, so we set it to a constant
@@ -245,7 +244,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     }
 
     // TODO: Change to production URL
-    const terraformCloudURL = `https://${TerraformCloudHost}/app/settings/tokens?source=vscode-terraform`;
+    const terraformCloudURL = `https://${TerraformCloudWebUrl}/settings/tokens?source=vscode-terraform`;
     let token: string | undefined;
     switch (choice.label) {
       case 'Open to generate a User token':

--- a/src/providers/tfc/organizationPicker.ts
+++ b/src/providers/tfc/organizationPicker.ts
@@ -16,7 +16,7 @@ export class CreateOrganizationItem implements vscode.QuickPickItem {
     return 'Open the browser to create a new organization';
   }
   async open() {
-    await vscode.env.openExternal(vscode.Uri.parse(`https://${TerraformCloudWebUrl}/organizations`));
+    await vscode.env.openExternal(vscode.Uri.parse(`${TerraformCloudWebUrl}/organizations`));
   }
   get alwaysShow() {
     return true;

--- a/src/providers/tfc/organizationPicker.ts
+++ b/src/providers/tfc/organizationPicker.ts
@@ -4,7 +4,7 @@
  */
 
 import * as vscode from 'vscode';
-import { TerraformCloudHost, apiClient } from '../../terraformCloud';
+import { TerraformCloudWebUrl, apiClient } from '../../terraformCloud';
 import { APIResource } from './uiHelpers';
 import { Organization } from '../../terraformCloud/organization';
 
@@ -16,7 +16,7 @@ export class CreateOrganizationItem implements vscode.QuickPickItem {
     return 'Open the browser to create a new organization';
   }
   async open() {
-    await vscode.env.openExternal(vscode.Uri.parse(`https://${TerraformCloudHost}/app/organizations`));
+    await vscode.env.openExternal(vscode.Uri.parse(`https://${TerraformCloudWebUrl}/organizations`));
   }
   get alwaysShow() {
     return true;

--- a/src/providers/tfc/runProvider.ts
+++ b/src/providers/tfc/runProvider.ts
@@ -4,11 +4,10 @@
  */
 
 import * as vscode from 'vscode';
-import { z } from 'zod';
 import axios from 'axios';
 import TelemetryReporter from '@vscode/extension-telemetry';
 
-import { apiClient } from '../../terraformCloud';
+import { TerraformCloudWebUrl, apiClient } from '../../terraformCloud';
 import { TerraformCloudAuthenticationProvider } from '../authenticationProvider';
 import {
   CONFIGURATION_SOURCE,
@@ -38,9 +37,6 @@ export class RunTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeI
       }),
     );
 
-    // TODO: get from settings or somewhere global
-    const baseUrl = 'https://app.staging.terraform.io/app';
-
     this.ctx.subscriptions.push(
       vscode.commands.registerCommand('terraform.cloud.run.viewInBrowser', (run: RunTreeItem) => {
         const orgName = this.ctx.workspaceState.get('terraform.cloud.organization', '');
@@ -49,7 +45,7 @@ export class RunTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeI
         }
 
         this.reporter.sendTelemetryEvent('tfc-runs-viewInBrowser');
-        const runURL = `${baseUrl}/${orgName}/workspaces/${run.workspace.attributes.name}/runs/${run.id}`;
+        const runURL = `${TerraformCloudWebUrl}/${orgName}/workspaces/${run.workspace.attributes.name}/runs/${run.id}`;
 
         vscode.env.openExternal(vscode.Uri.parse(runURL));
       }),

--- a/src/providers/tfc/workspaceProvider.ts
+++ b/src/providers/tfc/workspaceProvider.ts
@@ -8,7 +8,7 @@ import axios from 'axios';
 import TelemetryReporter from '@vscode/extension-telemetry';
 
 import { RunTreeDataProvider } from './runProvider';
-import { apiClient } from '../../terraformCloud';
+import { apiClient, TerraformCloudWebUrl } from '../../terraformCloud';
 import { TerraformCloudAuthenticationProvider } from '../authenticationProvider';
 import { ProjectsAPIResource, ResetProjectItem } from './workspaceFilters';
 import { GetRunStatusIcon, RelativeTimeFormat } from './helpers';
@@ -20,9 +20,6 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
   private readonly didChangeTreeData = new vscode.EventEmitter<void | WorkspaceTreeItem>();
   public readonly onDidChangeTreeData = this.didChangeTreeData.event;
   private projectFilter: string | undefined;
-
-  // TODO: get from settings or somewhere global
-  private baseUrl = 'https://app.staging.terraform.io/app';
 
   constructor(
     private ctx: vscode.ExtensionContext,
@@ -39,7 +36,7 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
         'terraform.cloud.workspaces.viewInBrowser',
         (workspaceItem: WorkspaceTreeItem) => {
           this.reporter.sendTelemetryEvent('tfc-workspaces-viewInBrowser');
-          const runURL = `${this.baseUrl}/${workspaceItem.organization}/workspaces/${workspaceItem.attributes.name}`;
+          const runURL = `${TerraformCloudWebUrl}/${workspaceItem.organization}/workspaces/${workspaceItem.attributes.name}`;
           vscode.env.openExternal(vscode.Uri.parse(runURL));
         },
       ),
@@ -139,7 +136,7 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
         const lastestRun = workspaceResponse.included
           ? workspaceResponse.included.find((run) => run.id === lastRunId)
           : undefined;
-        const link = vscode.Uri.joinPath(vscode.Uri.parse(this.baseUrl), workspace.links['self-html']);
+        const link = vscode.Uri.joinPath(vscode.Uri.parse(TerraformCloudWebUrl), workspace.links['self-html']);
 
         items.push(
           new WorkspaceTreeItem(

--- a/src/terraformCloud/index.ts
+++ b/src/terraformCloud/index.ts
@@ -16,8 +16,7 @@ import { workspaceEndpoints } from './workspace';
 // TODO: replace with production URL
 export const TerraformCloudHost = 'app.staging.terraform.io';
 
-// TODO: Replace with production URL before going live
-export const TerraformCloudAPIURL = `https://${TerraformCloudHost}/api/v2`;
+export const TerraformCloudAPIUrl = `https://${TerraformCloudHost}/api/v2`;
 export const TerraformCloudWebUrl = `https://${TerraformCloudHost}/app`;
 
 const jsonHeader = pluginHeader('Content-Type', async () => 'application/vnd.api+json');
@@ -38,12 +37,12 @@ function pluginLogger(): ZodiosPlugin {
   };
 }
 
-export const earlyApiClient = new Zodios(TerraformCloudAPIURL, accountEndpoints);
+export const earlyApiClient = new Zodios(TerraformCloudAPIUrl, accountEndpoints);
 earlyApiClient.use(jsonHeader);
 earlyApiClient.use(userAgentHeader);
 earlyApiClient.use(pluginLogger());
 
-export const apiClient = new Zodios(TerraformCloudAPIURL, [
+export const apiClient = new Zodios(TerraformCloudAPIUrl, [
   ...accountEndpoints,
   ...organizationEndpoints,
   ...projectEndpoints,

--- a/src/terraformCloud/index.ts
+++ b/src/terraformCloud/index.ts
@@ -17,7 +17,8 @@ import { workspaceEndpoints } from './workspace';
 export const TerraformCloudHost = 'app.staging.terraform.io';
 
 // TODO: Replace with production URL before going live
-export const baseUrl = 'https://app.staging.terraform.io/api/v2';
+export const TerraformCloudAPI = `https://${TerraformCloudHost}/api/v2`;
+export const TerraformCloudWebUrl = `https://${TerraformCloudHost}/app`;
 
 const jsonHeader = pluginHeader('Content-Type', async () => 'application/vnd.api+json');
 
@@ -37,12 +38,12 @@ function pluginLogger(): ZodiosPlugin {
   };
 }
 
-export const earlyApiClient = new Zodios(baseUrl, accountEndpoints);
+export const earlyApiClient = new Zodios(TerraformCloudAPI, accountEndpoints);
 earlyApiClient.use(jsonHeader);
 earlyApiClient.use(userAgentHeader);
 earlyApiClient.use(pluginLogger());
 
-export const apiClient = new Zodios(baseUrl, [
+export const apiClient = new Zodios(TerraformCloudAPI, [
   ...accountEndpoints,
   ...organizationEndpoints,
   ...projectEndpoints,

--- a/src/terraformCloud/index.ts
+++ b/src/terraformCloud/index.ts
@@ -17,7 +17,7 @@ import { workspaceEndpoints } from './workspace';
 export const TerraformCloudHost = 'app.staging.terraform.io';
 
 // TODO: Replace with production URL before going live
-export const TerraformCloudAPI = `https://${TerraformCloudHost}/api/v2`;
+export const TerraformCloudAPIURL = `https://${TerraformCloudHost}/api/v2`;
 export const TerraformCloudWebUrl = `https://${TerraformCloudHost}/app`;
 
 const jsonHeader = pluginHeader('Content-Type', async () => 'application/vnd.api+json');
@@ -38,12 +38,12 @@ function pluginLogger(): ZodiosPlugin {
   };
 }
 
-export const earlyApiClient = new Zodios(TerraformCloudAPI, accountEndpoints);
+export const earlyApiClient = new Zodios(TerraformCloudAPIURL, accountEndpoints);
 earlyApiClient.use(jsonHeader);
 earlyApiClient.use(userAgentHeader);
 earlyApiClient.use(pluginLogger());
 
-export const apiClient = new Zodios(TerraformCloudAPI, [
+export const apiClient = new Zodios(TerraformCloudAPIURL, [
   ...accountEndpoints,
   ...organizationEndpoints,
   ...projectEndpoints,

--- a/src/test/integration/mocks/server.ts
+++ b/src/test/integration/mocks/server.ts
@@ -6,7 +6,7 @@
 import { ZodiosPathsByMethod, ZodiosResponseByPath } from '@zodios/core/lib/zodios.types';
 import { ResponseResolver, rest, RestContext, RestRequest } from 'msw';
 import { setupServer } from 'msw/node';
-import { apiClient, baseUrl } from '../../../terraformCloud';
+import { TerraformCloudAPI, apiClient } from '../../../terraformCloud';
 
 type Api = typeof apiClient.api;
 
@@ -14,7 +14,7 @@ export function mockGet<Path extends ZodiosPathsByMethod<Api, 'get'>>(
   path: Path,
   resolver: ResponseResolver<RestRequest, RestContext, Awaited<ZodiosResponseByPath<Api, 'get', Path>>>,
 ) {
-  return rest.get(`${baseUrl}${path}`, resolver);
+  return rest.get(`${TerraformCloudAPI}${path}`, resolver);
 }
 
 const handlers = [

--- a/src/test/integration/mocks/server.ts
+++ b/src/test/integration/mocks/server.ts
@@ -6,7 +6,7 @@
 import { ZodiosPathsByMethod, ZodiosResponseByPath } from '@zodios/core/lib/zodios.types';
 import { ResponseResolver, rest, RestContext, RestRequest } from 'msw';
 import { setupServer } from 'msw/node';
-import { TerraformCloudAPIURL, apiClient } from '../../../terraformCloud';
+import { TerraformCloudAPIUrl, apiClient } from '../../../terraformCloud';
 
 type Api = typeof apiClient.api;
 
@@ -14,7 +14,7 @@ export function mockGet<Path extends ZodiosPathsByMethod<Api, 'get'>>(
   path: Path,
   resolver: ResponseResolver<RestRequest, RestContext, Awaited<ZodiosResponseByPath<Api, 'get', Path>>>,
 ) {
-  return rest.get(`${TerraformCloudAPIURL}${path}`, resolver);
+  return rest.get(`${TerraformCloudAPIUrl}${path}`, resolver);
 }
 
 const handlers = [

--- a/src/test/integration/mocks/server.ts
+++ b/src/test/integration/mocks/server.ts
@@ -6,7 +6,7 @@
 import { ZodiosPathsByMethod, ZodiosResponseByPath } from '@zodios/core/lib/zodios.types';
 import { ResponseResolver, rest, RestContext, RestRequest } from 'msw';
 import { setupServer } from 'msw/node';
-import { TerraformCloudAPI, apiClient } from '../../../terraformCloud';
+import { TerraformCloudAPIURL, apiClient } from '../../../terraformCloud';
 
 type Api = typeof apiClient.api;
 
@@ -14,7 +14,7 @@ export function mockGet<Path extends ZodiosPathsByMethod<Api, 'get'>>(
   path: Path,
   resolver: ResponseResolver<RestRequest, RestContext, Awaited<ZodiosResponseByPath<Api, 'get', Path>>>,
 ) {
-  return rest.get(`${TerraformCloudAPI}${path}`, resolver);
+  return rest.get(`${TerraformCloudAPIURL}${path}`, resolver);
 }
 
 const handlers = [


### PR DESCRIPTION
This creates an exported constant for the Terraform Cloud Web URL and replaces all hardcoded references.
