### PR TITLE
Remove preview script from deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -54,14 +54,6 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@a5ac7e51b41094c92402da3b24376905380afc29 # v4.1.6
 
-      - name: Set prerelease in package.json
-        if: inputs.deploy_type == 'prerelease'
-        id: set-preview
-        run: |
-          ./build/preview.sh
-        env:
-          LANGUAGE_SERVER_VERSION: ${{ github.event.inputs.langserver }}
-
       - name: Setup Node
         uses: actions/setup-node@60edb5dd545a775178f52524783378180af0d1f8 # v4.0.2
         with:

--- a/build/preview.sh
+++ b/build/preview.sh
@@ -20,13 +20,7 @@ MINOR=$(echo $VERSION | cut -d. -f2)
 NEW_PATCH=`git log -1 --format=%cd --date="format:%Y%m%d%H"` # e.g. 2023050312
 VER="$MAJOR.$MINOR.$NEW_PATCH"
 
-# Update the language server version if passed via the workflow
-if [ -z "${LANGUAGE_SERVER_VERSION:-}" ]; then
-  LANGUAGE_SERVER_VERSION="$(jq -r .langServer.version package.json)"
-fi
+npm version $VER --no-git-tag-version --no-commit-hooks
 
-# Update versions in package.json
-(cat package.json | jq --arg VER $VER --arg LANGVER $LANGUAGE_SERVER_VERSION '
-.version=$VER |
-.langServer.version=$LANGVER
-') > /tmp/package.json && mv /tmp/package.json package.json
+changie batch "v$VER"
+changie merge


### PR DESCRIPTION
This commit removes the preview script from the deploy workflow. The preview script is no longer needed as we use changie for incrementing the version number and will be committing the version number with prerelease as well as stable releases.
