### PR TITLE
Remove registering authentication provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,12 +56,6 @@
   "main": "./out/extension",
   "browser": "./out/web/extension",
   "contributes": {
-    "authentication": [
-      {
-        "id": "terraformcloud",
-        "label": "HashiCorp Terraform Cloud"
-      }
-    ],
     "languages": [
       {
         "id": "terraform",


### PR DESCRIPTION
This removes `contributes.authentication` from the package.json manifest to restore workspace extension enablement.

From the [discussion thread](https://github.com/microsoft/vscode-discussions/discussions/930) and our investigation we can conclude (if not verify completely as there is no documentation) that `contributes.authentication` is a way to advertise use of the provider to outside extensions and not necessary for internal functionality. This means we can remove advertising the auth provider without breaking existing functionality.
