### PR TITLE
Standardize text casing in TFC views

### DIFF
--- a/package.json
+++ b/package.json
@@ -473,7 +473,7 @@
       },
       {
         "command": "terraform.cloud.workspaces.viewInBrowser",
-        "title": "View Workspace",
+        "title": "View workspace",
         "icon": "$(globe)"
       },
       {
@@ -483,22 +483,22 @@
       },
       {
         "command": "terraform.cloud.run.viewInBrowser",
-        "title": "View Run",
+        "title": "View run",
         "icon": "$(globe)"
       },
       {
         "command": "terraform.cloud.run.plan.downloadLog",
-        "title": "View Raw Plan Log",
+        "title": "View raw plan log",
         "icon": "$(book)"
       },
       {
         "command": "terraform.cloud.run.apply.downloadLog",
-        "title": "View Raw Apply Log",
+        "title": "View raw apply log",
         "icon": "$(output)"
       },
       {
         "command": "terraform.cloud.workspaces.filterByProject",
-        "title": "Filter by Project",
+        "title": "Filter by project",
         "icon": "$(filter)"
       }
     ],
@@ -639,12 +639,12 @@
         {
           "id": "terraform.cloud.workspaces",
           "name": "Workspaces",
-          "contextualTitle": "Terraform Cloud Workspaces"
+          "contextualTitle": "Terraform Cloud workspaces"
         },
         {
           "id": "terraform.cloud.runs",
           "name": "Runs",
-          "contextualTitle": "Terraform Cloud Runs"
+          "contextualTitle": "Terraform Cloud runs"
         }
       ]
     },
@@ -673,12 +673,12 @@
       },
       {
         "view": "terraform.cloud.workspaces",
-        "contents": "In order to use Terraform Cloud features, you need to be logged in.\n[Login to Terraform Cloud](command:terraform.cloud.login)",
+        "contents": "In order to use Terraform Cloud features, you need to be logged in\n[Login to Terraform Cloud](command:terraform.cloud.login)",
         "when": "terraform.cloud.signed-in === false"
       },
       {
         "view": "terraform.cloud.workspaces",
-        "contents": "No organizations found for this token. Please create a new Terraform Cloud organization to get started:\n[Create or select an organization](command:terraform.cloud.organization.picker)",
+        "contents": "No organizations found for this token. Please create a new Terraform Cloud organization to get started\n[Create or select an organization](command:terraform.cloud.organization.picker)",
         "when": "terraform.cloud.signed-in && !terraform.cloud.organizationsExist && !terraform.cloud.organizationsChosen"
       },
       {
@@ -693,17 +693,17 @@
       },
       {
         "view": "terraform.cloud.workspaces",
-        "contents": "You have not yet accepted the invitation to this organization.\n[See pending invitation](command:terraform.cloud.organization.viewInBrowser)\n[Choose a different organization](command:terraform.cloud.organization.picker)",
+        "contents": "You have not yet accepted the invitation to this organization\n[See pending invitations](command:terraform.cloud.organization.viewInBrowser)\n[Choose a different organization](command:terraform.cloud.organization.picker)",
         "when": "terraform.cloud.signed-in && terraform.cloud.organizationsExist && terraform.cloud.organizationsChosen && !terraform.cloud.projectFilterUsed && !terraform.cloud.workspacesExist && terraform.cloud.pendingOrgMembership"
       },
       {
         "view": "terraform.cloud.workspaces",
-        "contents": "There are no workspaces in this project.\n[Create a new workspace](command:terraform.cloud.workspaces.picker)\n[Clear filter](command:terraform.cloud.workspaces.resetProjectFilter)",
+        "contents": "There are no workspaces in this project\n[Create a new workspace](command:terraform.cloud.workspaces.picker)\n[Clear filter](command:terraform.cloud.workspaces.resetProjectFilter)",
         "when": "terraform.cloud.signed-in && terraform.cloud.organizationsExist && terraform.cloud.organizationsChosen && terraform.cloud.projectFilterUsed && !terraform.cloud.workspacesExist"
       },
       {
         "view": "terraform.cloud.runs",
-        "contents": "Select a Workspace to view a list of runs"
+        "contents": "Select a workspace to view a list of runs"
       }
     ]
   },

--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -147,7 +147,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     try {
       const session = await this.sessionPromise;
       if (session) {
-        this.logger.info('Successfully fetched Terraform Cloud session.');
+        this.logger.info('Successfully fetched Terraform Cloud session');
         await vscode.commands.executeCommand('setContext', 'terraform.cloud.signed-in', true);
         return [session];
       } else {
@@ -171,8 +171,8 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     // Prompt for the UAT.
     const token = await this.promptForToken();
     if (!token) {
-      this.logger.error('User did not provide a UAT');
-      throw new Error('UAT is required');
+      this.logger.error('User did not provide a token');
+      throw new Error('Token is required');
     }
 
     try {
@@ -254,22 +254,22 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     const choice = await vscode.window.showQuickPick(
       [
         {
-          label: 'Stored User Token',
+          label: 'Stored user token',
           detail: 'Use a token stored in the Terraform CLI configuration file',
         },
         {
-          label: 'Existing User Token',
+          label: 'Existing user token',
           detail: 'Enter a token manually',
         },
         {
-          label: 'Open to generate a User token',
+          label: 'Generate a user token',
           detail: 'Open the Terraform Cloud website to generate a new token',
         },
       ],
       {
         canPickMany: false,
         ignoreFocusOut: true,
-        placeHolder: 'Choose a method to enter a Terraform Cloud User Token',
+        placeHolder: 'Choose a method to enter a Terraform Cloud user token',
         title: 'HashiCorp Terraform Cloud Authentication',
       },
     );
@@ -280,28 +280,28 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     const terraformCloudURL = `${TerraformCloudWebUrl}/settings/tokens?source=vscode-terraform`;
     let token: string | undefined;
     switch (choice.label) {
-      case 'Open to generate a User token':
+      case 'Generate a user token':
         this.reporter.sendTelemetryEvent('tfc-login', { method: 'browser' });
         await vscode.env.openExternal(vscode.Uri.parse(terraformCloudURL));
         // Prompt for the UAT.
         token = await vscode.window.showInputBox({
           ignoreFocusOut: true,
           placeHolder: 'User access token',
-          prompt: 'Enter an HashiCorp Terraform User Access Token (UAT).',
+          prompt: 'Enter an Terraform Cloud user access token',
           password: true,
         });
         break;
-      case 'Existing User Token':
+      case 'Existing user token':
         this.reporter.sendTelemetryEvent('tfc-login', { method: 'existing' });
         // Prompt for the UAT.
         token = await vscode.window.showInputBox({
           ignoreFocusOut: true,
           placeHolder: 'User access token',
-          prompt: 'Enter an HashiCorp Terraform User Access Token (UAT).',
+          prompt: 'Enter an Terraform Cloud user access token',
           password: true,
         });
         break;
-      case 'Stored User Token':
+      case 'Stored user token':
         this.reporter.sendTelemetryEvent('tfc-login', { method: 'stored' });
         token = await this.getTerraformCLIToken();
         break;

--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -287,7 +287,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
         token = await vscode.window.showInputBox({
           ignoreFocusOut: true,
           placeHolder: 'User access token',
-          prompt: 'Enter an Terraform Cloud user access token',
+          prompt: 'Enter a Terraform Cloud user access token',
           password: true,
         });
         break;
@@ -297,7 +297,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
         token = await vscode.window.showInputBox({
           ignoreFocusOut: true,
           placeHolder: 'User access token',
-          prompt: 'Enter an Terraform Cloud user access token',
+          prompt: 'Enter a Terraform Cloud user access token',
           password: true,
         });
         break;

--- a/src/providers/tfc/contentProvider.ts
+++ b/src/providers/tfc/contentProvider.ts
@@ -17,7 +17,7 @@ export class PlanLogContentProvider implements vscode.TextDocumentContentProvide
     try {
       const logUrl = await this.getLogUrl(uri);
       if (!logUrl) {
-        throw new Error('Unable to parse log Url');
+        throw new Error('Unable to parse log url');
       }
 
       const result = await axios.get<string>(logUrl, { headers: { Accept: 'text/plain' } });

--- a/src/providers/tfc/contentProvider.ts
+++ b/src/providers/tfc/contentProvider.ts
@@ -17,7 +17,7 @@ export class PlanLogContentProvider implements vscode.TextDocumentContentProvide
     try {
       const logUrl = await this.getLogUrl(uri);
       if (!logUrl) {
-        throw new Error('Unable to parse log url');
+        throw new Error('Unable to parse log URL');
       }
 
       const result = await axios.get<string>(logUrl, { headers: { Accept: 'text/plain' } });

--- a/src/providers/tfc/organizationPicker.ts
+++ b/src/providers/tfc/organizationPicker.ts
@@ -16,7 +16,7 @@ export class CreateOrganizationItem implements vscode.QuickPickItem {
   get label() {
     return '$(add) Create new organization';
   }
-  get description() {
+  get detail() {
     return 'Open the browser to create a new organization';
   }
   async open() {
@@ -31,7 +31,7 @@ export class RefreshOrganizationItem implements vscode.QuickPickItem {
   get label() {
     return '$(refresh) Refresh organizations';
   }
-  get description() {
+  get detail() {
     return 'Refetch all organizations';
   }
   get alwaysShow() {
@@ -49,7 +49,7 @@ class OrganizationItem implements vscode.QuickPickItem {
 export class OrganizationAPIResource implements APIResource {
   name = 'organizations';
   title = 'Welcome to Terraform Cloud';
-  placeholder = 'Choose an organization. Hit enter to select the first organization. (type to search)';
+  placeholder = 'Choose an organization (type to search)';
   ignoreFocusOut = true;
 
   constructor(private outputChannel: vscode.OutputChannel, private reporter: TelemetryReporter) {}

--- a/src/providers/tfc/workspaceFilters.ts
+++ b/src/providers/tfc/workspaceFilters.ts
@@ -36,7 +36,7 @@ class ProjectItem implements vscode.QuickPickItem {
 
 export class ProjectsAPIResource implements APIResource {
   name = 'projects';
-  title = 'Filter Workspaces';
+  title = 'Filter workspaces';
   placeholder = 'Select a project (type to search)';
 
   constructor(


### PR DESCRIPTION
- Choose Sentence case for most phrases
- Always properly capitalize HashiCorp, Terraform, Terraform Cloud, and other HashiCorp products
- Prefer using just 'Terraform Cloud' instead of 'HashiCorp Terraform Cloud'
- Do not capitalize TFC concepts like workspace or organization unless its the start of a phrase
- Do not put periods at the end of phrases in buttons, welcome views, messages
- Do not use colons or semi colons before buttons in welcome views

Exceptions:

- VS Code always capitalizes view titles
