### PR TITLE
Reset runs view on organization change

### DIFF
--- a/src/providers/tfc/workspaceProvider.ts
+++ b/src/providers/tfc/workspaceProvider.ts
@@ -44,6 +44,7 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<vscode
         this.projectFilter = undefined;
         this.reset();
         this.refresh();
+        this.runDataProvider.refresh();
       }),
       vscode.commands.registerCommand(
         'terraform.cloud.workspaces.viewInBrowser',


### PR DESCRIPTION
This PR fixes a bug where we kept the contents of the run view after changing the organization.