### PR TITLE
TFC: Implement apply panel for structured output

### DIFF
--- a/package.json
+++ b/package.json
@@ -508,6 +508,11 @@
         "icon": "$(output)"
       },
       {
+        "command": "terraform.cloud.run.viewApply",
+        "title": "View apply output",
+        "icon": "$(output)"
+      },
+      {
         "command": "terraform.cloud.organization.picker",
         "title": "HashiCorp Terraform Cloud: Pick Organization",
         "icon": "$(account)"
@@ -578,6 +583,10 @@
         },
         {
           "command": "terraform.cloud.run.apply.downloadLog",
+          "when": "false"
+        },
+        {
+          "command": "terraform.cloud.run.viewApply",
           "when": "false"
         },
         {
@@ -652,7 +661,12 @@
         },
         {
           "command": "terraform.cloud.run.apply.downloadLog",
-          "when": "view == terraform.cloud.runs && viewItem =~ /hasApply/",
+          "when": "view == terraform.cloud.runs && viewItem =~ /hasRawApply/",
+          "group": "inline"
+        },
+        {
+          "command": "terraform.cloud.run.viewApply",
+          "when": "view == terraform.cloud.runs && viewItem =~ /hasStructuredApply/",
           "group": "inline"
         }
       ]
@@ -685,6 +699,11 @@
           "id": "terraform.cloud.run.plan",
           "name": "Plan",
           "when": "terraform.cloud.run.viewingPlan"
+        },
+        {
+          "id": "terraform.cloud.run.apply",
+          "name": "Apply",
+          "when": "terraform.cloud.run.viewingApply"
         }
       ]
     },
@@ -755,6 +774,10 @@
       {
         "view": "terraform.cloud.run.plan",
         "contents": "Select a run to view a plan"
+      },
+      {
+        "view": "terraform.cloud.run.apply",
+        "contents": "Select a run to view an apply"
       }
     ]
   },

--- a/src/features/terraformCloud.ts
+++ b/src/features/terraformCloud.ts
@@ -18,6 +18,7 @@ import {
 import { APIQuickPick } from '../providers/tfc/uiHelpers';
 import { TerraformCloudWebUrl } from '../terraformCloud';
 import { PlanLogContentProvider } from '../providers/tfc/contentProvider';
+import { ApplyTreeDataProvider } from '../providers/tfc/applyProvider';
 
 export class TerraformCloudFeature implements vscode.Disposable {
   private statusBar: OrganizationStatusBar;
@@ -64,7 +65,20 @@ export class TerraformCloudFeature implements vscode.Disposable {
       treeDataProvider: planDataProvider,
     });
 
-    const runDataProvider = new RunTreeDataProvider(this.context, this.reporter, outputChannel, planDataProvider);
+    const applyDataProvider = new ApplyTreeDataProvider(this.context, this.reporter, outputChannel);
+    const applyView = vscode.window.createTreeView('terraform.cloud.run.apply', {
+      canSelectMany: false,
+      showCollapseAll: true,
+      treeDataProvider: applyDataProvider,
+    });
+
+    const runDataProvider = new RunTreeDataProvider(
+      this.context,
+      this.reporter,
+      outputChannel,
+      planDataProvider,
+      applyDataProvider,
+    );
     const runView = vscode.window.createTreeView('terraform.cloud.runs', {
       canSelectMany: false,
       showCollapseAll: true,
@@ -89,6 +103,8 @@ export class TerraformCloudFeature implements vscode.Disposable {
       runView,
       planView,
       planDataProvider,
+      applyView,
+      applyDataProvider,
       runDataProvider,
       workspaceDataProvider,
       workspaceView,
@@ -105,6 +121,7 @@ export class TerraformCloudFeature implements vscode.Disposable {
         // call the TFC Run provider with the workspace
         runDataProvider.refresh(item);
         planDataProvider.refresh();
+        applyDataProvider.refresh();
       }
     });
 
@@ -117,6 +134,7 @@ export class TerraformCloudFeature implements vscode.Disposable {
         workspaceDataProvider.refresh();
         runDataProvider.refresh();
         planDataProvider.refresh();
+        applyDataProvider.refresh();
       }
     });
 

--- a/src/providers/tfc/applyProvider.ts
+++ b/src/providers/tfc/applyProvider.ts
@@ -1,0 +1,238 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import * as vscode from 'vscode';
+import * as readline from 'readline';
+import { Writable } from 'stream';
+import axios from 'axios';
+import TelemetryReporter from '@vscode/extension-telemetry';
+
+import { TerraformCloudAuthenticationProvider } from '../authenticationProvider';
+import { ZodiosError } from '@zodios/core';
+import { handleAuthError, handleZodiosError } from './uiHelpers';
+import { GetChangeActionIcon } from './helpers';
+import { AppliedChange, ChangeSummary, Diagnostic, LogLine, Outputs } from '../../terraformCloud/log';
+import { ApplyTreeItem } from './runProvider';
+import { OutputsItem, DiagnosticsItem, DiagnosticSummary, ItemWithChildren, isItemWithChildren } from './logHelpers';
+
+export class ApplyTreeDataProvider implements vscode.TreeDataProvider<vscode.TreeItem>, vscode.Disposable {
+  private readonly didChangeTreeData = new vscode.EventEmitter<void | vscode.TreeItem>();
+  public readonly onDidChangeTreeData = this.didChangeTreeData.event;
+  private apply: ApplyTreeItem | undefined;
+
+  constructor(
+    private ctx: vscode.ExtensionContext,
+    private reporter: TelemetryReporter,
+    private outputChannel: vscode.OutputChannel,
+  ) {
+    this.ctx.subscriptions.push(
+      vscode.commands.registerCommand('terraform.cloud.run.apply.refresh', () => {
+        this.reporter.sendTelemetryEvent('tfc-run-apply-refresh');
+        this.refresh(this.apply);
+      }),
+    );
+  }
+
+  refresh(apply?: ApplyTreeItem): void {
+    this.apply = apply;
+    this.didChangeTreeData.fire();
+  }
+
+  getTreeItem(element: vscode.TreeItem): vscode.TreeItem | Thenable<vscode.TreeItem> {
+    return element;
+  }
+
+  getChildren(element?: vscode.TreeItem | undefined): vscode.ProviderResult<vscode.TreeItem[]> {
+    if (!this.apply) {
+      return [];
+    }
+
+    if (!element) {
+      try {
+        return this.getRootChildren(this.apply);
+      } catch (error) {
+        return [];
+      }
+    }
+
+    if (isItemWithChildren(element)) {
+      return element.getChildren();
+    }
+  }
+
+  private async getRootChildren(apply: ApplyTreeItem): Promise<vscode.TreeItem[]> {
+    const applyLog = await this.getApplyFromUrl(apply);
+
+    const items: vscode.TreeItem[] = [];
+    if (applyLog && applyLog.appliedChanges) {
+      items.push(new AppliedChangesItem(applyLog.appliedChanges, applyLog.changeSummary));
+    }
+    if (applyLog && applyLog.outputs && Object.keys(applyLog.outputs).length > 0) {
+      items.push(new OutputsItem(applyLog.outputs));
+    }
+    if (applyLog && applyLog.diagnostics && applyLog.diagnosticSummary && applyLog.diagnostics.length > 0) {
+      items.push(new DiagnosticsItem(applyLog.diagnostics, applyLog.diagnosticSummary));
+    }
+    return items;
+  }
+
+  private async getApplyFromUrl(apply: ApplyTreeItem): Promise<ApplyLog | undefined> {
+    const session = await vscode.authentication.getSession(TerraformCloudAuthenticationProvider.providerID, [], {
+      createIfNone: false,
+    });
+
+    if (session === undefined) {
+      return;
+    }
+
+    try {
+      const result = await axios.get(apply.logReadUrl, {
+        headers: { Accept: 'text/plain' },
+        responseType: 'stream',
+      });
+      const lineStream = readline.createInterface({
+        input: result.data,
+        output: new Writable(),
+      });
+
+      const applyLog: ApplyLog = {};
+
+      for await (const line of lineStream) {
+        try {
+          const logLine: LogLine = JSON.parse(line);
+
+          if (logLine.type === 'apply_complete' && logLine.hook) {
+            if (!applyLog.appliedChanges) {
+              applyLog.appliedChanges = [];
+            }
+            applyLog.appliedChanges.push(logLine.hook);
+            continue;
+          }
+          if (logLine.type === 'change_summary' && logLine.changes) {
+            applyLog.changeSummary = logLine.changes;
+            continue;
+          }
+          if (logLine.type === 'outputs' && logLine.outputs) {
+            applyLog.outputs = logLine.outputs;
+            continue;
+          }
+          if (logLine.type === 'diagnostic' && logLine.diagnostic) {
+            if (!applyLog.diagnostics) {
+              applyLog.diagnostics = [];
+            }
+            if (!applyLog.diagnosticSummary) {
+              applyLog.diagnosticSummary = {
+                errorCount: 0,
+                warningCount: 0,
+              };
+            }
+            applyLog.diagnostics.push(logLine.diagnostic);
+            if (logLine.diagnostic.severity === 'warning') {
+              applyLog.diagnosticSummary.warningCount += 1;
+            }
+            if (logLine.diagnostic.severity === 'error') {
+              applyLog.diagnosticSummary.errorCount += 1;
+            }
+            continue;
+          }
+
+          // TODO: logLine.type=test_*
+        } catch (e) {
+          // skip any non-JSON lines, like Terraform version output
+          continue;
+        }
+      }
+
+      return applyLog;
+    } catch (error) {
+      let message = `Failed to obtain apply log from ${apply.logReadUrl}: `;
+
+      if (error instanceof ZodiosError) {
+        handleZodiosError(error, message, this.outputChannel, this.reporter);
+        return;
+      }
+
+      if (axios.isAxiosError(error)) {
+        if (error.response?.status === 401) {
+          handleAuthError();
+          return;
+        }
+      }
+
+      if (error instanceof Error) {
+        message += error.message;
+        vscode.window.showErrorMessage(message);
+        this.reporter.sendTelemetryException(error);
+        return;
+      }
+
+      if (typeof error === 'string') {
+        message += error;
+      }
+      vscode.window.showErrorMessage(message);
+      return;
+    }
+  }
+
+  dispose() {
+    //
+  }
+}
+
+interface ApplyLog {
+  appliedChanges?: AppliedChange[];
+  changeSummary?: ChangeSummary;
+  outputs?: Outputs;
+  diagnostics?: Diagnostic[];
+  diagnosticSummary?: DiagnosticSummary;
+}
+
+class AppliedChangesItem extends vscode.TreeItem implements ItemWithChildren {
+  constructor(private appliedChanges: AppliedChange[], summary?: ChangeSummary) {
+    let label = 'Applied changes';
+    if (summary) {
+      const labels: string[] = [];
+      if (summary.import > 0) {
+        labels.push(`${summary.import} imported`);
+      }
+      if (summary.add > 0) {
+        labels.push(`${summary.add} added`);
+      }
+      if (summary.change > 0) {
+        labels.push(`${summary.change} changed`);
+      }
+      if (summary.remove > 0) {
+        labels.push(`${summary.remove} destroyed`);
+      }
+      if (labels.length > 0) {
+        label = `Applied changes: ${labels.join(', ')}`;
+      }
+    }
+    super(label, vscode.TreeItemCollapsibleState.Expanded);
+  }
+
+  getChildren(): vscode.TreeItem[] {
+    return this.appliedChanges.map((change) => new AppliedChangeItem(change));
+  }
+}
+
+class AppliedChangeItem extends vscode.TreeItem {
+  constructor(public change: AppliedChange) {
+    const label = change.resource.addr;
+
+    super(label, vscode.TreeItemCollapsibleState.None);
+    this.id = change.action + '/' + change.resource.addr;
+    this.iconPath = GetChangeActionIcon(change.action);
+
+    this.description = change.action;
+    if (change.id_key && change.id_value) {
+      this.description = `${change.id_key}=${change.id_value}`;
+    }
+
+    const tooltip = new vscode.MarkdownString();
+    tooltip.appendMarkdown(`_${change.action}_ \`${change.resource.addr}\``);
+    this.tooltip = tooltip;
+  }
+}

--- a/src/providers/tfc/logHelpers.ts
+++ b/src/providers/tfc/logHelpers.ts
@@ -1,0 +1,86 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import * as vscode from 'vscode';
+import { Outputs, OutputChange, Diagnostic } from '../../terraformCloud/log';
+import { GetChangeActionIcon, GetDiagnosticSeverityIcon } from './helpers';
+
+export interface DiagnosticSummary {
+  errorCount: number;
+  warningCount: number;
+}
+
+export interface ItemWithChildren {
+  getChildren(): vscode.TreeItem[];
+}
+
+export function isItemWithChildren(element: object): element is ItemWithChildren {
+  return 'getChildren' in element;
+}
+
+export class OutputsItem extends vscode.TreeItem implements ItemWithChildren {
+  constructor(private outputs: Outputs) {
+    const size = Object.keys(outputs).length;
+    super(`${size} outputs`, vscode.TreeItemCollapsibleState.Expanded);
+  }
+
+  getChildren(): vscode.TreeItem[] {
+    const items: vscode.TreeItem[] = [];
+    Object.entries(this.outputs).forEach(([name, change]: [string, OutputChange]) => {
+      items.push(new OutputChangeItem(name, change));
+    });
+    return items;
+  }
+}
+
+class OutputChangeItem extends vscode.TreeItem {
+  constructor(name: string, output: OutputChange) {
+    super(name, vscode.TreeItemCollapsibleState.None);
+    this.id = 'output/' + output.action + '/' + name;
+    if (output.action) {
+      this.iconPath = GetChangeActionIcon(output.action);
+    }
+    this.description = output.action;
+    if (output.sensitive) {
+      this.description += ' (sensitive)';
+    }
+  }
+}
+
+export class DiagnosticsItem extends vscode.TreeItem implements ItemWithChildren {
+  constructor(private diagnostics: Diagnostic[], summary: DiagnosticSummary) {
+    const labels: string[] = [];
+    if (summary.warningCount === 1) {
+      labels.push(`1 warning`);
+    } else if (summary.warningCount > 1) {
+      labels.push(`${summary.warningCount} warnings`);
+    }
+    if (summary.errorCount === 1) {
+      labels.push(`1 error`);
+    } else if (summary.errorCount > 1) {
+      labels.push(`${summary.errorCount} errors`);
+    }
+    super(labels.join(', '), vscode.TreeItemCollapsibleState.Expanded);
+  }
+
+  getChildren(): vscode.TreeItem[] {
+    return this.diagnostics.map((diagnostic) => new DiagnosticItem(diagnostic));
+  }
+}
+
+export class DiagnosticItem extends vscode.TreeItem {
+  constructor(diagnostic: Diagnostic) {
+    super(diagnostic.summary, vscode.TreeItemCollapsibleState.None);
+    this.description = diagnostic.severity;
+    const icon = GetDiagnosticSeverityIcon(diagnostic.severity);
+    this.iconPath = icon;
+
+    const tooltip = new vscode.MarkdownString();
+    tooltip.supportThemeIcons = true;
+    tooltip.appendMarkdown(`$(${icon.id}) **${diagnostic.summary}**\n\n`);
+    tooltip.appendMarkdown(diagnostic.detail);
+    this.tooltip = tooltip;
+  }
+}

--- a/src/terraformCloud/apply.ts
+++ b/src/terraformCloud/apply.ts
@@ -10,6 +10,7 @@ export const applyAttributes = z.object({
   'resource-additions': z.number().nullable(),
   'resource-changes': z.number().nullable(),
   'resource-destructions': z.number().nullable(),
+  'structured-run-output-enabled': z.boolean(),
   status: z.string(),
   'status-timestamps': z.object({
     'queued-at': z.string().optional(),

--- a/src/terraformCloud/log.ts
+++ b/src/terraformCloud/log.ts
@@ -13,6 +13,8 @@ export interface LogLine {
 
   // type=planned_change | type=resource_drift
   change?: Change;
+  // type=apply_start | type=apply_progress | type=apply_complete | type=apply_errored
+  hook?: AppliedChange;
   // type=change_summary
   changes?: ChangeSummary;
   // type=outputs
@@ -61,6 +63,14 @@ export interface Change {
   action: ChangeAction;
   reason?: ChangeReason;
   importing?: Importing;
+}
+
+export interface AppliedChange {
+  resource: Resource;
+  action: ChangeAction;
+  elapsed_seconds: number;
+  id_key?: string;
+  id_value?: string;
 }
 
 export type ChangeAction = 'noop' | 'create' | 'read' | 'update' | 'replace' | 'delete' | 'move' | 'import';
@@ -114,7 +124,7 @@ export interface Outputs {
 }
 
 export interface OutputChange {
-  action: ChangeAction;
+  action?: ChangeAction; // only present in plan logs, not apply logs
   sensitive: boolean;
 }
 


### PR DESCRIPTION
Closes https://github.com/hashicorp/vscode-terraform/issues/1637

Follow-up:

 - https://github.com/hashicorp/vscode-terraform/issues/1650
 - https://github.com/hashicorp/vscode-terraform/issues/1651

--- 

## UX Examples

Single panel

![2023-12-05 14 55 05](https://github.com/hashicorp/vscode-terraform/assets/287584/2984a0e7-6e9a-42ac-9add-8778eefe6bd2)

Both panels

https://github.com/hashicorp/vscode-terraform/assets/287584/dba715b2-1e95-4f40-b22b-cec4cdc76f57

## Implementation Notes

While it may look simple and not as helpful without all the deeply structured data in the form of attributes etc. I'm afraid this is as much as we can squeeze out of the _structured logs_ without downloading the whole plan file and rendering all the things with the full knowledge of types etc. This would be a whole different story in terms of complexity though.

I found a few bugs which affected the existing plan log, so while implementing apply log correctly I also fixed them there
 - we previously didn't ignore pending plans/applies, which have no log to offer
 - we were also trying to catch a specific axios exception related to `listRuns` when that methods is never actually called in the `try` part, it was just an earlier copy-paste error
