### PR TITLE
deps: bump js-releases to 1.7.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,7 @@
         "which": "^3.0.1"
       },
       "devDependencies": {
-        "@hashicorp/js-releases": "^1.6.1",
+        "@hashicorp/js-releases": "^1.7.1",
         "@types/chai": "^4.3.5",
         "@types/glob": "^8.1.0",
         "@types/jest": "^29.5.1",
@@ -764,9 +764,9 @@
       }
     },
     "node_modules/@hashicorp/js-releases": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/js-releases/-/js-releases-1.7.0.tgz",
-      "integrity": "sha512-ONeN2lH5qeZU+wK32CschZEPe+NB9ypGzsfCpEQgA87oGMEkWX66s95bLYN4ff+WirBWYvyvHxGLT1MWbj/m9A==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/js-releases/-/js-releases-1.7.1.tgz",
+      "integrity": "sha512-dxyEwAb/9c3edFax1+jei1Dd8LrCfsNvG5WaEvEmLO7iHIHigXWmW50tv8dAi7UrY5XyEVp7CAb3+EO7+ZfOUg==",
       "dev": true,
       "dependencies": {
         "axios": "^0.25.0",
@@ -10557,9 +10557,9 @@
       "dev": true
     },
     "@hashicorp/js-releases": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/@hashicorp/js-releases/-/js-releases-1.7.0.tgz",
-      "integrity": "sha512-ONeN2lH5qeZU+wK32CschZEPe+NB9ypGzsfCpEQgA87oGMEkWX66s95bLYN4ff+WirBWYvyvHxGLT1MWbj/m9A==",
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@hashicorp/js-releases/-/js-releases-1.7.1.tgz",
+      "integrity": "sha512-dxyEwAb/9c3edFax1+jei1Dd8LrCfsNvG5WaEvEmLO7iHIHigXWmW50tv8dAi7UrY5XyEVp7CAb3+EO7+ZfOUg==",
       "dev": true,
       "requires": {
         "axios": "^0.25.0",

--- a/package.json
+++ b/package.json
@@ -583,7 +583,7 @@
     "which": "^3.0.1"
   },
   "devDependencies": {
-    "@hashicorp/js-releases": "^1.6.1",
+    "@hashicorp/js-releases": "^1.7.1",
     "@types/chai": "^4.3.5",
     "@types/glob": "^8.1.0",
     "@types/jest": "^29.5.1",


### PR DESCRIPTION
Result of `npm i @hashicorp/js-releases`

This should also hopefully update the version constraints on `@babel/traverse` and allow us to bump it and get rid of the security scanner noise.