### PR TITLE
Rename `variables` to `inputs` for Stack deployments

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240715-175145.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240715-175145.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Rename variables to inputs for Stack deployments
+time: 2024-07-15T17:51:45.205093+02:00
+custom:
+    Issue: "1795"
+    Repository: vscode-terraform

--- a/src/test/integration/stacks/deployment.test.ts
+++ b/src/test/integration/stacks/deployment.test.ts
@@ -30,13 +30,13 @@ suite('stacks deployments', () => {
       assert.equal(doc.languageId, 'terraform-deploy', 'document language should be `terraform-deploy`');
     });
 
-    test('completes variables attribute in deployment block', async () => {
+    test('completes inputs attribute in deployment block', async () => {
       // add a new incomplete "test" deployment block to use for completions
       await vscode.window.activeTextEditor?.edit((editBuilder) => {
         editBuilder.insert(new vscode.Position(14, 0), 'deployment "test" {\n\n}\n');
       });
 
-      const expected = [new vscode.CompletionItem('variables', vscode.CompletionItemKind.Property)];
+      const expected = [new vscode.CompletionItem('inputs', vscode.CompletionItemKind.Property)];
 
       await testCompletion(docUri, new vscode.Position(15, 2), {
         items: expected,
@@ -44,10 +44,10 @@ suite('stacks deployments', () => {
     });
 
     // TODO: not implemented yet
-    test.skip('completes available variables in deployment block', async () => {
+    test.skip('completes available inputs in deployment block', async () => {
       // add a new incomplete "test" deployment block to use for completions
       await vscode.window.activeTextEditor?.edit((editBuilder) => {
-        editBuilder.insert(new vscode.Position(14, 0), 'deployment "test" {\nvariables = {\n\n}\n}\n');
+        editBuilder.insert(new vscode.Position(14, 0), 'deployment "test" {\ninputs = {\n\n}\n}\n');
       });
 
       const expected = [
@@ -70,7 +70,7 @@ suite('stacks deployments', () => {
           new vscode.Position(14, 0),
           `
 deployment "test" {
-  variables = {
+  inputs = {
     identity_token_file = identity_token.aws.
   }
 }

--- a/src/test/integration/stacks/stack.test.ts
+++ b/src/test/integration/stacks/stack.test.ts
@@ -30,7 +30,7 @@ suite('stacks stack', () => {
         new vscode.CompletionItem('component', vscode.CompletionItemKind.Class),
         new vscode.CompletionItem('output', vscode.CompletionItemKind.Class),
         new vscode.CompletionItem('provider', vscode.CompletionItemKind.Class),
-        new vscode.CompletionItem('required_provider', vscode.CompletionItemKind.Class),
+        new vscode.CompletionItem('required_providers', vscode.CompletionItemKind.Class),
         new vscode.CompletionItem('variable', vscode.CompletionItemKind.Class),
       ];
 
@@ -74,7 +74,7 @@ suite('stacks stack', () => {
         new vscode.CompletionItem('inputs', vscode.CompletionItemKind.Property),
         new vscode.CompletionItem('providers', vscode.CompletionItemKind.Property),
         new vscode.CompletionItem('source', vscode.CompletionItemKind.Property),
-        new vscode.CompletionItem('versions', vscode.CompletionItemKind.Property),
+        new vscode.CompletionItem('version', vscode.CompletionItemKind.Property),
       ];
 
       // await testCompletion(docUri, new vscode.Position(4, 2), {

--- a/src/test/integration/stacks/workspace/deployments.tfdeploy.hcl
+++ b/src/test/integration/stacks/workspace/deployments.tfdeploy.hcl
@@ -13,7 +13,7 @@ identity_token "aws" {
 # }
 
 deployment "development" {
-  variables = {
+  inputs = {
     region              = "us-east-1"
     role_arn            = "<Set to your development AWS account IAM role ARN>"
     identity_token_file = identity_token.aws.jwt_filename
@@ -22,7 +22,7 @@ deployment "development" {
 }
 
 deployment "production" {
-  variables = {
+  inputs = {
     region              = "us-east-1"
     role_arn            = "<Set to your production AWS account IAM role ARN>"
     identity_token_file = identity_token.aws.jwt_filename


### PR DESCRIPTION
This was recently renamed in the agent.