### PR TITLE
Cache npm packages in GitHub Actions

### DIFF
--- a/.changes/unreleased/INTERNAL-20240524-100633.yaml
+++ b/.changes/unreleased/INTERNAL-20240524-100633.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Cache npm packages in GHA
+time: 2024-05-24T10:06:33.229796-04:00
+custom:
+    Issue: "1762"
+    Repository: vscode-terraform

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -66,6 +66,7 @@ jobs:
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: '.nvmrc'
+          cache: npm
 
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,6 +26,7 @@ jobs:
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: '.nvmrc'
+          cache: npm
       - name: npm install
         run: npm ci
       - name: lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,13 +48,13 @@ jobs:
           - ubuntu-latest
     runs-on: ${{ matrix.os }}
     timeout-minutes: 10
-
     steps:
       - name: Checkout Repo
         uses: actions/checkout@0ad4b8fadaa221de15dcec353f45205ec38ea70b # v4.1.4
       - uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:
           node-version-file: '.nvmrc'
+          cache: npm
       - name: Install Terraform
         uses: hashicorp/setup-terraform@v3
         with:


### PR DESCRIPTION
This PR adds npm caching to the GitHub Actions workflows. This should speed up the CI builds by caching the npm packages between builds.
