### PR TITLE
Prepare for 2.28.0 release

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terraform",
-  "version": "2.27.2",
+  "version": "2.28.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "terraform",
-      "version": "2.27.2",
+      "version": "2.28.0",
       "license": "MPL-2.0",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.4.9",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "terraform",
   "displayName": "HashiCorp Terraform",
   "description": "Syntax highlighting and autocompletion for Terraform",
-  "version": "2.27.2",
+  "version": "2.28.0",
   "publisher": "hashicorp",
   "appInsightsKey": "885372d2-6f3c-499f-9d25-b8b219983a52",
   "license": "MPL-2.0",
@@ -18,7 +18,7 @@
     "vscode": "^1.75.1"
   },
   "langServer": {
-    "version": "0.31.5"
+    "version": "0.32.0"
   },
   "syntax": {
     "version": "0.4.2"


### PR DESCRIPTION
This should only be merged when LS 0.32.0 is actually released, at which point the tests can re-run and should be green.