### PR TITLE
Add develop launch target for extensionHost

### DIFF
--- a/.changes/unreleased/INTERNAL-20240724-124159.yaml
+++ b/.changes/unreleased/INTERNAL-20240724-124159.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Add development launch target for extensionHost
+time: 2024-07-24T12:41:59.998606-04:00
+custom:
+    Issue: "1805"
+    Repository: vscode-terraform

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,6 +10,14 @@
       "preLaunchTask": "${defaultBuildTask}"
     },
     {
+      "name": "Develop Extension",
+      "type": "extensionHost",
+      "request": "launch",
+      "args": ["--extensionDevelopmentPath=${workspaceFolder}"],
+      "outFiles": ["${workspaceFolder}/out/**/*.js"],
+      "preLaunchTask": "${defaultBuildTask}"
+    },
+    {
       "name": "Run Web Extension ",
       "type": "pwa-extensionHost",
       "debugWebWorkerHost": true,


### PR DESCRIPTION
This commit adds a new launch target to the launch.json file that allows you to run the extension in a development environment.

This is useful for debugging and testing the extension without using a temporary profile.
