### PR TITLE
Update vscode-languageclient to 9.0.1

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -63,7 +63,7 @@ jobs:
       fail-fast: false
       matrix:
         vscode:
-          - '1.82.3'
+          - '1.86.2'
           - 'insiders'
           - 'stable'
         os:

--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ The Terraform VS Code extension bundles the [Terraform Language Server](https://
 
 The extension does require the following to be installed before use:
 
-- VS Code v1.82 or greater
+- VS Code v1.86 or greater
 - Terraform v0.12 or greater
 
 ## Platform Support

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@zodios/plugins": "^10.6.0",
         "axios": "^1.4.0",
         "semver": "^7.5.4",
-        "vscode-languageclient": "8.1.0",
+        "vscode-languageclient": "^9.0.1",
         "vscode-uri": "^3.0.7",
         "which": "^3.0.1",
         "zod": "^3.21.4"
@@ -53,7 +53,7 @@
       "engines": {
         "node": "~18.X",
         "npm": "~10.X",
-        "vscode": "^1.82.3"
+        "vscode": "^1.86.2"
       }
     },
     "node_modules/@aashutoshrathi/word-wrap": {
@@ -7226,24 +7226,24 @@
       }
     },
     "node_modules/vscode-jsonrpc": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.1.0.tgz",
-      "integrity": "sha512-6TDy/abTQk+zDGYazgbIPc+4JoXdwC8NHU9Pbn4UJP1fehUyZmM4RHp5IthX7A6L5KS30PRui+j+tbbMMMafdw==",
+      "version": "8.2.0",
+      "resolved": "https://registry.npmjs.org/vscode-jsonrpc/-/vscode-jsonrpc-8.2.0.tgz",
+      "integrity": "sha512-C+r0eKJUIfiDIfwJhria30+TYWPtuHJXHtI7J0YlOmKAo7ogxP20T0zxB7HZQIFhIyvoBPwWskjxrvAtfjyZfA==",
       "engines": {
         "node": ">=14.0.0"
       }
     },
     "node_modules/vscode-languageclient": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-8.1.0.tgz",
-      "integrity": "sha512-GL4QdbYUF/XxQlAsvYWZRV3V34kOkpRlvV60/72ghHfsYFnS/v2MANZ9P6sHmxFcZKOse8O+L9G7Czg0NUWing==",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/vscode-languageclient/-/vscode-languageclient-9.0.1.tgz",
+      "integrity": "sha512-JZiimVdvimEuHh5olxhxkht09m3JzUGwggb5eRUkzzJhZ2KjCN0nh55VfiED9oez9DyF8/fz1g1iBV3h+0Z2EA==",
       "dependencies": {
         "minimatch": "^5.1.0",
         "semver": "^7.3.7",
-        "vscode-languageserver-protocol": "3.17.3"
+        "vscode-languageserver-protocol": "3.17.5"
       },
       "engines": {
-        "vscode": "^1.67.0"
+        "vscode": "^1.82.0"
       }
     },
     "node_modules/vscode-languageclient/node_modules/brace-expansion": {
@@ -7266,18 +7266,18 @@
       }
     },
     "node_modules/vscode-languageserver-protocol": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.3.tgz",
-      "integrity": "sha512-924/h0AqsMtA5yK22GgMtCYiMdCOtWTSGgUOkgEDX+wk2b0x4sAfLiO4NxBxqbiVtz7K7/1/RgVrVI0NClZwqA==",
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-protocol/-/vscode-languageserver-protocol-3.17.5.tgz",
+      "integrity": "sha512-mb1bvRJN8SVznADSGWM9u/b07H7Ecg0I3OgXDuLdn307rl/J3A9YD6/eYOssqhecL27hK1IPZAsaqh00i/Jljg==",
       "dependencies": {
-        "vscode-jsonrpc": "8.1.0",
-        "vscode-languageserver-types": "3.17.3"
+        "vscode-jsonrpc": "8.2.0",
+        "vscode-languageserver-types": "3.17.5"
       }
     },
     "node_modules/vscode-languageserver-types": {
-      "version": "3.17.3",
-      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.3.tgz",
-      "integrity": "sha512-SYU4z1dL0PyIMd4Vj8YOqFvHu7Hz/enbWtpfnVbJHU4Nd1YNYx8u0ennumc6h48GQNeOLxmwySmnADouT/AuZA=="
+      "version": "3.17.5",
+      "resolved": "https://registry.npmjs.org/vscode-languageserver-types/-/vscode-languageserver-types-3.17.5.tgz",
+      "integrity": "sha512-Ld1VelNuX9pdF39h2Hgaeb5hEZM2Z3jUrrMgWQAu82jMtZp7p3vJT3BzToKtZI7NgQssZje5o0zryOrhQvzQAg=="
     },
     "node_modules/vscode-uri": {
       "version": "3.0.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,7 +26,7 @@
         "@types/glob": "^8.1.0",
         "@types/mocha": "^10.0.1",
         "@types/node": "^18.x",
-        "@types/vscode": "~1.82.0",
+        "@types/vscode": "1.86",
         "@types/webpack-env": "^1.18.0",
         "@types/which": "^3.0.0",
         "@typescript-eslint/eslint-plugin": "^5.59.5",
@@ -792,9 +792,9 @@
       "dev": true
     },
     "node_modules/@types/vscode": {
-      "version": "1.82.0",
-      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.82.0.tgz",
-      "integrity": "sha512-VSHV+VnpF8DEm8LNrn8OJ8VuUNcBzN3tMvKrNpbhhfuVjFm82+6v44AbDhLvVFgCzn6vs94EJNTp7w8S6+Q1Rw==",
+      "version": "1.86.0",
+      "resolved": "https://registry.npmjs.org/@types/vscode/-/vscode-1.86.0.tgz",
+      "integrity": "sha512-DnIXf2ftWv+9LWOB5OJeIeaLigLHF7fdXF6atfc7X5g2w/wVZBgk0amP7b+ub5xAuW1q7qP5YcFvOcit/DtyCQ==",
       "dev": true
     },
     "node_modules/@types/webpack-env": {

--- a/package.json
+++ b/package.json
@@ -883,7 +883,7 @@
     "@types/glob": "^8.1.0",
     "@types/mocha": "^10.0.1",
     "@types/node": "^18.x",
-    "@types/vscode": "~1.82.0",
+    "@types/vscode": "~1.86",
     "@types/webpack-env": "^1.18.0",
     "@types/which": "^3.0.0",
     "@typescript-eslint/eslint-plugin": "^5.59.5",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "engines": {
     "npm": "~10.X",
     "node": "~18.X",
-    "vscode": "^1.82.3"
+    "vscode": "^1.86.2"
   },
   "langServer": {
     "version": "0.33.1"
@@ -871,7 +871,7 @@
     "@zodios/plugins": "^10.6.0",
     "axios": "^1.4.0",
     "semver": "^7.5.4",
-    "vscode-languageclient": "8.1.0",
+    "vscode-languageclient": "^9.0.1",
     "vscode-uri": "^3.0.7",
     "which": "^3.0.1",
     "zod": "^3.21.4"

--- a/src/features/languageStatus.ts
+++ b/src/features/languageStatus.ts
@@ -19,6 +19,9 @@ export class LanguageStatusFeature implements StaticFeature {
     private outputChannel: vscode.OutputChannel,
   ) {}
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  clear(): void {}
+
   getState(): FeatureState {
     return {
       kind: 'static',

--- a/src/features/moduleCalls.ts
+++ b/src/features/moduleCalls.ts
@@ -21,6 +21,9 @@ export class ModuleCallsFeature implements StaticFeature {
 
   constructor(private client: BaseLanguageClient, private view: ModuleCallsDataProvider) {}
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  clear(): void {}
+
   getState(): FeatureState {
     return {
       kind: 'static',

--- a/src/features/moduleProviders.ts
+++ b/src/features/moduleProviders.ts
@@ -21,6 +21,9 @@ export class ModuleProvidersFeature implements StaticFeature {
 
   constructor(private client: BaseLanguageClient, private view: ModuleProvidersDataProvider) {}
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  clear(): void {}
+
   getState(): FeatureState {
     return {
       kind: 'static',

--- a/src/features/semanticTokens.ts
+++ b/src/features/semanticTokens.ts
@@ -25,6 +25,9 @@ interface ObjectWithId {
 export class CustomSemanticTokens implements StaticFeature {
   constructor(private _client: BaseLanguageClient, private manifest: PartialManifest) {}
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  clear(): void {}
+
   getState(): FeatureState {
     return {
       kind: 'static',

--- a/src/features/showReferences.ts
+++ b/src/features/showReferences.ts
@@ -35,6 +35,9 @@ export class ShowReferencesFeature implements StaticFeature {
 
   constructor(private _client: BaseLanguageClient) {}
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  clear(): void {}
+
   getState(): FeatureState {
     return {
       kind: 'static',

--- a/src/features/telemetry.ts
+++ b/src/features/telemetry.ts
@@ -22,6 +22,9 @@ export class TelemetryFeature implements StaticFeature {
 
   constructor(private client: BaseLanguageClient, private reporter: TelemetryReporter) {}
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  clear(): void {}
+
   getState(): FeatureState {
     return {
       kind: 'static',

--- a/src/features/terraformVersion.ts
+++ b/src/features/terraformVersion.ts
@@ -26,6 +26,9 @@ export class TerraformVersionFeature implements StaticFeature {
     private outputChannel: vscode.OutputChannel,
   ) {}
 
+  // eslint-disable-next-line @typescript-eslint/no-empty-function
+  clear(): void {}
+
   getState(): FeatureState {
     return {
       kind: 'static',

--- a/src/test/helper.ts
+++ b/src/test/helper.ts
@@ -4,7 +4,6 @@
  */
 
 import * as vscode from 'vscode';
-import * as path from 'path';
 import * as assert from 'assert';
 
 export async function open(docUri: vscode.Uri): Promise<void> {


### PR DESCRIPTION
This updates the vscode-languageclient package to 9.0.1. This is a major update that includes a number of changes, including a new dependency on vscode-jsonrpc 8.2.0 and vscode-languageserver-protocol 3.17.5

NOTE: This requires bumping the minimum supported VS Code version to 1.86