### PR TITLE
Declare support for Terraform Stacks

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240611-152455.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240611-152455.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Declare support for Terraform Stack files
+time: 2024-06-11T15:24:55.009488-04:00
+custom:
+    Issue: "1773"
+    Repository: vscode-terraform

--- a/build/downloader.ts
+++ b/build/downloader.ts
@@ -108,38 +108,44 @@ async function downloadLanguageServer(platform: string, architecture: string, ex
   });
 }
 
+async function downloadFile(url: string, installPath: string) {
+  if (process.env.downloader_log === 'true') {
+    console.log(`Downloading: ${url}`);
+  }
+
+  const buffer = await fileFromUrl(url);
+  fs.writeFileSync(installPath, buffer);
+  if (process.env.downloader_log === 'true') {
+    console.log(`Download completed: ${installPath}`);
+  }
+}
+
 async function downloadSyntax(info: ExtensionInfo) {
   const release = `v${info.syntaxVersion}`;
-
-  const productName = info.name.replace('-preview', '');
-  const fileName = `${productName}.tmGrammar.json`;
 
   const cwd = path.resolve(__dirname);
   const buildDir = path.basename(cwd);
   const repoDir = cwd.replace(buildDir, '');
   const installPath = path.join(repoDir, 'syntaxes');
 
-  const fpath = path.join(installPath, fileName);
-  if (fs.existsSync(fpath)) {
+  if (fs.existsSync(installPath)) {
     if (process.env.downloader_log === 'true') {
-      console.log(`Syntax path exists at ${fpath}. Exiting`);
+      console.log(`Syntax path exists at ${installPath}. Exiting`);
     }
     return;
   }
 
   fs.mkdirSync(installPath);
 
-  const url = `https://github.com/hashicorp/syntax/releases/download/${release}/${fileName}`;
-  if (process.env.downloader_log === 'true') {
-    console.log(`Downloading: ${url}`);
-  }
-  // const content = await got({ url }).text();
-  // fs.writeFileSync(fpath, content);
-  const buffer = await fileFromUrl(url);
-  fs.writeFileSync(fpath, buffer);
-  if (process.env.downloader_log === 'true') {
-    console.log(`Download completed: ${fpath}`);
-  }
+  const productName = info.name.replace('-preview', '');
+  const terraformSyntaxFile = `${productName}.tmGrammar.json`;
+  const hclSyntaxFile = `hcl.tmGrammar.json`;
+
+  let url = `https://github.com/hashicorp/syntax/releases/download/${release}/${terraformSyntaxFile}`;
+  await downloadFile(url, path.join(installPath, terraformSyntaxFile));
+
+  url = `https://github.com/hashicorp/syntax/releases/download/${release}/${hclSyntaxFile}`;
+  await downloadFile(url, path.join(installPath, hclSyntaxFile));
 }
 
 async function run(platform: string, architecture: string) {

--- a/build/downloader.ts
+++ b/build/downloader.ts
@@ -130,9 +130,9 @@ async function downloadSyntax(info: ExtensionInfo) {
 
   if (fs.existsSync(installPath)) {
     if (process.env.downloader_log === 'true') {
-      console.log(`Syntax path exists at ${installPath}. Exiting`);
+      console.log(`Syntax path exists at ${installPath}. Removing`);
     }
-    return;
+    fs.rmSync(installPath, { recursive: true });
   }
 
   fs.mkdirSync(installPath);

--- a/package.json
+++ b/package.json
@@ -115,13 +115,13 @@
       },
       {
         "language": "terraform-stacks",
-        "scopeName": "source.hcl.terraform",
-        "path": "./syntaxes/terraform.tmGrammar.json"
+        "scopeName": "source.hcl",
+        "path": "./syntaxes/hcl.tmGrammar.json"
       },
       {
         "language": "terraform-deployment",
-        "scopeName": "source.hcl.terraform",
-        "path": "./syntaxes/terraform.tmGrammar.json"
+        "scopeName": "source.hcl",
+        "path": "./syntaxes/hcl.tmGrammar.json"
       }
     ],
     "semanticTokenTypes": [

--- a/package.json
+++ b/package.json
@@ -76,6 +76,26 @@
         "configuration": "./language-configuration.json"
       },
       {
+        "id": "terraform-stacks",
+        "aliases": [
+          "Terraform Stacks"
+        ],
+        "extensions": [
+          ".tfstack.hcl"
+        ],
+        "configuration": "./language-configuration.json"
+      },
+      {
+        "id": "terraform-deployment",
+        "aliases": [
+          "Terraform Stacks Deployment"
+        ],
+        "extensions": [
+          ".tfdeploy.hcl"
+        ],
+        "configuration": "./language-configuration.json"
+      },
+      {
         "id": "json",
         "extensions": [
           ".tfstate"
@@ -90,6 +110,16 @@
       },
       {
         "language": "terraform-vars",
+        "scopeName": "source.hcl.terraform",
+        "path": "./syntaxes/terraform.tmGrammar.json"
+      },
+      {
+        "language": "terraform-stacks",
+        "scopeName": "source.hcl.terraform",
+        "path": "./syntaxes/terraform.tmGrammar.json"
+      },
+      {
+        "language": "terraform-deployment",
         "scopeName": "source.hcl.terraform",
         "path": "./syntaxes/terraform.tmGrammar.json"
       }

--- a/package.json
+++ b/package.json
@@ -76,9 +76,9 @@
         "configuration": "./language-configuration.json"
       },
       {
-        "id": "terraform-stacks",
+        "id": "terraform-stack",
         "aliases": [
-          "Terraform Stacks"
+          "Terraform Stack"
         ],
         "extensions": [
           ".tfstack.hcl"
@@ -86,9 +86,9 @@
         "configuration": "./language-configuration.json"
       },
       {
-        "id": "terraform-deployment",
+        "id": "terraform-deploy",
         "aliases": [
-          "Terraform Stacks Deployment"
+          "Terraform Deployment"
         ],
         "extensions": [
           ".tfdeploy.hcl"
@@ -114,12 +114,12 @@
         "path": "./syntaxes/terraform.tmGrammar.json"
       },
       {
-        "language": "terraform-stacks",
+        "language": "terraform-stack",
         "scopeName": "source.hcl",
         "path": "./syntaxes/hcl.tmGrammar.json"
       },
       {
-        "language": "terraform-deployment",
+        "language": "terraform-deploy",
         "scopeName": "source.hcl",
         "path": "./syntaxes/hcl.tmGrammar.json"
       }


### PR DESCRIPTION
This begins the process of adding support for tfstack and tfdeploy files by declaring the file extensions and language identifiers in the package.json file. This will allow the extension to recognize these files and provide syntax highlighting and other language features. Future work will add icons and other features to fill out support.

Of particular note is the aliases used for tfstack.hcl and tfdeploy.hcl files. These aliases are used to provide a more user-friendly name for the language in the VS Code status bar and other places where the language name is displayed. Getting these aliases right is not only important from a branding perspective but also from a user experience perspective. They have to be readable and understandable in a small amount of space.
