### PR TITLE
Explicitly set diagnosticCollectionName

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -75,6 +75,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.workspace.createFileSystemWatcher('**/*.tfvars'),
       ],
     },
+    diagnosticCollectionName: 'HashiCorpTerraform',
     outputChannel: outputChannel,
     revealOutputChannelOn: RevealOutputChannelOn.Never,
     initializationOptions: initializationOptions,


### PR DESCRIPTION
In general VS Code is supposed to allow multiple extensions to provide diagnositics for a file without collision. There are [reported cases](https://github.com/sourcery-ai/sourcery-vscode/issues/121) where multiple extensions that claim support for the same language overwrite diagnositics. To avoid this, we can set diagnosticCollectionName explicitly and create our own collection.

While we haven't specifically seen this happen for us, it may have happened and we are not the only ones to set it explicitly.

Reference: https://github.com/microsoft/vscode-languageserver-node/blob/f2ff7d55464a1f58f978cb6635bd8865f050553c/client/src/common/client.ts#L1080-L1084
