### PR TITLE
Enable langauge status bar for Stack languages

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20240905-143313.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20240905-143313.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Enable language status bar for Stack language
+time: 2024-09-05T14:33:13.601998-04:00
+custom:
+    Issue: "1835"
+    Repository: vscode-terraform

--- a/src/status/language.ts
+++ b/src/status/language.ts
@@ -8,6 +8,8 @@ import * as vscode from 'vscode';
 const lsStatus = vscode.languages.createLanguageStatusItem('terraform-ls.status', [
   { language: 'terraform' },
   { language: 'terraform-vars' },
+  { language: 'terraform-stack' },
+  { language: 'terraform-deploy' },
 ]);
 lsStatus.name = 'Terraform LS';
 lsStatus.detail = 'Terraform LS';


### PR DESCRIPTION
This commit enables the language status bar for the `terraform-stack` and `terraform-deploy` languages.
