### PR TITLE
Add sleep to code action test

### DIFF
--- a/src/test/integration/codeAction.test.ts
+++ b/src/test/integration/codeAction.test.ts
@@ -29,6 +29,9 @@ suite('code actions', () => {
       new vscode.CodeAction('Format Document', vscode.CodeActionKind.Source.append('formatAll').append('terraform')),
     ];
 
+    // wait till the LS is ready to acccept a code action request
+    await sleep(1000);
+
     for (let index = 0; index < supported.length; index++) {
       const wanted = supported[index];
       const requested = wanted.kind?.value.toString();
@@ -50,3 +53,9 @@ suite('code actions', () => {
     }
   });
 });
+
+function sleep(ms: number) {
+  return new Promise((resolve) => {
+    setTimeout(resolve, ms);
+  });
+}

--- a/src/test/integration/codeAction.test.ts
+++ b/src/test/integration/codeAction.test.ts
@@ -30,7 +30,7 @@ suite('code actions', () => {
     ];
 
     // wait till the LS is ready to acccept a code action request
-    await sleep(1000);
+    await new Promise((r) => setTimeout(r, 1000));
 
     for (let index = 0; index < supported.length; index++) {
       const wanted = supported[index];
@@ -53,9 +53,3 @@ suite('code actions', () => {
     }
   });
 });
-
-function sleep(ms: number) {
-  return new Promise((resolve) => {
-    setTimeout(resolve, ms);
-  });
-}


### PR DESCRIPTION
The test for code actions can take slightlty longer to activate terraform-ls than the method open() accounts for. This adds a sleep to ensure that it's activated before we attempt to ask for supported code actions.
