### PR TITLE
Add build files to .vscodeignore

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -6,6 +6,7 @@
 .gitattributes
 .github
 .gitignore
+META.d
 .npmrc
 .nvmrc
 .prettierignore
@@ -24,5 +25,6 @@ node_modules/
 ROADMAP.md
 src/
 out/
-esbuild.js
+esbuild.mjs
+eslint.config.mjs
 tsconfig.json


### PR DESCRIPTION
This commit adds build files to the .vscodeignore file to prevent them from being included in the extension.
