### PR TITLE
Enable integration tests for Stacks feature

### DIFF
--- a/.changes/unreleased/INTERNAL-20241016-132945.yaml
+++ b/.changes/unreleased/INTERNAL-20241016-132945.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Enable integration tests for Stacks feature
+time: 2024-10-16T13:29:45.578502+02:00
+custom:
+    Issue: "1864"
+    Repository: vscode-terraform

--- a/src/test/integration/stacks/deployment.test.ts
+++ b/src/test/integration/stacks/deployment.test.ts
@@ -33,21 +33,36 @@ suite('stacks deployments', () => {
     test('completes inputs attribute in deployment block', async () => {
       // add a new incomplete "test" deployment block to use for completions
       await vscode.window.activeTextEditor?.edit((editBuilder) => {
-        editBuilder.insert(new vscode.Position(14, 0), 'deployment "test" {\n\n}\n');
+        editBuilder.insert(
+          new vscode.Position(14, 0),
+          `
+deployment "test" {
+
+}
+`,
+        );
       });
 
       const expected = [new vscode.CompletionItem('inputs', vscode.CompletionItemKind.Property)];
 
-      await testCompletion(docUri, new vscode.Position(15, 2), {
+      await testCompletion(docUri, new vscode.Position(16, 2), {
         items: expected,
       });
     });
 
-    // TODO: not implemented yet
-    test.skip('completes available inputs in deployment block', async () => {
+    test('completes available inputs in deployment block', async () => {
       // add a new incomplete "test" deployment block to use for completions
       await vscode.window.activeTextEditor?.edit((editBuilder) => {
-        editBuilder.insert(new vscode.Position(14, 0), 'deployment "test" {\ninputs = {\n\n}\n}\n');
+        editBuilder.insert(
+          new vscode.Position(14, 0),
+          `
+deployment "test" {
+  inputs = {
+
+  }
+}
+`,
+        );
       });
 
       const expected = [
@@ -62,8 +77,7 @@ suite('stacks deployments', () => {
       });
     });
 
-    // TODO: not implemented yet
-    test.skip('completes attributes of identity_token block', async () => {
+    test('completes attributes of identity_token block', async () => {
       // add a new incomplete deployment block to use for completions
       await vscode.window.activeTextEditor?.edit((editBuilder) => {
         editBuilder.insert(
@@ -78,7 +92,11 @@ deployment "test" {
         );
       });
 
-      const expected = [new vscode.CompletionItem('jwt_filename', vscode.CompletionItemKind.Property)];
+      const expected = [
+        new vscode.CompletionItem('identity_token.aws.audience', vscode.CompletionItemKind.Variable),
+        new vscode.CompletionItem('identity_token.aws.jwt', vscode.CompletionItemKind.Variable),
+        new vscode.CompletionItem('identity_token.aws.jwt_filename', vscode.CompletionItemKind.Variable),
+      ];
 
       await testCompletion(docUri, new vscode.Position(17, 45), {
         items: expected,
@@ -128,47 +146,37 @@ deployment "test" {
         });
       });
 
-      // TODO: not implemented yet
-      test.skip('completes context root level', async () => {
+      test('completes context', async () => {
+        const generateSubChanges = (label: string) => [
+          new vscode.CompletionItem(label, vscode.CompletionItemKind.Variable),
+          new vscode.CompletionItem(`${label}.add`, vscode.CompletionItemKind.Variable),
+          new vscode.CompletionItem(`${label}.change`, vscode.CompletionItemKind.Variable),
+          new vscode.CompletionItem(`${label}.defer`, vscode.CompletionItemKind.Variable),
+          new vscode.CompletionItem(`${label}.forget`, vscode.CompletionItemKind.Variable),
+          new vscode.CompletionItem(`${label}.import`, vscode.CompletionItemKind.Variable),
+          new vscode.CompletionItem(`${label}.move`, vscode.CompletionItemKind.Variable),
+          new vscode.CompletionItem(`${label}.remove`, vscode.CompletionItemKind.Variable),
+          new vscode.CompletionItem(`${label}.total`, vscode.CompletionItemKind.Variable),
+        ];
+
         const expected = [
-          new vscode.CompletionItem('errors', vscode.CompletionItemKind.Property),
-          new vscode.CompletionItem('operation', vscode.CompletionItemKind.Property),
-          new vscode.CompletionItem('plan', vscode.CompletionItemKind.Property),
-          new vscode.CompletionItem('warnings', vscode.CompletionItemKind.Property),
+          new vscode.CompletionItem('context.errors', vscode.CompletionItemKind.Variable),
+          new vscode.CompletionItem('context.operation', vscode.CompletionItemKind.Variable),
+          new vscode.CompletionItem('context.plan', vscode.CompletionItemKind.Variable),
+          new vscode.CompletionItem('context.plan.applyable', vscode.CompletionItemKind.Variable),
+          ...generateSubChanges('context.plan.changes'),
+          ...generateSubChanges('context.plan.component_changes["api_gateway"]'),
+          ...generateSubChanges('context.plan.component_changes["foo"]'),
+          ...generateSubChanges('context.plan.component_changes["lambda"]'),
+          ...generateSubChanges('context.plan.component_changes["s3"]'),
+          new vscode.CompletionItem('context.plan.deployment', vscode.CompletionItemKind.Variable),
+          new vscode.CompletionItem('context.plan.mode', vscode.CompletionItemKind.Variable),
+          new vscode.CompletionItem('context.plan.replans', vscode.CompletionItemKind.Variable),
+          new vscode.CompletionItem('context.success', vscode.CompletionItemKind.Variable),
+          new vscode.CompletionItem('context.warnings', vscode.CompletionItemKind.Variable),
         ];
 
         await testCompletion(docUri, new vscode.Position(17, 26), {
-          items: expected,
-        });
-      });
-
-      // TODO: not implemented yet
-      test.skip('completes context.plan level', async () => {
-        const expected = [
-          new vscode.CompletionItem('applyable', vscode.CompletionItemKind.Property),
-          new vscode.CompletionItem('changes', vscode.CompletionItemKind.Property),
-          new vscode.CompletionItem('component_changes', vscode.CompletionItemKind.Property),
-          new vscode.CompletionItem('deployment', vscode.CompletionItemKind.Property),
-          new vscode.CompletionItem('mode', vscode.CompletionItemKind.Property),
-          new vscode.CompletionItem('replans', vscode.CompletionItemKind.Property),
-        ];
-
-        await testCompletion(docUri, new vscode.Position(17, 31), {
-          items: expected,
-        });
-      });
-
-      // TODO: not implemented yet
-      test.skip('completes context.plan.component_changes item level', async () => {
-        const expected = [
-          new vscode.CompletionItem('add', vscode.CompletionItemKind.Property),
-          new vscode.CompletionItem('change', vscode.CompletionItemKind.Property),
-          new vscode.CompletionItem('import', vscode.CompletionItemKind.Property),
-          new vscode.CompletionItem('remove', vscode.CompletionItemKind.Property),
-          new vscode.CompletionItem('total', vscode.CompletionItemKind.Property),
-        ];
-
-        await testCompletion(docUri, new vscode.Position(17, 74), {
           items: expected,
         });
       });

--- a/src/test/integration/stacks/stack.test.ts
+++ b/src/test/integration/stacks/stack.test.ts
@@ -16,7 +16,7 @@ suite('stacks stack', () => {
       await activateExtension();
     });
 
-    teardown(async () => {
+    this.afterAll(async () => {
       await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 
@@ -50,8 +50,13 @@ suite('stacks stack', () => {
       await activateExtension();
     });
 
-    teardown(async () => {
+    this.afterAll(async () => {
       await vscode.commands.executeCommand('workbench.action.closeAllEditors');
+    });
+
+    this.afterEach(async () => {
+      // revert any changes made to the document after each test
+      await vscode.commands.executeCommand('workbench.action.files.revert');
     });
 
     test('language is registered', async () => {
@@ -60,17 +65,6 @@ suite('stacks stack', () => {
     });
 
     test('completes attributes of component block', async () => {
-      //       await vscode.window.activeTextEditor?.edit((editBuilder) => {
-      //         editBuilder.insert(
-      //           new vscode.Position(2, 0),
-      //           `
-      // component "test" {
-
-      // }
-      // `,
-      //         );
-      //       });
-
       const expected = [
         new vscode.CompletionItem('depends_on', vscode.CompletionItemKind.Property),
         new vscode.CompletionItem('for_each', vscode.CompletionItemKind.Property),
@@ -80,25 +74,23 @@ suite('stacks stack', () => {
         new vscode.CompletionItem('version', vscode.CompletionItemKind.Property),
       ];
 
-      // await testCompletion(docUri, new vscode.Position(4, 2), {
       await testCompletion(docUri, new vscode.Position(4, 12), {
         items: expected,
       });
     });
 
-    // TODO: not implemented yet
-    test.skip('completes inputs for local component', async () => {
+    test('completes inputs for local component', async () => {
       await vscode.window.activeTextEditor?.edit((editBuilder) => {
         editBuilder.insert(
           new vscode.Position(2, 0),
           `
-    component "test" {
-      source = "./lambda"
+component "test" {
+  source = "./lambda"
 
-      inputs = {
+  inputs = {
 
-      }
-    }
+  }
+}
     `,
         );
       });
@@ -110,8 +102,22 @@ suite('stacks stack', () => {
       });
     });
 
-    // TODO: not implemented yet
-    test.skip('completes references to provider blocks', async () => {
+    test('completes providers for local component', async () => {
+      await vscode.window.activeTextEditor?.edit((editBuilder) => {
+        editBuilder.insert(
+          new vscode.Position(2, 0),
+          `
+component "test" {
+  source = "./lambda"
+
+  providers = {
+
+  }
+}
+    `,
+        );
+      });
+
       const expected = [
         new vscode.CompletionItem('archive', vscode.CompletionItemKind.Property),
         new vscode.CompletionItem('aws', vscode.CompletionItemKind.Property),
@@ -119,16 +125,34 @@ suite('stacks stack', () => {
         new vscode.CompletionItem('random', vscode.CompletionItemKind.Property),
       ];
 
-      await testCompletion(docUri, new vscode.Position(11, 22), {
+      await testCompletion(docUri, new vscode.Position(7, 4), {
         items: expected,
       });
     });
 
-    // TODO implement this
-    test.skip('completes references to provider block names', async () => {
-      const expected = [new vscode.CompletionItem('this', vscode.CompletionItemKind.Property)];
+    test('completes references to providers', async () => {
+      await vscode.window.activeTextEditor?.edit((editBuilder) => {
+        editBuilder.insert(
+          new vscode.Position(2, 0),
+          `
+component "test" {
+  source = "./lambda"
 
-      await testCompletion(docUri, new vscode.Position(11, 26), {
+  providers = {
+    aws = provider.
+  }
+}
+    `,
+        );
+      });
+
+      const expected = [
+        new vscode.CompletionItem('provider.archive.this', vscode.CompletionItemKind.Variable),
+        new vscode.CompletionItem('provider.aws.this', vscode.CompletionItemKind.Variable),
+        new vscode.CompletionItem('provider.local.this', vscode.CompletionItemKind.Variable),
+        new vscode.CompletionItem('provider.random.this', vscode.CompletionItemKind.Variable),
+      ];
+      await testCompletion(docUri, new vscode.Position(7, 19), {
         items: expected,
       });
     });
@@ -142,7 +166,7 @@ suite('stacks stack', () => {
       await activateExtension();
     });
 
-    teardown(async () => {
+    this.afterAll(async () => {
       await vscode.commands.executeCommand('workbench.action.closeAllEditors');
     });
 


### PR DESCRIPTION
This PR enables / completes the skipped tests for `.tfstack.hcl` and `.tfdeploy.hcl` files