### PR TITLE
Fix plan and apply item tooltip

### DIFF
--- a/package.json
+++ b/package.json
@@ -495,7 +495,7 @@
       {
         "command": "terraform.cloud.run.plan.downloadLog",
         "title": "View raw plan log",
-        "icon": "$(book)"
+        "icon": "$(output)"
       },
       {
         "command": "terraform.cloud.run.apply.downloadLog",

--- a/src/providers/tfc/runProvider.ts
+++ b/src/providers/tfc/runProvider.ts
@@ -73,8 +73,10 @@ export class RunTreeDataProvider implements vscode.TreeDataProvider<TFCRunTreeIt
     }
   }
 
-  async resolveTreeItem(item: vscode.TreeItem, element: RunTreeItem): Promise<vscode.TreeItem> {
-    item.tooltip = await runMarkdown(element);
+  async resolveTreeItem(item: vscode.TreeItem, element: TFCRunTreeItem): Promise<vscode.TreeItem> {
+    if (element instanceof RunTreeItem) {
+      item.tooltip = await runMarkdown(element);
+    }
     return item;
   }
 


### PR DESCRIPTION
With the introduction of TFCRunTreeItem, any method that operates on a specific type of treeitem must check it's type. This is especially important in order to only resolve the tooltip for the RunTreeItem and not for Plan or Apply treeitems.

This also makes the Plan and Apply buttons use the same codeicon.