### PR TITLE
Do not prompt for TFC authentication

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -32,7 +32,6 @@ import { getInitializationOptions } from './settings';
 import { TerraformLSCommands } from './commands/terraformls';
 import { TerraformCommands } from './commands/terraform';
 import { TerraformVersionFeature } from './features/terraformVersion';
-import { TerraformCloudAuthenticationProvider } from './providers/authenticationProvider';
 import { TerraformCloudFeature } from './features/terraformCloud';
 
 const id = 'terraform';
@@ -58,11 +57,6 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
   context.subscriptions.push(new TerraformLSCommands());
 
   context.subscriptions.push(new TerraformCloudFeature(context, reporter, tfcOutputChannel));
-  // This triggers a badge to appear in the User Account icon.
-  // TODO: remove this when workspace views land
-  await vscode.authentication.getSession(TerraformCloudAuthenticationProvider.providerID, [], {
-    createIfNone: false,
-  });
 
   if (config('terraform').get<boolean>('languageServer.enable') === false) {
     reporter.sendTelemetryEvent('disabledTerraformLS');


### PR DESCRIPTION
This removes the badge on the User Account icon prompting to login to TFC on extension activation. They will no longer be prompted to login unless they click on the Terraform Cloud sidebar. A user can already additionally choose to hide the Terraform Clound sidebar icon and not see any mention of TFC.

Previously the extension would check if there was an existing login session, and if none was found would add a badge to the User Account icon indicating the user should login. This provided two opportunities for the user to see how to login, but would prompt users who did not want to use TFC anyway. By disabling this we lose the second way, but gain control of when the login prompt is displayed.
