### PR TITLE
Ignore changie logs in vsix by default

### DIFF
--- a/.changes/unreleased/INTERNAL-20240523-135341.yaml
+++ b/.changes/unreleased/INTERNAL-20240523-135341.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Remove old web testing infrastructure and update the test GHA
+time: 2024-05-23T13:53:41.899594-04:00
+custom:
+    Issue: "1760"
+    Repository: vscode-terraform

--- a/.copywrite.hcl
+++ b/.copywrite.hcl
@@ -12,5 +12,6 @@ project {
     "test/fixtures/**",
     "src/test/integration/*/workspace/**",
     ".vscode-test/**",
+    ".changes/**"
   ]
 }

--- a/.vscodeignore
+++ b/.vscodeignore
@@ -27,3 +27,5 @@ tsconfig.json
 test/
 .copywrite.hcl
 .vscode-test.mjs
+.changie.yaml
+.changes


### PR DESCRIPTION
This change adds `.changie.yaml` and `.changes` to the `.vscodeignore` file so that they are not included in the VSIX package.

This was missed in https://github.com/hashicorp/vscode-terraform/pull/1757
