### PR TITLE
TFC: Fix missing context key & account for pending org invitations

### DIFF
--- a/package.json
+++ b/package.json
@@ -689,7 +689,12 @@
       {
         "view": "terraform.cloud.workspaces",
         "contents": "There are no workspaces in this organization.\n[Create a new workspace](command:terraform.cloud.workspaces.picker)\n[Choose a different organization](command:terraform.cloud.organization.picker)",
-        "when": "terraform.cloud.signed-in && terraform.cloud.organizationsExist && terraform.cloud.organizationsChosen && !terraform.cloud.projectFilterUsed && !terraform.cloud.workspacesExist"
+        "when": "terraform.cloud.signed-in && terraform.cloud.organizationsExist && terraform.cloud.organizationsChosen && !terraform.cloud.projectFilterUsed && !terraform.cloud.workspacesExist && !terraform.cloud.pendingOrgMembership"
+      },
+      {
+        "view": "terraform.cloud.workspaces",
+        "contents": "You have not yet accepted the invitation to this organization.\n[See pending invitation](command:terraform.cloud.organization.viewInBrowser)\n[Choose a different organization](command:terraform.cloud.organization.picker)",
+        "when": "terraform.cloud.signed-in && terraform.cloud.organizationsExist && terraform.cloud.organizationsChosen && !terraform.cloud.projectFilterUsed && !terraform.cloud.workspacesExist && terraform.cloud.pendingOrgMembership"
       },
       {
         "view": "terraform.cloud.workspaces",

--- a/src/providers/tfc/workspaceProvider.ts
+++ b/src/providers/tfc/workspaceProvider.ts
@@ -142,6 +142,9 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
         },
       });
 
+      // We can imply organization existence based on 200 OK (i.e. not 404) here
+      vscode.commands.executeCommand('setContext', 'terraform.cloud.organizationsExist', true);
+
       const workspaces = workspaceResponse.data;
       if (workspaces.length <= 0) {
         await vscode.commands.executeCommand('setContext', 'terraform.cloud.workspacesExist', false);
@@ -192,6 +195,7 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<Worksp
         }
 
         if (error.response?.status === 404) {
+          vscode.commands.executeCommand('setContext', 'terraform.cloud.organizationsExist', false);
           vscode.window.showWarningMessage(`Organization '${organization}' not found, please pick another one`);
           vscode.commands.executeCommand('terraform.cloud.organization.picker');
           return [];


### PR DESCRIPTION
This fixes two problems.

Previously, if the org picker was never shown, the `terraform.cloud.organizationsExist` key would be missing from the context, resulting in empty workspaces view:

![Screenshot 2023-06-20 at 12 03 54](https://github.com/hashicorp/vscode-terraform/assets/287584/f9dcd84f-26a0-4a7b-b766-edb7f147d42e)

Setting the key from within the workspace view based on some logical assumptions brings back the expected welcome view:

![Screenshot 2023-06-20 at 12 01 48](https://github.com/hashicorp/vscode-terraform/assets/287584/85ff15cf-0831-48c0-9b9a-d0adc3cbe783)

Secondly if the user picks an org which they have still pending invitation for, we'd just display no workspaces with no more context (as above). Now we check for memberships and show a separate new welcome view in such a case:

![Screenshot 2023-06-20 at 12 05 00](https://github.com/hashicorp/vscode-terraform/assets/287584/92d32494-25bf-4a27-ad39-e1acf3f5beb2)
