### PR TITLE
Add test fixture files for E2E test

### DIFF
--- a/test/fixtures/ai/variables.tf
+++ b/test/fixtures/ai/variables.tf
@@ -1,0 +1,3 @@
+variable "agi" {
+  default = false
+}

--- a/test/fixtures/compute/main.tf
+++ b/test/fixtures/compute/main.tf
@@ -1,0 +1,21 @@
+
+resource "google_compute_network" "vpc_network" {
+  name = "terraform-network"
+}
+
+resource "google_compute_instance" "vm_instance" {
+  name         = var.instance_name
+  machine_type = var.machine_type
+
+  boot_disk {
+    initialize_params {
+      image = "debian-cloud/debian-11"
+    }
+  }
+
+  network_interface {
+    network = google_compute_network.vpc_network.name
+    access_config {
+    }
+  }
+}

--- a/test/fixtures/compute/outputs.tf
+++ b/test/fixtures/compute/outputs.tf
@@ -1,0 +1,3 @@
+output "ip" {
+  value = google_compute_instance.vm_instance.network_interface[0].network_ip
+}

--- a/test/fixtures/compute/variables.tf
+++ b/test/fixtures/compute/variables.tf
@@ -1,0 +1,9 @@
+variable "instance_name" {
+  type        = string
+  description = "Name of the compute instance"
+}
+
+variable "machine_type" {
+  type    = string
+  default = "f1-micro"
+}

--- a/test/fixtures/main.tf
+++ b/test/fixtures/main.tf
@@ -1,0 +1,22 @@
+terraform {
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 4.0"
+    }
+  }
+}
+
+provider "google" {
+  credentials = file(var.credentials_file)
+
+  project = var.project
+  region  = var.region
+  zone    = var.zone
+}
+
+module "compute" {
+  source = "./compute"
+
+  instance_name = "terraform-machine"
+}

--- a/test/fixtures/terraform.tfvars
+++ b/test/fixtures/terraform.tfvars
@@ -1,0 +1,1 @@
+zone = "us-central1-c"

--- a/test/fixtures/variables.tf
+++ b/test/fixtures/variables.tf
@@ -1,0 +1,15 @@
+variable "project" {
+  type = string
+}
+
+variable "credentials_file" {
+  type = string
+}
+
+variable "region" {
+  default = "us-central1"
+}
+
+variable "zone" {
+  default = "us-central1-c"
+}


### PR DESCRIPTION
This should allow us to implement some scenarios like:

- Completion for a local module sources (prefix `./`)
- Completion for inputs of a local module
- Go-to-definition on a local module source
- Go-to-definition on a module input
- Go-to-definition on a `var.something` reference
- Completion of the variable name inside the `tfvars` file
- Go-to-definition on the variable name inside `tfvars`
- Find references on the variable block