### PR TITLE
Bump LS version to 0.33.2

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240606-104729.yaml
+++ b/.changes/unreleased/BUG FIXES-20240606-104729.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: Fix data race in schema merging logic
+time: 2024-06-06T10:47:29.137057+02:00
+custom:
+  Issue: "397"
+  Repository: hcl-lang

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "vscode": "^1.86.2"
   },
   "langServer": {
-    "version": "0.33.1"
+    "version": "0.33.2"
   },
   "syntax": {
     "version": "0.5.0"


### PR DESCRIPTION
This will pull in the latest version of the language server with a small bug fix.

Since we now include the license file with each LS release, we extract two files into the `bin/` folder. But I don't see any problems with that.