### PR TITLE
Terraform Stacks Icons

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240611-152345.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240611-152345.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: This adds a new file icon for the Stacks language which will apply to all tfstack.hcl and tfdeploy.hcl files
+time: 2024-06-11T15:23:45.846172-04:00
+custom:
+    Issue: "1774"
+    Repository: vscode-terraform

--- a/assets/icons/terraform_stacks.svg
+++ b/assets/icons/terraform_stacks.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" fill="none" viewBox="1 1 62 62">
+  <g fill="#a074c4" fill-rule="evenodd" clip-path="url(#a) translate(1,0)" clip-rule="evenodd">
+    <path
+      d="m23 11 17 10.335V42L23 31.67zM42 21.335V42l18-10.33V11zM3 0v20l18 10V10zM23 53.999 40 64V44.002L23 34z" />
+  </g>
+  <defs>
+    <clipPath id="a">
+      <path fill="#fff" d="M0 0h64v64H0z" />
+    </clipPath>
+  </defs>
+</svg>

--- a/package.json
+++ b/package.json
@@ -83,7 +83,11 @@
         "extensions": [
           ".tfstack.hcl"
         ],
-        "configuration": "./language-configuration.json"
+        "configuration": "./language-configuration.json",
+        "icon": {
+          "dark": "assets/icons/terraform_stacks.svg",
+          "light": "assets/icons/terraform_stacks.svg"
+        }
       },
       {
         "id": "terraform-deploy",
@@ -93,7 +97,11 @@
         "extensions": [
           ".tfdeploy.hcl"
         ],
-        "configuration": "./language-configuration.json"
+        "configuration": "./language-configuration.json",
+        "icon": {
+          "dark": "assets/icons/terraform_stacks.svg",
+          "light": "assets/icons/terraform_stacks.svg"
+        }
       },
       {
         "id": "json",


### PR DESCRIPTION
This adds a new file icon for the Stacks language which will apply to all tfstack.hcl and tfdeploy.hcl files.

This is a new icon for several reasons:
- The existing icon is not provided by HashiCorp, it is from the default VS Code icon theme Seti and releases to it are delivered in VS Code releases.
- We cannot reference it in our extension manifest, so we need to provide our own.
- We cannot override the Seti theme, [VS Code does not allow this](https://code.visualstudio.com/api/extension-guides/file-icon-theme#language-default-icons) and replace it.

Since this is not something we can control, we are providing our own icon to ensure we can deliver a consistent experience to our users.

To solve this a new icon was created that is similar in shape and size to the existing Seti Terraform icon and uses the Seti purple color. This ensures it is visually similar to the existing icon, which is important when the user is looking at Stack files and Terraform files in the same workspace. The one flaw is that the existing Terraform icon is slightly misaligned in the Seti theme, so any icon we provide looks slightly off. This is a [known issue](https://github.com/microsoft/vscode/issues/154492) and is not something we can fix.

We could try to get the Seti icon updated, but that would require a PR to the Seti theme and a release of that theme. The Seti project does not accept new file icons lightly and does not release frequently. In addition to consume their release requires a VS Code release. There would be a long indeterminate time between submitting a new icon and a user finally seeing a correct Stacks icon.

- [ ] Needs https://github.com/hashicorp/vscode-terraform/pull/1773 to merge first