### PR TITLE
Static schema support for Terraform Test and Mock files

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240912-115949.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240912-115949.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Static schema support for Terraform Test and Mock files
+time: 2024-09-12T11:59:49.158918+02:00
+custom:
+    Issue: "1812"
+    Repository: vscode-terraform

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -43,6 +43,8 @@ const documentSelector: DocumentSelector = [
   { scheme: 'file', language: 'terraform-vars' },
   { scheme: 'file', language: 'terraform-stack' },
   { scheme: 'file', language: 'terraform-deploy' },
+  { scheme: 'file', language: 'terraform-test' },
+  { scheme: 'file', language: 'terraform-mock' },
 ];
 const outputChannel = vscode.window.createOutputChannel(brand);
 const tfcOutputChannel = vscode.window.createOutputChannel('HCP Terraform');
@@ -84,6 +86,8 @@ export async function activate(context: vscode.ExtensionContext): Promise<void> 
         vscode.workspace.createFileSystemWatcher('**/*.tfvars'),
         vscode.workspace.createFileSystemWatcher('**/*.tfstack.hcl'),
         vscode.workspace.createFileSystemWatcher('**/*.tfdeploy.hcl'),
+        vscode.workspace.createFileSystemWatcher('**/*.tftest.hcl'),
+        vscode.workspace.createFileSystemWatcher('**/*.tfmock.hcl'),
       ],
     },
     diagnosticCollectionName: 'HashiCorpTerraform',


### PR DESCRIPTION
* Requires https://github.com/hashicorp/terraform-ls/pull/1782

This PR adds Terraform Test & Mock file support. It adds the language configuration for test and mock files and registers the document selectors, so test files are picked up by the language server.