### PR TITLE
Prompt for custom tfcloud host

### DIFF
--- a/src/api/terraformCloud/index.ts
+++ b/src/api/terraformCloud/index.ts
@@ -86,7 +86,10 @@ export function earlySetupForHostname(hostname: string) {
   earlyApiClient.use(pluginLogger());
 }
 
-export function apiSetup() {
+export function apiSetup(hostname: string) {
+  TerraformCloudHost = hostname;
+  TerraformCloudAPIUrl = `https://${TerraformCloudHost}/api/v2`;
+  TerraformCloudWebUrl = `https://${TerraformCloudHost}/app`;
   // ApiClient setup
   apiClient = new Zodios(TerraformCloudAPIUrl, [
     ...accountEndpoints,

--- a/src/api/terraformCloud/instance.ts
+++ b/src/api/terraformCloud/instance.ts
@@ -1,0 +1,33 @@
+/**
+ * Copyright (c) HashiCorp, Inc.
+ * SPDX-License-Identifier: MPL-2.0
+ */
+
+import { makeApi } from '@zodios/core';
+import { z } from 'zod';
+import { errors } from './errors';
+
+const hcpInstance = z.object({
+  appName: z.string().nullish(),
+  apiVersion: z.string().nullish(),
+});
+export type HCPInstance = z.infer<typeof hcpInstance>;
+
+const details = z.object({
+  data: hcpInstance,
+});
+export type HCPInstanceDetails = z.infer<typeof details>;
+
+export const pingEndpoints = makeApi([
+  {
+    method: 'get',
+    path: '/ping',
+    alias: 'ping',
+    description: 'Get instance details',
+    response: z.object({
+      appName: z.string().nullish(),
+      apiVersion: z.string().nullish(),
+    }),
+    errors,
+  },
+]);

--- a/src/providers/tfc/authenticationProvider.ts
+++ b/src/providers/tfc/authenticationProvider.ts
@@ -286,11 +286,16 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
       label: 'app.terraform.io',
       detail: 'Default HCP Terraform hostname',
     };
-    const hostnames = [newHostSelection, defaultHostName];
+
+    const hostnames = [];
+
     if (tfcCredentials instanceof Error) {
       this.logger.info('HCP Terraform credential file not yet initialized.');
+      // either there isn't a credential file present or it's empty so
+      // use the default HCP hostname
+      hostnames.push(defaultHostName);
     } else {
-      tfcCredentials.delete('app.terraform.io');
+      // add all of the user's existing entries
       for (const key of tfcCredentials.keys()) {
         hostnames.push({
           label: key,
@@ -299,10 +304,14 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
       }
     }
 
+    // Add the new hostname option no matter if there is a credential file or not
+    // so the user can select a new hostname if they want to
+    hostnames.push(newHostSelection);
+
     const choice = await vscode.window.showQuickPick(hostnames, {
       canPickMany: false,
       ignoreFocusOut: true,
-      placeHolder: 'Choose HCP Terraform hostname to connect to',
+      placeHolder: 'Choose the HCP Terraform hostname to connect to',
       title: 'HashiCorp HCP Terraform Authentication',
     });
 
@@ -328,6 +337,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     }
     return hostname;
   }
+
   private async promptForToken(): Promise<string | undefined> {
     const choice = await vscode.window.showQuickPick(
       [

--- a/src/providers/tfc/authenticationProvider.ts
+++ b/src/providers/tfc/authenticationProvider.ts
@@ -107,6 +107,7 @@ class TerraformCloudSessionHandler {
     return this.secretStorage.delete(this.sessionKey);
   }
 }
+
 export class TerraformCloudAuthenticationProvider implements vscode.AuthenticationProvider, vscode.Disposable {
   static providerLabel = 'HashiCorp Cloud Platform Terraform';
   // These are IDs and session keys that are used to identify the provider and the session in VS Code secret storage
@@ -218,7 +219,10 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     const token = await this.promptForToken();
     if (!token) {
       this.logger.error('User did not provide a token');
-      throw new Error('Token is required');
+      // throw new InvalidToken();
+      this.reporter.sendTelemetryEvent('tfc-login-fail', { reason: 'Invalid token' });
+      vscode.window.showErrorMessage(`Invalid token. Please try again`);
+      return this.createSession(_scopes);
     }
 
     try {

--- a/src/providers/tfc/authenticationProvider.ts
+++ b/src/providers/tfc/authenticationProvider.ts
@@ -8,7 +8,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import TelemetryReporter from '@vscode/extension-telemetry';
 import {
-  apiSetup,
+  apiSetupForHostName,
   earlyApiClient,
   earlySetupForHostname,
   pingClient,
@@ -81,7 +81,7 @@ class TerraformCloudSessionHandler {
       });
 
       await this.secretStorage.store(this.sessionKey, JSON.stringify(session));
-      apiSetup(session.hostName);
+      apiSetupForHostName(session.hostName);
       return session;
     } catch (error) {
       if (error instanceof ZodiosError) {
@@ -184,7 +184,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
       // setup the API client for getting the user info
       earlySetupForHostname(session.hostName);
       // setup the API client for the session
-      apiSetup(session.hostName);
+      apiSetupForHostName(session.hostName);
 
       this.logger.info('Successfully fetched HCP Terraform session');
       await vscode.commands.executeCommand('setContext', 'terraform.cloud.signed-in', true);

--- a/src/providers/tfc/authenticationProvider.ts
+++ b/src/providers/tfc/authenticationProvider.ts
@@ -274,21 +274,21 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     const tfcCredentials = await this.getTerraformCLICredentials();
     const newHostSelection = {
       label: 'New Hostname',
-      detail: 'Connect to a new Terraform Cloud hostname',
+      detail: 'Connect to a new HCP Terraform hostname',
     };
     const defaultHostName = {
       label: 'app.terraform.io',
-      detail: 'Default Terraform Cloud hostname',
+      detail: 'Default HCP Terraform hostname',
     };
     const hostnames = [newHostSelection, defaultHostName];
     if (tfcCredentials instanceof Error) {
-      this.logger.info('Terraform cloud credential file not yet initialized.');
+      this.logger.info('HCP Terraform credential file not yet initialized.');
     } else {
       tfcCredentials.delete('app.terraform.io');
       for (const key of tfcCredentials.keys()) {
         hostnames.push({
           label: key,
-          detail: `${key} Terraform Cloud instance`,
+          detail: `${key} HCP Terraform instance`,
         });
       }
     }
@@ -296,8 +296,8 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     const choice = await vscode.window.showQuickPick(hostnames, {
       canPickMany: false,
       ignoreFocusOut: true,
-      placeHolder: 'Choose Terraform Cloud hostname to connect to',
-      title: 'HashiCorp Terraform Cloud Authentication',
+      placeHolder: 'Choose HCP Terraform hostname to connect to',
+      title: 'HashiCorp HCP Terraform Authentication',
     });
 
     if (choice === undefined) {
@@ -312,7 +312,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
           ignoreFocusOut: true,
           placeHolder: 'app.terraform.io',
           value: 'app.terraform.io',
-          prompt: 'Enter a Terraform Cloud hostname',
+          prompt: 'Enter a HCP Terraform hostname',
           password: false,
         });
         break;


### PR DESCRIPTION
This is a simplified version of PR #1673 , as requested
This closes #1671  and closes #1505
Allow TFC host selection during login. Hosts already in TFC credentials file are displayed. Options for insertion of new hosts added:
![image](https://github.com/hashicorp/vscode-terraform/assets/72307937/70a2e835-883f-4cc2-99b9-c887cbac3986)
![image](https://github.com/hashicorp/vscode-terraform/assets/72307937/6d8078b5-99f8-4d85-8aab-77b45406349d)

N.B. Logging to a new hostname does not update the TFC credentials file (Maybe to be implemented in the future?)