### PR TITLE
github: Revert upgrade of artifact actions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -82,7 +82,7 @@ jobs:
         run: npm run package -- --target=${{ matrix.vsce_target }}
 
       - name: Upload vsix as artifact
-        uses: actions/upload-artifact@c7d193f32edcb7bfad88892161225aeda64e9392 # v4.0.0
+        uses: actions/upload-artifact@a8a3f3ad30e3422c9c7b888a15615d19a852ae32 # v3.1.3
         with:
           name: ${{ matrix.vsce_target }}
           path: '*.vsix'
@@ -93,7 +93,7 @@ jobs:
     needs: build
     if: success() && inputs.deploy_type == 'prerelease'
     steps:
-      - uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       - name: Publish Prerelease to Marketplace
         run: npx vsce publish --pre-release --no-git-tag-version --packagePath $(find . -iname *.vsix)
         env:
@@ -105,7 +105,7 @@ jobs:
     needs: build
     if: success() && inputs.deploy_type == 'stable'
     steps:
-      - uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       - name: Publish Stable to Marketplace
         run: npx vsce publish --no-git-tag-version --packagePath $(find . -iname *.vsix)
         env:
@@ -117,7 +117,7 @@ jobs:
     needs: build
     if: success() && inputs.deploy_type == 'stable'
     steps:
-      - uses: actions/download-artifact@f44cd7b40bfd40b6aa1cc1b9b5b7bf03d3c67110 # v4.1.0
+      - uses: actions/download-artifact@9bc31d5ccc31df68ecc42ccf4149144866c47d8a # v3.0.2
       - name: Publish Stable to OpenVSX
         run: npx ovsx publish --packagePath $(find . -iname *.vsix)
         env:


### PR DESCRIPTION
This _partially_ reverts https://github.com/hashicorp/vscode-terraform/pull/1661 as a way of preventing any effects of a known upstream issue with the new version as discussed in https://github.com/actions/download-artifact/issues/249