### PR TITLE
Fix dependabot npm version

### DIFF
--- a/.changes/unreleased/INTERNAL-20241204-105834.yaml
+++ b/.changes/unreleased/INTERNAL-20241204-105834.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Broaden npm version to allow dependabot to run
+time: 2024-12-04T10:58:34.365289-05:00
+custom:
+    Issue: "1888"
+    Repository: vscode-terraform

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "workspace"
   ],
   "engines": {
-    "npm": "~10.X",
+    "npm": "^9.6.5 || ~10.X",
     "node": "~20.X",
     "vscode": "^1.92.2"
   },


### PR DESCRIPTION
This broadens the range of npm versions that are allowed to be used with this project. This is to allow for the use of npm 9.6.5, which is the version that dependabot is currently using.

This fixes the following dependabot error:
updater | npm ERR! code EBADENGINE
updater | npm ERR! engine Unsupported engine
updater | npm ERR! engine Not compatible with your version of node/npm: terraform@2.34.0
updater | npm ERR! notsup Not compatible with your version of node/npm: terraform@2.34.0
updater | npm ERR! notsup Required: {"npm":"~10.X","node":"~20.X","vscode":"^1.92.2"}
updater | npm ERR! notsup Actual:   {"npm":"9.6.5","node":"v20.18.1"}
