### PR TITLE
Enable LSP for Terraform Stacks and Deployments

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240611-133948.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240611-133948.yaml
@@ -1,6 +1,0 @@
-kind: ENHANCEMENTS
-body: Re-architect the language server for improved performance and resource utilization
-time: 2024-06-11T13:39:48.445375-04:00
-custom:
-    Issue: "1667"
-    Repository: terraform-ls

--- a/.changes/unreleased/ENHANCEMENTS-20240611-133948.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240611-133948.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Re-architect the language server for improved performance and resource utilization
+time: 2024-06-11T13:39:48.445375-04:00
+custom:
+    Issue: "1667"
+    Repository: terraform-ls

--- a/.changes/v2.31.2024061114.md
+++ b/.changes/v2.31.2024061114.md
@@ -1,0 +1,10 @@
+## 2.31.2024061114 (2024-06-11)
+
+ENHANCEMENTS:
+
+* Re-architect the language server for improved performance and resource utilization ([terraform-ls#1667](https://github.com/hashicorp/terraform-ls/issues/1667))
+
+This marks the completion of a major refactoring effort. The language server will now start up much faster and use less resources, especially on larger workspaces. We achieve this by doing less work during the initial walk of a workspace. Instead, we only parse modules with open files. Whenever a file of a module is opened, we schedule all the jobs needed to understand the contents of that directory (and the referenced modules).
+
+We have tested this with workspaces and configurations of different sizes, but still expect some bugs. Please give this preview a try and let us know how it works for you.
+

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,14 @@
       "preLaunchTask": "${defaultBuildTask}"
     },
     {
+      "name": "Develop Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "preLaunchTask": "${defaultBuildTask}"
+    },
+    {
       "name": "Run Web Extension ",
       "type": "pwa-extensionHost",
       "debugWebWorkerHost": true,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,4 @@
+<<<<<<< HEAD
 ## 2.31.0 (2024-06-27)
 
 ENHANCEMENTS:
@@ -7,6 +8,17 @@ ENHANCEMENTS:
 * Adds file icons for the Stacks language which will apply to all tfstack.hcl and tfdeploy.hcl files ([#1774](https://github.com/hashicorp/vscode-terraform/issues/1774))
 * Add support for the new `templatestring` functions in Terraform 1.9 ([terraform-ls#357](https://github.com/hashicorp/terraform-ls/issues/357))
 * Introduce provisioners to `removed` blocks in Terraform 1.9 ([terraform-schema#358](https://github.com/hashicorp/terraform-schema/issues/358))
+=======
+## 2.31.2024061114 (2024-06-11)
+
+ENHANCEMENTS:
+
+* Re-architect the language server for improved performance and resource utilization ([terraform-ls#1667](https://github.com/hashicorp/terraform-ls/issues/1667))
+
+This marks the completion of a major refactoring effort. The language server will now start up much faster and use less resources, especially on larger workspaces. We achieve this by doing less work during the initial walk of a workspace. Instead, we only parse modules with open files. Whenever a file of a module is opened, we schedule all the jobs needed to understand the contents of that directory (and the referenced modules).
+
+We have tested this with workspaces and configurations of different sizes, but still expect some bugs. Please give this preview a try and let us know how it works for you.
+>>>>>>> 5ea66ef (Release 2.31.2024061114 (#1778))
 
 ## 2.30.2 (2024-06-06)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,20 @@
 {
   "name": "terraform",
+<<<<<<< HEAD
   "version": "2.31.0",
+=======
+  "version": "2.31.2024061114",
+>>>>>>> 5ea66ef (Release 2.31.2024061114 (#1778))
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terraform",
+<<<<<<< HEAD
       "version": "2.31.0",
+=======
+      "version": "2.31.2024061114",
+>>>>>>> 5ea66ef (Release 2.31.2024061114 (#1778))
       "license": "MPL-2.0",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.4.9",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "vscode": "^1.86.2"
   },
   "langServer": {
-    "version": "0.33.3"
+    "version": "0.34.0-alpha20240611"
   },
   "syntax": {
     "version": "0.5.0"

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "terraform",
   "displayName": "HashiCorp Terraform",
   "description": "Syntax highlighting and autocompletion for Terraform",
-  "version": "2.31.0",
+  "version": "2.31.2024061114",
   "publisher": "hashicorp",
   "appInsightsKey": "885372d2-6f3c-499f-9d25-b8b219983a52",
   "license": "MPL-2.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,6 +41,8 @@ const brand = `HashiCorp Terraform`;
 const documentSelector: DocumentSelector = [
   { scheme: 'file', language: 'terraform' },
   { scheme: 'file', language: 'terraform-vars' },
+  { scheme: 'file', language: 'terraform-stacks' },
+  { scheme: 'file', language: 'terraform-deployment' },
 ];
 const outputChannel = vscode.window.createOutputChannel(brand);
 const tfcOutputChannel = vscode.window.createOutputChannel('HCP Terraform');

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,6 +83,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.workspace.createFileSystemWatcher('**/*.tf'),
         vscode.workspace.createFileSystemWatcher('**/*.tfvars'),
         vscode.workspace.createFileSystemWatcher('**/*.tfstack.hcl'),
+        vscode.workspace.createFileSystemWatcher('**/*.tfdeploy.hcl'),
       ],
     },
     diagnosticCollectionName: 'HashiCorpTerraform',

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -41,8 +41,8 @@ const brand = `HashiCorp Terraform`;
 const documentSelector: DocumentSelector = [
   { scheme: 'file', language: 'terraform' },
   { scheme: 'file', language: 'terraform-vars' },
-  { scheme: 'file', language: 'terraform-stacks' },
-  { scheme: 'file', language: 'terraform-deployment' },
+  { scheme: 'file', language: 'terraform-stack' },
+  { scheme: 'file', language: 'terraform-deploy' },
 ];
 const outputChannel = vscode.window.createOutputChannel(brand);
 const tfcOutputChannel = vscode.window.createOutputChannel('HCP Terraform');
@@ -82,6 +82,7 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
       fileEvents: [
         vscode.workspace.createFileSystemWatcher('**/*.tf'),
         vscode.workspace.createFileSystemWatcher('**/*.tfvars'),
+        vscode.workspace.createFileSystemWatcher('**/*.tfstack.hcl'),
       ],
     },
     diagnosticCollectionName: 'HashiCorpTerraform',


### PR DESCRIPTION
This change adds document selectors for the Terraform Stacks and Terraform Deployments languages. This will enable the Language Server Protocol (LSP) for these languages.

Needs https://github.com/hashicorp/terraform-ls/pull/1732
