### PR TITLE
Language Status indicator

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,10 +28,12 @@ import { ShowReferencesFeature } from './features/showReferences';
 import { CustomSemanticTokens } from './features/semanticTokens';
 import { ModuleProvidersFeature } from './features/moduleProviders';
 import { ModuleCallsFeature } from './features/moduleCalls';
+import { TerraformVersionFeature } from './features/terraformVersion';
+import { LanguageStatusFeature } from './features/languageStatus';
 import { getInitializationOptions } from './settings';
 import { TerraformLSCommands } from './commands/terraformls';
 import { TerraformCommands } from './commands/terraform';
-import { TerraformVersionFeature } from './features/terraformVersion';
+import * as lsStatus from './status/language';
 
 const id = 'terraform';
 const brand = `HashiCorp Terraform`;
@@ -69,6 +71,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
 
   const clientOptions: LanguageClientOptions = {
     documentSelector: documentSelector,
+    progressOnInitialization: true,
     synchronize: {
       fileEvents: [
         vscode.workspace.createFileSystemWatcher('**/*.tf'),
@@ -176,12 +179,22 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   client = new LanguageClient(id, serverOptions, clientOptions);
   client.onDidChangeState((event) => {
     outputChannel.appendLine(`Client: ${State[event.oldState]} --> ${State[event.newState]}`);
-    if (event.newState === State.Stopped) {
-      reporter.sendTelemetryEvent('stopClient');
+    switch (event.newState) {
+      case State.Starting:
+        lsStatus.setLanguageServerStarting();
+        break;
+      case State.Running:
+        lsStatus.setLanguageServerRunning();
+        break;
+      case State.Stopped:
+        lsStatus.setLanguageServerStopped();
+        reporter.sendTelemetryEvent('stopClient');
+        break;
     }
   });
 
   client.registerFeatures([
+    new LanguageStatusFeature(client, reporter, outputChannel),
     new CustomSemanticTokens(client, manifest),
     new ModuleProvidersFeature(client, new ModuleProvidersDataProvider(context, client, reporter)),
     new ModuleCallsFeature(client, new ModuleCallsDataProvider(context, client, reporter)),
@@ -194,17 +207,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   context.subscriptions.push(new GenerateBugReportCommand(context), new TerraformCommands(client, reporter));
 
   try {
-    outputChannel.appendLine('Starting client');
-
     await client.start();
-
-    reporter.sendTelemetryEvent('startClient');
-
-    const initializeResult = client.initializeResult;
-    if (initializeResult !== undefined) {
-      const multiFoldersSupported = initializeResult.capabilities.workspace?.workspaceFolders?.supported;
-      outputChannel.appendLine(`Multi-folder support: ${multiFoldersSupported}`);
-    }
   } catch (error) {
     await handleLanguageClientStartError(error, context, reporter);
   }
@@ -218,10 +221,12 @@ export async function deactivate(): Promise<void> {
       outputChannel.appendLine(error.message);
       reporter.sendTelemetryException(error);
       vscode.window.showErrorMessage(error.message);
+      lsStatus.setLanguageServerState(error.message, false, vscode.LanguageStatusSeverity.Error);
     } else if (typeof error === 'string') {
       outputChannel.appendLine(error);
       reporter.sendTelemetryException(new Error(error));
       vscode.window.showErrorMessage(error);
+      lsStatus.setLanguageServerState(error, false, vscode.LanguageStatusSeverity.Error);
     }
   }
 }

--- a/src/features/languageStatus.ts
+++ b/src/features/languageStatus.ts
@@ -1,0 +1,49 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import * as vscode from 'vscode';
+import TelemetryReporter from '@vscode/extension-telemetry';
+import { BaseLanguageClient, ClientCapabilities, FeatureState, StaticFeature } from 'vscode-languageclient';
+
+import { ExperimentalClientCapabilities } from './types';
+import * as lsStatus from '../status/language';
+
+export class LanguageStatusFeature implements StaticFeature {
+  private disposables: vscode.Disposable[] = [];
+
+  constructor(
+    private client: BaseLanguageClient,
+    private reporter: TelemetryReporter,
+    private outputChannel: vscode.OutputChannel,
+  ) {}
+
+  getState(): FeatureState {
+    return {
+      kind: 'static',
+    };
+  }
+
+  public fillClientCapabilities(capabilities: ClientCapabilities & ExperimentalClientCapabilities): void {
+    if (!capabilities['experimental']) {
+      capabilities['experimental'] = {};
+    }
+  }
+
+  public initialize(): void {
+    this.reporter.sendTelemetryEvent('startClient');
+    this.outputChannel.appendLine('Started client');
+
+    const initializeResult = this.client.initializeResult;
+    if (initializeResult === undefined) {
+      return;
+    }
+
+    lsStatus.setVersion(initializeResult.serverInfo?.version ?? '');
+  }
+
+  public dispose(): void {
+    this.disposables.forEach((d: vscode.Disposable) => d.dispose());
+  }
+}

--- a/src/features/terraformVersion.ts
+++ b/src/features/terraformVersion.ts
@@ -52,8 +52,8 @@ export class TerraformVersionFeature implements StaticFeature {
       const moduleDir = Utils.dirname(editor.document.uri);
 
       try {
-        versionStatus.Waiting();
-        requiredVersionStatus.Waiting();
+        versionStatus.setWaiting();
+        requiredVersionStatus.setWaiting();
 
         lsStatus.setLanguageServerBusy();
 
@@ -62,8 +62,8 @@ export class TerraformVersionFeature implements StaticFeature {
         requiredVersionStatus.setVersion(response.required_version || 'any');
 
         lsStatus.setLanguageServerRunning();
-        versionStatus.Ready();
-        requiredVersionStatus.Ready();
+        versionStatus.setReady();
+        requiredVersionStatus.setReady();
       } catch (error) {
         let message = 'Unknown Error';
         if (error instanceof Error) {
@@ -82,8 +82,8 @@ export class TerraformVersionFeature implements StaticFeature {
         this.outputChannel.appendLine(message);
 
         lsStatus.setLanguageServerRunning();
-        versionStatus.Ready();
-        requiredVersionStatus.Ready();
+        versionStatus.setReady();
+        requiredVersionStatus.setReady();
       }
     });
 

--- a/src/features/terraformVersion.ts
+++ b/src/features/terraformVersion.ts
@@ -11,35 +11,20 @@ import { ExperimentalClientCapabilities } from './types';
 import { Utils } from 'vscode-uri';
 import TelemetryReporter from '@vscode/extension-telemetry';
 import { LanguageClient } from 'vscode-languageclient/node';
+import * as lsStatus from '../status/language';
+import * as versionStatus from '../status/installedVersion';
+import * as requiredVersionStatus from '../status/requiredVersion';
 
 export class TerraformVersionFeature implements StaticFeature {
   private disposables: vscode.Disposable[] = [];
 
   private clientTerraformVersionCommandId = 'client.refreshTerraformVersion';
 
-  private installedVersion = vscode.languages.createLanguageStatusItem('terraform.installedVersion', [
-    { language: 'terraform' },
-    { language: 'terraform-vars' },
-  ]);
-  private requiredVersion = vscode.languages.createLanguageStatusItem('terraform.requiredVersion', [
-    { language: 'terraform' },
-    { language: 'terraform-vars' },
-  ]);
-
   constructor(
     private client: LanguageClient,
     private reporter: TelemetryReporter,
     private outputChannel: vscode.OutputChannel,
-  ) {
-    this.installedVersion.name = 'TerraformInstalledVersion';
-    this.installedVersion.detail = 'Installed Version';
-
-    this.requiredVersion.name = 'TerraformRequiredVersion';
-    this.requiredVersion.detail = 'Required Version';
-
-    this.disposables.push(this.installedVersion);
-    this.disposables.push(this.requiredVersion);
-  }
+  ) {}
 
   getState(): FeatureState {
     return {
@@ -67,9 +52,18 @@ export class TerraformVersionFeature implements StaticFeature {
       const moduleDir = Utils.dirname(editor.document.uri);
 
       try {
+        versionStatus.Waiting();
+        requiredVersionStatus.Waiting();
+
+        lsStatus.setLanguageServerBusy();
+
         const response = await terraform.terraformVersion(moduleDir.toString(), this.client, this.reporter);
-        this.installedVersion.text = response.discovered_version || 'unknown';
-        this.requiredVersion.text = response.required_version || 'any';
+        versionStatus.setVersion(response.discovered_version || 'unknown');
+        requiredVersionStatus.setVersion(response.required_version || 'unknown');
+
+        lsStatus.setLanguageServerRunning();
+        versionStatus.Ready();
+        requiredVersionStatus.Ready();
       } catch (error) {
         let message = 'Unknown Error';
         if (error instanceof Error) {
@@ -86,6 +80,10 @@ export class TerraformVersionFeature implements StaticFeature {
          see this errored here.
         */
         this.outputChannel.appendLine(message);
+
+        lsStatus.setLanguageServerRunning();
+        versionStatus.Ready();
+        requiredVersionStatus.Ready();
       }
     });
 

--- a/src/features/terraformVersion.ts
+++ b/src/features/terraformVersion.ts
@@ -59,7 +59,7 @@ export class TerraformVersionFeature implements StaticFeature {
 
         const response = await terraform.terraformVersion(moduleDir.toString(), this.client, this.reporter);
         versionStatus.setVersion(response.discovered_version || 'unknown');
-        requiredVersionStatus.setVersion(response.required_version || 'unknown');
+        requiredVersionStatus.setVersion(response.required_version || 'any');
 
         lsStatus.setLanguageServerRunning();
         versionStatus.Ready();

--- a/src/status/installedVersion.ts
+++ b/src/status/installedVersion.ts
@@ -16,10 +16,10 @@ export function setVersion(version: string) {
   installedVersion.text = version;
 }
 
-export function Ready() {
+export function setReady() {
   installedVersion.busy = false;
 }
 
-export function Waiting() {
+export function setWaiting() {
   installedVersion.busy = true;
 }

--- a/src/status/installedVersion.ts
+++ b/src/status/installedVersion.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import * as vscode from 'vscode';
+
+const installedVersion = vscode.languages.createLanguageStatusItem('terraform.installedVersion', [
+  { language: 'terraform' },
+  { language: 'terraform-vars' },
+]);
+installedVersion.name = 'TerraformInstalledVersion';
+installedVersion.detail = 'Terraform Installed';
+
+export function setVersion(version: string) {
+  installedVersion.text = version;
+}
+
+export function Ready() {
+  installedVersion.busy = false;
+}
+
+export function Waiting() {
+  installedVersion.busy = true;
+}

--- a/src/status/language.ts
+++ b/src/status/language.ts
@@ -1,0 +1,50 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import * as vscode from 'vscode';
+
+const lsStatus = vscode.languages.createLanguageStatusItem('terraform-ls.status', [
+  { language: 'terraform' },
+  { language: 'terraform-vars' },
+]);
+lsStatus.name = 'Terraform LS';
+lsStatus.detail = 'Terraform LS';
+
+export function setVersion(version: string) {
+  lsStatus.text = version;
+}
+
+export function setLanguageServerRunning() {
+  lsStatus.busy = false;
+}
+
+export function setLanguageServerReady() {
+  lsStatus.busy = false;
+}
+
+export function setLanguageServerStarting() {
+  lsStatus.busy = true;
+}
+
+export function setLanguageServerBusy() {
+  lsStatus.busy = true;
+}
+
+export function setLanguageServerStopped() {
+  // this makes the statusItem a different color in the bar
+  // and triggers an alert, so the user 'sees' that the LS is stopped
+  lsStatus.severity = vscode.LanguageStatusSeverity.Warning;
+  lsStatus.busy = false;
+}
+
+export function setLanguageServerState(
+  detail: string,
+  busy: boolean,
+  severity: vscode.LanguageStatusSeverity = vscode.LanguageStatusSeverity.Information,
+) {
+  lsStatus.busy = busy;
+  lsStatus.detail = detail;
+  lsStatus.severity = severity;
+}

--- a/src/status/requiredVersion.ts
+++ b/src/status/requiredVersion.ts
@@ -1,0 +1,25 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import * as vscode from 'vscode';
+
+const requiredVersion = vscode.languages.createLanguageStatusItem('terraform.requiredVersion', [
+  { language: 'terraform' },
+  { language: 'terraform-vars' },
+]);
+requiredVersion.name = 'TerraformRequiredVersion';
+requiredVersion.detail = 'Terraform Required';
+
+export function setVersion(version: string) {
+  requiredVersion.text = version;
+}
+
+export function Ready() {
+  requiredVersion.busy = false;
+}
+
+export function Waiting() {
+  requiredVersion.busy = true;
+}

--- a/src/status/requiredVersion.ts
+++ b/src/status/requiredVersion.ts
@@ -16,10 +16,10 @@ export function setVersion(version: string) {
   requiredVersion.text = version;
 }
 
-export function Ready() {
+export function setReady() {
   requiredVersion.busy = false;
 }
 
-export function Waiting() {
+export function setWaiting() {
   requiredVersion.busy = true;
 }


### PR DESCRIPTION
This sets a busy status when finding out the terraform version, which approximates a loading status for the extension because the request for status happens after all the other requests happen "in the background". So, we get a loading bar for the extension in the lower right hand corner.


https://github.com/hashicorp/vscode-terraform/assets/272569/e3472dd4-97d1-43c1-9124-d1bd173ab7c0
