### PR TITLE
bump LS version to 0.31.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "vscode": "^1.75.1"
   },
   "langServer": {
-    "version": "0.31.2"
+    "version": "0.31.3"
   },
   "syntax": {
     "version": "0.4.1"


### PR DESCRIPTION
This is to complement https://github.com/hashicorp/vscode-terraform/pull/1502 (which targets `f-tfc` branch)

It brings in the following enhancements: https://github.com/hashicorp/terraform-ls/releases/tag/v0.31.3

We can update the changelog in `main` as we get closer to a stable release.