### PR TITLE
github: Disable dependabot for GHA

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,9 +11,3 @@ updates:
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
       - dependency-name: "@typescript-eslint/*"
         update-types: ["version-update:semver-minor", "version-update:semver-patch"]
-
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "daily"
-    labels: ["dependencies"]


### PR DESCRIPTION
This is to avoid conflicts with our own internal tooling, which comes with an added layer of trusted/reviewed revisions.