### PR TITLE
Introduce a new setting for enhanced validation

### DIFF
--- a/package.json
+++ b/package.json
@@ -284,7 +284,7 @@
             "default": false,
             "description": "Display reference counts above top level blocks and attributes."
           },
-          "terraform.validation.earlyValidation": {
+          "terraform.validation.enableEnhancedValidation": {
             "scope": "window",
             "type": "boolean",
             "default": true,

--- a/package.json
+++ b/package.json
@@ -288,7 +288,7 @@
             "scope": "window",
             "type": "boolean",
             "default": true,
-            "description": "Enable early validation of Terraform files and modules"
+            "description": "Enable enhanced validation of Terraform files and modules"
           }
         }
       },

--- a/package.json
+++ b/package.json
@@ -283,6 +283,12 @@
             "type": "boolean",
             "default": false,
             "description": "Display reference counts above top level blocks and attributes."
+          },
+          "terraform.validation.earlyValidation": {
+            "scope": "window",
+            "type": "boolean",
+            "default": true,
+            "description": "Enable early validation of Terraform files and modules"
           }
         }
       },

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -30,7 +30,7 @@ export interface ExperimentalFeatures {
 }
 
 export interface ValidationOptions {
-  earlyValidation: boolean;
+  enableEnhancedValidation: boolean;
 }
 
 export function getInitializationOptions() {
@@ -40,7 +40,7 @@ export function getInitializationOptions() {
     we tackle #791
   */
   const validation = config('terraform').get<ValidationOptions>('validation', {
-    earlyValidation: true,
+    enableEnhancedValidation: true,
   });
   const terraform = config('terraform').get<TerraformOptions>('languageServer.terraform', {
     path: '',

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -10,6 +10,7 @@ export interface InitializationOptions {
   experimentalFeatures?: ExperimentalFeatures;
   ignoreSingleFileWarning?: boolean;
   terraform?: TerraformOptions;
+  validation?: ValidationOptions;
 }
 
 export interface TerraformOptions {
@@ -28,12 +29,19 @@ export interface ExperimentalFeatures {
   prefillRequiredFields: boolean;
 }
 
+export interface ValidationOptions {
+  earlyValidation: boolean;
+}
+
 export function getInitializationOptions() {
   /*
     This is basically a set of settings masquerading as a function. The intention
     here is to make room for this to be added to a configuration builder when
     we tackle #791
   */
+  const validation = config('terraform').get<ValidationOptions>('validation', {
+    earlyValidation: true,
+  });
   const terraform = config('terraform').get<TerraformOptions>('languageServer.terraform', {
     path: '',
     timeout: '',
@@ -55,6 +63,7 @@ export function getInitializationOptions() {
   }
 
   const initializationOptions: InitializationOptions = {
+    validation,
     experimentalFeatures,
     ignoreSingleFileWarning,
     terraform,


### PR DESCRIPTION
Adds `terraform.validation.enableEnhancedValidation` setting to the initializationOptions sent to terraform-ls.

I chose to use `terraform.validation` as we expect to add future settings for this feature.

This relies on functionality to be added to terraform-ls to parse the new setting.
