### PR TITLE
Remove terraform init from integration tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,13 +85,6 @@ jobs:
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           echo ">>> Started xvfb"
         if: matrix.os == 'ubuntu-latest'
-      - name: Install Terraform
-        uses: hashicorp/setup-terraform@v3
-        with:
-          terraform_wrapper: false
-          terraform_version: '~1.5'
-      - name: Terraform version
-        run: terraform version
       - name: Clean Install Dependencies
         run: npm ci
       - name: Run Tests

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -16,23 +16,8 @@
       }
     },
     {
-      "type": "process",
-      "label": "terraformInit",
-      "isBackground": true,
-      "command": "terraform",
-      "args": ["init"],
-      "options": {
-        "cwd": "${workspaceFolder}/testFixture"
-      },
-      "presentation": {
-        "reveal": "never",
-        "group": "watchers"
-      },
-      "group": "build"
-    },
-    {
       "label": "tasks: watch-tests",
-      "dependsOn": ["npm: watch", "terraformInit"],
+      "dependsOn": ["npm: watch"],
       "problemMatcher": []
     },
     {

--- a/src/test/runTest.ts
+++ b/src/test/runTest.ts
@@ -6,26 +6,8 @@
 import * as path from 'path';
 import { runTests } from '@vscode/test-electron';
 import { TestOptions } from '@vscode/test-electron/out/runTest';
-import { exec } from '../utils/helpers';
-
-async function terraformInit() {
-  const cwd = process.cwd();
-  process.chdir('testFixture');
-  const { stdout } = await exec('terraform', ['init', '-no-color']);
-  console.log(stdout);
-  process.chdir(cwd);
-}
 
 async function main(): Promise<void> {
-  try {
-    // initialize terraform before vscode opens
-    await terraformInit();
-  } catch (err) {
-    console.error(err);
-    console.error('Failed to run tests');
-    process.exitCode = 1;
-  }
-
   // The folder containing the Extension Manifest package.json
   // Passed to `--extensionDevelopmentPath`
   // this is also the process working dir, even if vscode opens another folder


### PR DESCRIPTION
This removes executing terraform before the tests. As the terraform-ls progressed, it has moved away from requiring a terraform init run before being able to parse the configuration.
