### PR TITLE
Add `removed` block to Stack tests

### DIFF
--- a/.changes/unreleased/BUG FIXES-20241015-153342.yaml
+++ b/.changes/unreleased/BUG FIXES-20241015-153342.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: Add `removed` block to Stack tests
+time: 2024-10-15T15:33:42.052847+02:00
+custom:
+    Issue: "1861"
+    Repository: vscode-terraform

--- a/src/test/integration/stacks/stack.test.ts
+++ b/src/test/integration/stacks/stack.test.ts
@@ -31,6 +31,7 @@ suite('stacks stack', () => {
         new vscode.CompletionItem('locals', vscode.CompletionItemKind.Class),
         new vscode.CompletionItem('output', vscode.CompletionItemKind.Class),
         new vscode.CompletionItem('provider', vscode.CompletionItemKind.Class),
+        new vscode.CompletionItem('removed', vscode.CompletionItemKind.Class),
         new vscode.CompletionItem('required_providers', vscode.CompletionItemKind.Class),
         new vscode.CompletionItem('variable', vscode.CompletionItemKind.Class),
       ];


### PR DESCRIPTION
This PR fixes the test failure on `main`