### PR TITLE
(IPL-7500) Fix HCP workspace link

### DIFF
--- a/.changes/unreleased/BUG FIXES-20241204-121924.yaml
+++ b/.changes/unreleased/BUG FIXES-20241204-121924.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: Fix HCP workspace link
+time: 2024-12-04T12:19:24.122829-05:00
+custom:
+    Issue: "1889"
+    Repository: vscode-terraform

--- a/src/api/terraformCloud/index.ts
+++ b/src/api/terraformCloud/index.ts
@@ -23,6 +23,7 @@ export let TerraformCloudHost = 'app.terraform.io';
 
 export let TerraformCloudAPIUrl = `https://${TerraformCloudHost}/api/v2`;
 export let TerraformCloudWebUrl = `https://${TerraformCloudHost}/app`;
+export const TerraformCloudUrl = `https://${TerraformCloudHost}`;
 
 // eslint-disable-next-line @typescript-eslint/require-await
 const jsonHeader = pluginHeader('Content-Type', async () => 'application/vnd.api+json');

--- a/src/providers/tfc/workspaceProvider.ts
+++ b/src/providers/tfc/workspaceProvider.ts
@@ -7,7 +7,7 @@ import * as vscode from 'vscode';
 import TelemetryReporter from '@vscode/extension-telemetry';
 
 import { RunTreeDataProvider } from './runProvider';
-import { apiClient, TerraformCloudWebUrl } from '../../api/terraformCloud';
+import { apiClient, TerraformCloudUrl, TerraformCloudWebUrl } from '../../api/terraformCloud';
 import { TerraformCloudAuthenticationProvider } from './authenticationProvider';
 import { ProjectsAPIResource, ResetProjectItem } from './workspaceFilters';
 import { GetRunStatusIcon, GetRunStatusMessage, RelativeTimeFormat } from './helpers';
@@ -216,7 +216,7 @@ export class WorkspaceTreeDataProvider implements vscode.TreeDataProvider<vscode
         const lastestRun = workspaceResponse.included
           ? workspaceResponse.included.find((run) => run.id === lastRunId)
           : undefined;
-        const link = vscode.Uri.joinPath(vscode.Uri.parse(TerraformCloudWebUrl), workspace.links['self-html']);
+        const link = vscode.Uri.joinPath(vscode.Uri.parse(TerraformCloudUrl), workspace.links['self-html']);
 
         items.push(
           new WorkspaceTreeItem(


### PR DESCRIPTION
The `self-html` link for a workspace starts with `/app` so we need to use the base URL for Terraform Cloud to construct the full URL.
