### PR TITLE
TFC: bump LS version to 0.31.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "vscode": "^1.75.1"
   },
   "langServer": {
-    "version": "0.31.2"
+    "version": "0.31.3"
   },
   "syntax": {
     "version": "0.4.1"


### PR DESCRIPTION
This is to bring the following enhancements: https://github.com/hashicorp/terraform-ls/releases/tag/v0.31.3

I raised https://github.com/hashicorp/vscode-terraform/pull/1503 with the same change to target `main` and we can update https://github.com/hashicorp/vscode-terraform/pull/1501 once this is merged to reflect the changes.