### PR TITLE
Remove webpack extension recommendation

### DIFF
--- a/.changes/unreleased/INTERNAL-20241115-115811.yaml
+++ b/.changes/unreleased/INTERNAL-20241115-115811.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Remove webpack extension recommendation
+time: 2024-11-15T11:58:11.543329-05:00
+custom:
+    Issue: "1880"
+    Repository: vscode-terraform

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,6 +1,5 @@
 {
   "recommendations": [
-    "amodio.tsl-problem-matcher",
     "connor4312.esbuild-problem-matchers",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode",


### PR DESCRIPTION
This extension is no longer needed as we are using esbuild for our build process.
