### PR TITLE
Remove `win32-ia32` build target

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -31,9 +31,6 @@ jobs:
           - vsce_target: win32-x64
             ls_target: windows_amd64
             npm_config_arch: x64
-          - vsce_target: win32-ia32
-            ls_target: windows_386
-            npm_config_arch: ia32
           - vsce_target: win32-arm64
             ls_target: windows_arm64
             npm_config_arch: arm

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [2.29.1] (2023-12-13)
 
+BREAKING CHANGES:
+
+* Publishing extensions for the `win32-ia32` target has been disabled, so we can no longer provide builds for Windows 32bit. (see [microsoft/vscode-vsce#908](https://github.com/microsoft/vscode-vsce/pull/908) and [microsoft/vscode#195559](https://github.com/microsoft/vscode/pull/195559))
+
 ENHANCEMENTS:
 
 * Add new panel for Terraform Cloud structured plans ([#1590](https://github.com/hashicorp/vscode-terraform/pull/1590))

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -135,7 +135,6 @@ macOS    | darwin_arm64  | darwin_arm64  | ✅
 Linux    | linux_amd64   | linux_x64     | ✅
 Linux    | linux_arm     | linux_armhf   | ✅
 Linux    | linux_arm64   | linux_arm64   | ✅
-Windows  | windows_386   | win32_ia32    | ✅
 Windows  | windows_amd64 | win32_x64     | ✅
 Windows  | windows_arm64 | win32_arm64   | ✅
 

--- a/build/downloader.ts
+++ b/build/downloader.ts
@@ -26,12 +26,8 @@ function getArch(arch: string) {
   // Linux    | linux_amd64   | linux_x64          | ✅
   // Linux    | linux_arm     | linux_armhf        | ✅
   // Linux    | linux_arm64   | linux_arm64        | ✅
-  // Windows  | windows_386   | win32_ia32         | ✅
   // Windows  | windows_amd64 | win32_x64          | ✅
   // Windows  | windows_arm64 | win32_arm64        | ✅
-  if (arch === 'ia32') {
-    return '386';
-  }
   if (arch === 'x64') {
     return 'amd64';
   }


### PR DESCRIPTION
Based on https://github.com/microsoft/vscode-vsce/pull/908 and https://github.com/microsoft/vscode/pull/195559, it appears that extensions should no longer be published for the now removed `win32-ia32` target.