### PR TITLE
Bump Terraform version in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -89,7 +89,7 @@ jobs:
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_wrapper: false
-          terraform_version: '~1.1'
+          terraform_version: '~1.5'
       - name: Terraform version
         run: terraform version
       - name: Clean Install Dependencies

--- a/src/test/integration/completion.test.ts
+++ b/src/test/integration/completion.test.ts
@@ -15,7 +15,9 @@ suite('completion', () => {
 
   test('simple completion', async () => {
     const wanted = new vscode.CompletionList([
+      new vscode.CompletionItem('check', vscode.CompletionItemKind.Class),
       new vscode.CompletionItem('data', vscode.CompletionItemKind.Class),
+      new vscode.CompletionItem('import', vscode.CompletionItemKind.Class),
       new vscode.CompletionItem('locals', vscode.CompletionItemKind.Class),
       new vscode.CompletionItem('module', vscode.CompletionItemKind.Class),
       new vscode.CompletionItem('moved', vscode.CompletionItemKind.Class),


### PR DESCRIPTION
This PR bumps the Terraform version used in the tests from `1.1` to `1.5`. This is more inline with our development environments.