### PR TITLE
Rename TokenTypeCapsule to TokenTypeComplex

### DIFF
--- a/package.json
+++ b/package.json
@@ -152,7 +152,7 @@
         "description": "Traversal step"
       },
       {
-        "id": "hcl-typeCapsule",
+        "id": "hcl-typeComplex",
         "superType": "keyword",
         "description": "Type (complex)"
       },
@@ -200,7 +200,7 @@
           "hcl-traversalStep": [
             "variable.other.readwrite"
           ],
-          "hcl-typeCapsule": [
+          "hcl-typeComplex": [
             "keyword.control"
           ],
           "hcl-typePrimitive": [


### PR DESCRIPTION
This renames the existing token type TokenTypeCapsule to TokenTypeComplex to aid readability and reflect existing naming conventions.

This token represents `list` in `type = list(string)` and similar, i.e. the name of the complex type. The term "capsule" has slightly different meaning in cty and HCL and we should not use it in this context.

Relies on https://github.com/hashicorp/terraform-ls/pull/1529
