### PR TITLE
Bump syntax version to 0.7.1

### DIFF
--- a/.changes/unreleased/BUG FIXES-20240924-094740.yaml
+++ b/.changes/unreleased/BUG FIXES-20240924-094740.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: Fixes parsing expressions containing an open curly brace as blocks
+time: 2024-09-24T09:47:40.335136-04:00
+custom:
+    Issue: "149"
+    Repository: syntax

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "version": "0.35.0-beta2"
   },
   "syntax": {
-    "version": "0.7.0"
+    "version": "0.7.1"
   },
   "qna": "https://discuss.hashicorp.com/c/terraform-core/terraform-editor-integrations/46",
   "bugs": {


### PR DESCRIPTION
This commit updates the syntax version to 0.7.1, which fixes parsing expressions containing an open curly brace as blocks in https://github.com/hashicorp/syntax/pull/149
