### PR TITLE
deps: Bump js-releases to 1.7.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -764,14 +764,14 @@
       }
     },
     "node_modules/@hashicorp/js-releases": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/js-releases/-/js-releases-1.6.1.tgz",
-      "integrity": "sha512-eb8NgI+oTrQ1BWioenKSCH8a90uLngeaVkyMOXofPLPcShJwhc/AAJpzP5AZoYCGrbt1nVJmFGgjUrS858YLBw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/js-releases/-/js-releases-1.7.0.tgz",
+      "integrity": "sha512-ONeN2lH5qeZU+wK32CschZEPe+NB9ypGzsfCpEQgA87oGMEkWX66s95bLYN4ff+WirBWYvyvHxGLT1MWbj/m9A==",
       "dev": true,
       "dependencies": {
         "axios": "^0.25.0",
         "https-proxy-agent": "^5.0.1",
-        "openpgp": "5.1.0",
+        "openpgp": "^5.5.0",
         "semver": "^7.3.5",
         "yauzl": "^2.10.0"
       }
@@ -7571,9 +7571,9 @@
       "dev": true
     },
     "node_modules/openpgp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-5.1.0.tgz",
-      "integrity": "sha512-keCno6QPMXWwfjrOOtT8fwZ5XgCcB7vZH80xb44SbJ49qQ11Efl2fFfqHpaie7jTQFjRKxgT8hSFPXJUjogNPw==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-5.10.1.tgz",
+      "integrity": "sha512-SR5Ft+ej51d0+p53ld5Ney0Yiz0y8Mh1YYLJrvpRMbTaNhvS1QcDX0Oq1rW9sjBnQXtgrpWw2Zve3rm7K5C/pw==",
       "dev": true,
       "dependencies": {
         "asn1.js": "^5.0.0"
@@ -10557,14 +10557,14 @@
       "dev": true
     },
     "@hashicorp/js-releases": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/@hashicorp/js-releases/-/js-releases-1.6.1.tgz",
-      "integrity": "sha512-eb8NgI+oTrQ1BWioenKSCH8a90uLngeaVkyMOXofPLPcShJwhc/AAJpzP5AZoYCGrbt1nVJmFGgjUrS858YLBw==",
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/@hashicorp/js-releases/-/js-releases-1.7.0.tgz",
+      "integrity": "sha512-ONeN2lH5qeZU+wK32CschZEPe+NB9ypGzsfCpEQgA87oGMEkWX66s95bLYN4ff+WirBWYvyvHxGLT1MWbj/m9A==",
       "dev": true,
       "requires": {
         "axios": "^0.25.0",
         "https-proxy-agent": "^5.0.1",
-        "openpgp": "5.1.0",
+        "openpgp": "^5.5.0",
         "semver": "^7.3.5",
         "yauzl": "^2.10.0"
       }
@@ -15736,9 +15736,9 @@
       "dev": true
     },
     "openpgp": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-5.1.0.tgz",
-      "integrity": "sha512-keCno6QPMXWwfjrOOtT8fwZ5XgCcB7vZH80xb44SbJ49qQ11Efl2fFfqHpaie7jTQFjRKxgT8hSFPXJUjogNPw==",
+      "version": "5.10.1",
+      "resolved": "https://registry.npmjs.org/openpgp/-/openpgp-5.10.1.tgz",
+      "integrity": "sha512-SR5Ft+ej51d0+p53ld5Ney0Yiz0y8Mh1YYLJrvpRMbTaNhvS1QcDX0Oq1rW9sjBnQXtgrpWw2Zve3rm7K5C/pw==",
       "dev": true,
       "requires": {
         "asn1.js": "^5.0.0"


### PR DESCRIPTION
This also updates a transitive dependency `openpgp` to `5.10.1`, which should in turn address https://github.com/advisories/GHSA-ch3c-v47x-4pgp

While this was flagged as security alert my understanding is that it doesn't impact us (or our users) in any way, because `js-releases` does not use `readCleartextMessage` nor `verifyCleartextMessage` as per https://github.com/hashicorp/js-releases/blob/6b64ff2a17be14820d7cdef5fad8d45645e83a80/src/index.ts#L215-L231