### PR TITLE
Bump minimal engine version to `1.82.3`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         vscode:
-          - '1.75.1'
+          - '1.82.3'
           - 'insiders'
           - 'stable'
         os:

--- a/README.md
+++ b/README.md
@@ -178,16 +178,17 @@ The Terraform VS Code extension bundles the [Terraform Language Server](https://
 
 The extension does require the following to be installed before use:
 
-- VS Code v1.75 or greater
+- VS Code v1.82 or greater
 - Terraform v0.12 or greater
 
 ## Platform Support
 
 The extension should work anywhere VS Code itself and Terraform 0.12 or higher is supported. Our test matrix includes the following:
 
-- Windows Server 2019 with Terraform v1.1
-- macOS 10.15 with Terraform v1.1
-- Ubuntu 20.04 with Terraform v1.1
+- Windows Server 2022 with Terraform v1.6
+- macOS 12 with Terraform v1.6
+- macOS 11 with Terraform v1.6
+- Ubuntu 22.04 with Terraform v1.6
 
 Intellisense, error checking and other language features are supported for Terraform v0.12 and greater.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -57,7 +57,7 @@
       "engines": {
         "node": "~18.X",
         "npm": "~9.X",
-        "vscode": "^1.75.1"
+        "vscode": "^1.82.3"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@types/jest": "^29.5.1",
         "@types/mocha": "^10.0.1",
         "@types/node": "^16.18.36",
-        "@types/vscode": "~1.75.1",
+        "@types/vscode": "~1.82.0",
         "@types/webpack-env": "^1.18.0",
         "@types/which": "^3.0.0",
         "@typescript-eslint/eslint-plugin": "^5.59.5",
@@ -2053,9 +2053,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.75.1",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.75.1.tgz",
-      "integrity": "sha512-emg7wdsTFzdi+elvoyoA+Q8keEautdQHyY5LNmHVM4PTpY8JgOTVADrGVyXGepJ6dVW2OS5/xnLUWh+nZxvdiA==",
+      "version": "1.82.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
+      "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
       "dev": true
     },
     "node_modules/@types/webpack-env": {

--- a/package.json
+++ b/package.json
@@ -820,7 +820,7 @@
     "@types/jest": "^29.5.1",
     "@types/mocha": "^10.0.1",
     "@types/node": "^16.18.36",
-    "@types/vscode": "~1.75.1",
+    "@types/vscode": "~1.82.0",
     "@types/webpack-env": "^1.18.0",
     "@types/which": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^5.59.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "engines": {
     "npm": "~9.X",
     "node": "~18.X",
-    "vscode": "^1.75.1"
+    "vscode": "^1.82.3"
   },
   "langServer": {
     "version": "0.32.4"


### PR DESCRIPTION
As discussed yesterday, this PR bumps our minimal required VS Code version to 1.82.3. This completes the transition to Node.js 18.