### PR TITLE
Add TFC workspace pagination

### DIFF
--- a/package.json
+++ b/package.json
@@ -610,7 +610,7 @@
         },
         {
           "command": "terraform.cloud.workspaces.viewInBrowser",
-          "when": "view == terraform.cloud.workspaces",
+          "when": "view == terraform.cloud.workspaces && viewItem =~ /hasLink/",
           "group": "inline"
         },
         {

--- a/src/features/terraformCloud.ts
+++ b/src/features/terraformCloud.ts
@@ -95,6 +95,7 @@ export class TerraformCloudFeature implements vscode.Disposable {
     vscode.authentication.onDidChangeSessions((e) => {
       // Refresh the workspace list if the user changes session
       if (e.provider.id === TerraformCloudAuthenticationProvider.providerID) {
+        workspaceDataProvider.reset();
         workspaceDataProvider.refresh();
         runDataProvider.refresh();
       }

--- a/src/features/terraformCloud.ts
+++ b/src/features/terraformCloud.ts
@@ -155,10 +155,7 @@ export class TerraformCloudFeature implements vscode.Disposable {
 
         // project filter should be cleared on org change
         await vscode.commands.executeCommand('terraform.cloud.workspaces.resetProjectFilter');
-
-        // refresh workspaces so they pick up the change
-        workspaceDataProvider.refresh();
-        runDataProvider.refresh();
+        // filter reset will refresh workspaces
       }),
     );
   }

--- a/src/features/terraformCloud.ts
+++ b/src/features/terraformCloud.ts
@@ -83,10 +83,11 @@ export class TerraformCloudFeature implements vscode.Disposable {
       }
 
       // we don't allow multi-select yet so this will always be one
-      const workspaceItem = event.selection[0] as WorkspaceTreeItem;
-
-      // call the TFC Run provider with the workspace
-      runDataProvider.refresh(workspaceItem);
+      const item = event.selection[0];
+      if (item instanceof WorkspaceTreeItem) {
+        // call the TFC Run provider with the workspace
+        runDataProvider.refresh(item);
+      }
     });
 
     // TODO: move this as the login/organization picker is fleshed out

--- a/src/providers/tfc/runProvider.ts
+++ b/src/providers/tfc/runProvider.ts
@@ -57,7 +57,7 @@ export class RunTreeDataProvider implements vscode.TreeDataProvider<TFCRunTreeIt
   }
 
   getChildren(element?: TFCRunTreeItem | undefined): vscode.ProviderResult<TFCRunTreeItem[]> {
-    if (!this.activeWorkspace) {
+    if (!this.activeWorkspace || !(this.activeWorkspace instanceof WorkspaceTreeItem)) {
       return [];
     }
 

--- a/src/providers/tfc/workspaceProvider.ts
+++ b/src/providers/tfc/workspaceProvider.ts
@@ -35,14 +35,14 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<vscode
     this.ctx.subscriptions.push(
       vscode.commands.registerCommand('terraform.cloud.workspaces.refresh', (workspaceItem: WorkspaceTreeItem) => {
         this.reporter.sendTelemetryEvent('tfc-workspaces-refresh');
-        this.cache = [];
+        this.reset();
         this.refresh();
         this.runDataProvider.refresh(workspaceItem);
       }),
       vscode.commands.registerCommand('terraform.cloud.workspaces.resetProjectFilter', () => {
         this.reporter.sendTelemetryEvent('tfc-workspaces-filter-reset');
         this.projectFilter = undefined;
-        this.cache = [];
+        this.reset();
         this.refresh();
       }),
       vscode.commands.registerCommand(
@@ -75,6 +75,12 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<vscode
     this.didChangeTreeData.fire();
   }
 
+  // This resets the internal cache, e.g. after logout
+  reset(): void {
+    this.totalWorkspaceCount = -1;
+    this.cache = [];
+  }
+
   async filterByProject(): Promise<void> {
     const session = await vscode.authentication.getSession(TerraformCloudAuthenticationProvider.providerID, [], {
       createIfNone: false,
@@ -96,7 +102,7 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<vscode
       this.projectFilter = project.description;
       await vscode.commands.executeCommand('setContext', 'terraform.cloud.projectFilterUsed', true);
     }
-    this.cache = [];
+    this.reset();
     this.refresh();
     this.runDataProvider.refresh();
   }

--- a/src/providers/tfc/workspaceProvider.ts
+++ b/src/providers/tfc/workspaceProvider.ts
@@ -65,7 +65,6 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<vscode
       }),
       vscode.commands.registerCommand('terraform.cloud.workspaces.loadMore', async () => {
         this.reporter.sendTelemetryEvent('tfc-workspaces-loadMore');
-        this.cache = [...this.cache, ...(await this.getWorkspaces())];
         this.refresh();
         this.runDataProvider.refresh();
       }),
@@ -116,13 +115,10 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<vscode
   }
 
   private async buildChildren() {
-    if (this.cache.length === 0) {
-      try {
-        const items = await this.getWorkspaces();
-        this.cache = items;
-      } catch (error) {
-        return [];
-      }
+    try {
+      this.cache = [...this.cache, ...(await this.getWorkspaces())];
+    } catch (error) {
+      return [];
     }
 
     const items = this.cache.slice(0);


### PR DESCRIPTION
This PR adds a simple pagination to the workspaces view. We load the next page and append it to the tree view when a user clicks "load more".

Hitting refresh or using the project filter will reset the cache.

## UX
I'd like to improve the UX here, but it's not possible to programatically update the scroll position or deselect an item. Also, the current solution is cumbersome for 500+ workspaces, where a user would have to hit "load more" at least 10 times to get to workspaces further down the list. A filter (e.g. by name) might improve this in the future.

![2023-10-12 10 31 40](https://github.com/hashicorp/vscode-terraform/assets/45985/f3e1f217-1aaf-4a61-bc92-6e82a82447c4)
