### PR TITLE
Fix test failures on main

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -85,6 +85,13 @@ jobs:
           /usr/bin/Xvfb :99 -screen 0 1024x768x24 > /dev/null 2>&1 &
           echo ">>> Started xvfb"
         if: matrix.os == 'ubuntu-latest'
+      - name: Install Terraform
+        uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_wrapper: false
+          terraform_version: '~1.6'
+      - name: Terraform version
+        run: terraform version
       - name: Clean Install Dependencies
         run: npm ci
       - name: Run Tests

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -40,8 +40,8 @@
   },
   "[typescript]": {
     "editor.codeActionsOnSave": {
-      "source.fixAll": true,
-      "source.organizeImports": false
+      "source.fixAll": "explicit",
+      "source.organizeImports": "never"
     },
     "editor.defaultFormatter": "esbenp.prettier-vscode"
   },

--- a/src/test/integration/codeAction.test.ts
+++ b/src/test/integration/codeAction.test.ts
@@ -29,7 +29,7 @@ suite('code actions', () => {
       new vscode.CodeAction('Format Document', vscode.CodeActionKind.Source.append('formatAll').append('terraform')),
     ];
 
-    // wait till the LS is ready to acccept a code action request
+    // wait till the LS is ready to accept a code action request
     await new Promise((r) => setTimeout(r, 1000));
 
     for (let index = 0; index < supported.length; index++) {


### PR DESCRIPTION
We removed calling `terraform init` for integration tests in https://github.com/hashicorp/vscode-terraform/pull/1645 and also removed the Terraform installation altogether. It turns out that the formatting code action still requires Terraform. 

This PR adds the installation of Terraform 1.6 to fix the testing issues on Windows and MacOS (the Ubuntu runner ships with Terraform installed).

VS Code automatically updates the workspace settings when the project is opened, so I've included that small change here as well.