### PR TITLE
Set codelensReferenceCount to experimental

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Completing the snippet allows you to tab complete through each attribute and blo
 Display reference counts above top level blocks and attributes
 
 ```json
-"terraform.codelens.referenceCount": true
+"terraform.experimentalFeatures.codelensReferenceCount": true
 ```
 
 ![](docs/code_lens.png)

--- a/package.json
+++ b/package.json
@@ -277,14 +277,7 @@
       {
         "title": "General",
         "order": 0,
-        "properties": {
-          "terraform.codelens.referenceCount": {
-            "scope": "window",
-            "type": "boolean",
-            "default": false,
-            "description": "Display reference counts above top level blocks and attributes."
-          }
-        }
+        "properties": {}
       },
       {
         "title": "Language Server",
@@ -381,6 +374,12 @@
         "title": "Experimental Features",
         "order": 4,
         "properties": {
+          "terraform.experimentalFeatures.codelensReferenceCount": {
+            "scope": "window",
+            "type": "boolean",
+            "default": false,
+            "description": "Display reference counts above top level blocks and attributes."
+          },
           "terraform.experimentalFeatures.validateOnSave": {
             "description": "Enable validating the currently open file on save",
             "scope": "window",

--- a/src/features/showReferences.ts
+++ b/src/features/showReferences.ts
@@ -31,7 +31,7 @@ const VSCODE_SHOW_REFERENCES = 'editor.action.showReferences';
 
 export class ShowReferencesFeature implements StaticFeature {
   private registeredCommands: vscode.Disposable[] = [];
-  private isEnabled = config('terraform').get<boolean>('codelens.referenceCount', false);
+  private isEnabled = config('terraform').get<boolean>('experimentalFeatures.codelensReferenceCount', false);
 
   constructor(private _client: BaseLanguageClient) {}
 

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -24,6 +24,7 @@ export interface IndexingOptions {
 }
 
 export interface ExperimentalFeatures {
+  codelensReferenceCount: boolean;
   validateOnSave: boolean;
   prefillRequiredFields: boolean;
 }


### PR DESCRIPTION
This moves the `terraform.codelens.referenceCount` setting to `terraform.experimentalFeatures.codelensReferenceCount` to properly reflect the experimental nature of this setting.

While terraform.codelens.referenceCount was set to false and declared to be experimental in the README, it was not marked as experimental in the name of the setting. We have been seeing reports of usage where it has been affecting performance and want to ensure that users are opting in with intent to test usage of this feature.

When this feature moves to stable, the previous setting name can return.

Needs https://github.com/hashicorp/terraform-ls/pull/1331
