### PR TITLE
Replace outdated remove-labels action with `gh`

### DIFF
--- a/.github/workflows/issue-comment-created.yml
+++ b/.github/workflows/issue-comment-created.yml
@@ -10,11 +10,11 @@ on:
 
 jobs:
   issue_comment_triage:
+    # Only run this job for issue comments
+    if: ${{ !github.event.issue.pull_request }}
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
-      - uses: actions-ecosystem/action-remove-labels@2ce5d41b4b6aa8503e285553f75ed56e0a40bae0 # v1.3.0
-        with:
-          labels: |
-            stale
-            waiting-reply
+      - name: Remove stale and waiting-response labels
+        run: gh issue edit ${{ github.event.issue.html_url }} --remove-label stale,waiting-response


### PR DESCRIPTION
This PR replaces the unmaintained https://github.com/actions-ecosystem/action-remove-labels actions with a `gh` command.

This is part of the migration to Node 20 and should remove most of the warnings: https://github.com/hashicorp/vscode-terraform/actions/runs/8875007191