### PR TITLE
Rename TFC to HCP Terraform

### DIFF
--- a/.github/SUPPORT.md
+++ b/.github/SUPPORT.md
@@ -4,4 +4,4 @@ If you have questions about Terraform VS Code extension usage, please feel free 
 
 ## Enterprise/Commercial Support
 
-If you are an existing Terraform Cloud or Enterprise customer on a [plan](https://www.hashicorp.com/products/terraform/pricing) with support included, please submit a HashiCorp support request or email tf-cloud@hashicorp.support
+If you are an existing HCP Terraform or Terraform Enterprise customer on a [plan](https://www.hashicorp.com/products/terraform/pricing) with support included, please submit a HashiCorp support request or email tf-cloud@hashicorp.support

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Read the [Troubleshooting Guide](#troubleshooting) for answers to common questio
 - [Code Navigation](#code-navigation) Navigate through your codebase with Go to Definition and Symbol support
 - [Code Formatting](#code-formatting) Format your code with `terraform fmt` automatically
 - [Code Snippets](#code-snippets) Shortcuts for common snippets like `for_each` and `variable`
-- [Terraform Cloud Integration](#terraform-cloud-integration) View Terraform Cloud Workspaces and Run details inside VS Code
+- [HCP Terraform Integration](#hcp-terraform-integration) View HCP Terraform Workspaces and Run details inside VS Code
 - [Terraform Module Explorer](#terraform-module-and-provider-explorer) View all modules and providers referenced in the currently open document.
 - [Terraform commands](#terraform-commands) Directly execute commands like `terraform init` or `terraform plan` from the VS Code Command Palette.
 
@@ -115,13 +115,13 @@ The extension provides several snippets to accelerate adding Terraform code to y
 - `vare` - Empty variable
 - `varm` - Map Variable
 
-### Terraform Cloud Integration
+### HCP Terraform Integration
 
-Every time you have to switch away from your code, you risk losing momentum and the context about your tasks. Previously, Terraform users needed to have at least two windows open – their editor and a web page – to develop Terraform code. The editor contains all of the Terraform code they are working on, and the web page has the Terraform Cloud workspace loaded. Switching back and forth between the Terraform Cloud website and the text editor can be a frustrating and fragmented experience.
+Every time you have to switch away from your code, you risk losing momentum and the context about your tasks. Previously, Terraform users needed to have at least two windows open – their editor and a web page – to develop Terraform code. The editor contains all of the Terraform code they are working on, and the web page has the HCP Terraform workspace loaded. Switching back and forth between the HCP Terraform website and the text editor can be a frustrating and fragmented experience.
 
-The Terraform Cloud Visual Studio Code integration improves user experience by allowing users to view workspaces directly from within Visual Studio Code. Users can view the status of current and past runs and inspect detailed logs – without ever leaving the comfort of their editor.
+The HCP Terraform Visual Studio Code integration improves user experience by allowing users to view workspaces directly from within Visual Studio Code. Users can view the status of current and past runs and inspect detailed logs – without ever leaving the comfort of their editor.
 
-To start using Terraform Cloud with VS Code, open the new Terraform Cloud sidebar and click "Login to Terraform Cloud". You can login using a stored token from the Terraform CLI, an existing token you provide, or open the Terraform Cloud website to generate a new token.
+To start using HCP Terraform with VS Code, open the new HCP Terraform sidebar and click "Login to HCP Terraform". You can login using a stored token from the Terraform CLI, an existing token you provide, or open the HCP Terraform website to generate a new token.
 
 ![](docs/tfc/login_view.gif)
 
@@ -141,7 +141,7 @@ If a Run has been Planned or Applied, you can view the raw log for each by expan
 
 ![](docs/tfc/plan_apply_view.gif)
 
-To sign out or log out of your Terraform Cloud session, click the Accounts icon next to the Settings icon in the Activity Bar and select "Sign Out":
+To sign out or log out of your HCP Terraform session, click the Accounts icon next to the Settings icon in the Activity Bar and select "Sign Out":
 
 ![](docs/tfc/log_out.png)
 

--- a/package.json
+++ b/package.json
@@ -464,7 +464,7 @@
       },
       {
         "command": "terraform.cloud.login",
-        "title": "HashiCorp Terraform Cloud: Login",
+        "title": "HashiCorp HCP Terraform: Login",
         "enablement": "terraform.cloud.signed-in === false"
       },
       {
@@ -516,7 +516,7 @@
       },
       {
         "command": "terraform.cloud.organization.picker",
-        "title": "HashiCorp Terraform Cloud: Pick Organization",
+        "title": "HashiCorp HCP Terraform: Pick Organization",
         "icon": "$(account)",
         "enablement": "terraform.cloud.signed-in"
       },
@@ -707,12 +707,12 @@
         {
           "id": "terraform.cloud.workspaces",
           "name": "Workspaces",
-          "contextualTitle": "Terraform Cloud workspaces"
+          "contextualTitle": "HCP Terraform workspaces"
         },
         {
           "id": "terraform.cloud.runs",
           "name": "Runs",
-          "contextualTitle": "Terraform Cloud runs"
+          "contextualTitle": "HCP Terraform runs"
         }
       ],
       "terraform-cloud-panel": [
@@ -737,14 +737,14 @@
         },
         {
           "id": "terraform-cloud",
-          "title": "HashiCorp Terraform Cloud",
+          "title": "HashiCorp Cloud Platform Terraform",
           "icon": "assets/icons/vs_code_terraform_cloud.svg"
         }
       ],
       "panel": [
         {
           "id": "terraform-cloud-panel",
-          "title": "Terraform Cloud",
+          "title": "HCP Terraform",
           "icon": "assets/icons/vs_code_terraform_cloud.svg"
         }
       ]
@@ -802,12 +802,12 @@
       },
       {
         "view": "terraform.cloud.workspaces",
-        "contents": "In order to use Terraform Cloud features, you need to be logged in\n[Login to Terraform Cloud](command:terraform.cloud.login)",
+        "contents": "In order to use HCP Terraform features, you need to be logged in\n[Login to HCP Terraform](command:terraform.cloud.login)",
         "when": "terraform.cloud.signed-in === false"
       },
       {
         "view": "terraform.cloud.workspaces",
-        "contents": "No organizations found for this token. Please create a new Terraform Cloud organization to get started\n[Create or select an organization](command:terraform.cloud.organization.picker)",
+        "contents": "No organizations found for this token. Please create a new HCP Terraform organization to get started\n[Create or select an organization](command:terraform.cloud.organization.picker)",
         "when": "terraform.cloud.signed-in && !terraform.cloud.organizationsExist && !terraform.cloud.organizationsChosen"
       },
       {

--- a/package.json
+++ b/package.json
@@ -464,7 +464,7 @@
       },
       {
         "command": "terraform.cloud.login",
-        "title": "HashiCorp HCP Terraform: Login",
+        "title": "HCP Terraform: Login",
         "enablement": "terraform.cloud.signed-in === false"
       },
       {
@@ -516,7 +516,7 @@
       },
       {
         "command": "terraform.cloud.organization.picker",
-        "title": "HashiCorp HCP Terraform: Pick Organization",
+        "title": "HCP Terraform: Pick Organization",
         "icon": "$(account)",
         "enablement": "terraform.cloud.signed-in"
       },
@@ -737,7 +737,7 @@
         },
         {
           "id": "terraform-cloud",
-          "title": "HashiCorp Cloud Platform Terraform",
+          "title": "HCP Terraform",
           "icon": "assets/icons/vs_code_terraform_cloud.svg"
         }
       ],

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ const documentSelector: DocumentSelector = [
   { scheme: 'file', language: 'terraform-vars' },
 ];
 const outputChannel = vscode.window.createOutputChannel(brand);
-const tfcOutputChannel = vscode.window.createOutputChannel('HashiCorp Terraform Cloud');
+const tfcOutputChannel = vscode.window.createOutputChannel('HashiCorp Cloud Platform Terraform');
 
 let reporter: TelemetryReporter;
 let client: LanguageClient;

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,7 +43,7 @@ const documentSelector: DocumentSelector = [
   { scheme: 'file', language: 'terraform-vars' },
 ];
 const outputChannel = vscode.window.createOutputChannel(brand);
-const tfcOutputChannel = vscode.window.createOutputChannel('HashiCorp Cloud Platform Terraform');
+const tfcOutputChannel = vscode.window.createOutputChannel('HCP Terraform');
 
 let reporter: TelemetryReporter;
 let client: LanguageClient;

--- a/src/features/terraformCloud.ts
+++ b/src/features/terraformCloud.ts
@@ -213,7 +213,7 @@ export class OrganizationStatusBar implements vscode.Disposable {
     this.organizationStatusBar.name = 'TFCOrganizationBar';
     this.organizationStatusBar.command = {
       command: 'terraform.cloud.organization.picker',
-      title: 'Choose your Terraform Cloud Organization',
+      title: 'Choose your HCP Terraform Organization',
     };
   }
 

--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -92,6 +92,8 @@ class TerraformCloudSessionHandler {
 }
 export class TerraformCloudAuthenticationProvider implements vscode.AuthenticationProvider, vscode.Disposable {
   static providerLabel = 'HashiCorp Cloud Platform Terraform';
+  // These are IDs and session keys that are used to identify the provider and the session in VS Code secret storage
+  // we cannot change these in the rebrand without the user losing the previous session
   static providerID = 'HashiCorpTerraformCloud';
   private sessionKey = 'HashiCorpTerraformCloudSession';
   private logger: vscode.LogOutputChannel;
@@ -270,7 +272,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
         canPickMany: false,
         ignoreFocusOut: true,
         placeHolder: 'Choose a method to enter a HCP Terraform user token',
-        title: 'HashiCorp Cloud Platform Terraform Authentication',
+        title: 'HCP Terraform Authentication',
       },
     );
     if (choice === undefined) {

--- a/src/providers/authenticationProvider.ts
+++ b/src/providers/authenticationProvider.ts
@@ -91,7 +91,7 @@ class TerraformCloudSessionHandler {
   }
 }
 export class TerraformCloudAuthenticationProvider implements vscode.AuthenticationProvider, vscode.Disposable {
-  static providerLabel = 'HashiCorp Terraform Cloud';
+  static providerLabel = 'HashiCorp Cloud Platform Terraform';
   static providerID = 'HashiCorpTerraformCloud';
   private sessionKey = 'HashiCorpTerraformCloudSession';
   private logger: vscode.LogOutputChannel;
@@ -147,7 +147,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     try {
       const session = await this.sessionPromise;
       if (session) {
-        this.logger.info('Successfully fetched Terraform Cloud session');
+        this.logger.info('Successfully fetched HCP Terraform session');
         await vscode.commands.executeCommand('setContext', 'terraform.cloud.signed-in', true);
         return [session];
       } else {
@@ -178,7 +178,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
     try {
       const session = await this.sessionHandler.store(token);
       this.reporter.sendTelemetryEvent('tfc-login-success');
-      this.logger.info('Successfully logged in to Terraform Cloud');
+      this.logger.info('Successfully logged in to HCP Terraform');
 
       await vscode.commands.executeCommand('setContext', 'terraform.cloud.signed-in', true);
 
@@ -263,14 +263,14 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
         },
         {
           label: 'Generate a user token',
-          detail: 'Open the Terraform Cloud website to generate a new token',
+          detail: 'Open the HCP Terraform website to generate a new token',
         },
       ],
       {
         canPickMany: false,
         ignoreFocusOut: true,
-        placeHolder: 'Choose a method to enter a Terraform Cloud user token',
-        title: 'HashiCorp Terraform Cloud Authentication',
+        placeHolder: 'Choose a method to enter a HCP Terraform user token',
+        title: 'HashiCorp Cloud Platform Terraform Authentication',
       },
     );
     if (choice === undefined) {
@@ -287,7 +287,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
         token = await vscode.window.showInputBox({
           ignoreFocusOut: true,
           placeHolder: 'User access token',
-          prompt: 'Enter a Terraform Cloud user access token',
+          prompt: 'Enter a HCP Terraform user access token',
           password: true,
         });
         break;
@@ -297,7 +297,7 @@ export class TerraformCloudAuthenticationProvider implements vscode.Authenticati
         token = await vscode.window.showInputBox({
           ignoreFocusOut: true,
           placeHolder: 'User access token',
-          prompt: 'Enter a Terraform Cloud user access token',
+          prompt: 'Enter a HCP Terraform user access token',
           password: true,
         });
         break;

--- a/src/providers/tfc/organizationPicker.ts
+++ b/src/providers/tfc/organizationPicker.ts
@@ -48,7 +48,7 @@ class OrganizationItem implements vscode.QuickPickItem {
 
 export class OrganizationAPIResource implements APIResource {
   name = 'organizations';
-  title = 'Welcome to Terraform Cloud';
+  title = 'Welcome to HCP Terraform';
   placeholder = 'Choose an organization (type to search)';
   ignoreFocusOut = true;
 

--- a/src/terraformCloud/configurationVersion.ts
+++ b/src/terraformCloud/configurationVersion.ts
@@ -12,7 +12,7 @@ export const CONFIGURATION_SOURCE: { [id: string]: string } = {
   gitlab: 'GitLab',
   github: 'GitHub',
   terraform: 'Terraform',
-  'terraform+cloud': 'Terraform Cloud',
+  'terraform+cloud': 'HCP Terraform',
   tfeAPI: 'API',
   'tfe-api': 'API',
   module: 'No-code Module',

--- a/src/terraformCloud/configurationVersion.ts
+++ b/src/terraformCloud/configurationVersion.ts
@@ -12,8 +12,6 @@ export const CONFIGURATION_SOURCE: { [id: string]: string } = {
   gitlab: 'GitLab',
   github: 'GitHub',
   terraform: 'Terraform',
-  // TODO: check that the map is rebranded
-  // 'terraform+cloud': 'HCP Terraform',
   'terraform+cloud': 'Terraform Cloud',
   tfeAPI: 'API',
   'tfe-api': 'API',

--- a/src/terraformCloud/configurationVersion.ts
+++ b/src/terraformCloud/configurationVersion.ts
@@ -12,7 +12,9 @@ export const CONFIGURATION_SOURCE: { [id: string]: string } = {
   gitlab: 'GitLab',
   github: 'GitHub',
   terraform: 'Terraform',
-  'terraform+cloud': 'HCP Terraform',
+  // TODO: check that the map is rebranded
+  // 'terraform+cloud': 'HCP Terraform',
+  'terraform+cloud': 'Terraform Cloud',
   tfeAPI: 'API',
   'tfe-api': 'API',
   module: 'No-code Module',

--- a/test/specs/extension.ts
+++ b/test/specs/extension.ts
@@ -28,7 +28,7 @@ describe('VS Code Extension Testing', () => {
       'Run and Debug',
       'Extensions',
       'HashiCorp Terraform',
-      'HashiCorp Terraform Cloud',
+      'HCP Terraform',
     ]);
   });
 


### PR DESCRIPTION
This renames all user facing information containing the words "Terraform Cloud" to "HCP Terraform".

It does not rename/refactor any code using the old references. The authentication provider ID and sesison key remain the same to preserve existing logins.