### PR TITLE
(TFECO-8268) Enable code coverage reporting

### DIFF
--- a/.changes/unreleased/INTERNAL-20241205-163130.yaml
+++ b/.changes/unreleased/INTERNAL-20241205-163130.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Enable code coverage reporting
+time: 2024-12-05T16:31:30.723429-05:00
+custom:
+    Issue: "1901"
+    Repository: vscode-terraform

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -31,10 +31,12 @@ jobs:
           cache: npm
       - name: npm install
         run: npm ci
-      - name: lint
-        run: npm run lint
+      - name: check types
+        run: npm run check-types
       - name: format
         run: npm run check-format
+      - name: lint
+        run: npm run lint
 
   test:
     strategy:

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 .test-extensions
 *.vsix
 bin
+coverage
 node_modules
 npm-debug.log
 dist

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -18,6 +18,7 @@ const testSuiteFolderNames = fs
   .map((entry) => entry.name);
 
 const configs = testSuiteFolderNames.map((folderName) => ({
+  label: `Integration Tests - ${folderName}`,
   version: process.env['VSCODE_VERSION'] ?? 'stable',
   workspaceFolder: process.env['VSCODE_WORKSPACE_FOLDER'] ?? path.join(BASE_SRC_PATH, folderName, 'workspace'),
   launchArgs: ['--disable-extensions', '--disable-workspace-trust'],
@@ -30,6 +31,19 @@ const configs = testSuiteFolderNames.map((folderName) => ({
   },
 }));
 
-const config = defineConfig(configs);
+const config = defineConfig({
+  tests: configs,
+  coverage: {
+    exclude: ['src/test/**', '**/node_modules/**', '**/dist/**'],
+    thresholds: {
+      global: {
+        statements: 80,
+        branches: 80,
+        functions: 80,
+        lines: 80,
+      },
+    },
+  },
+});
 
 export default config;

--- a/.vscode-test.mjs
+++ b/.vscode-test.mjs
@@ -35,14 +35,6 @@ const config = defineConfig({
   tests: configs,
   coverage: {
     exclude: ['src/test/**', '**/node_modules/**', '**/dist/**'],
-    thresholds: {
-      global: {
-        statements: 80,
-        branches: 80,
-        functions: 80,
-        lines: 80,
-      },
-    },
   },
 });
 

--- a/package.json
+++ b/package.json
@@ -929,7 +929,7 @@
   },
   "scripts": {
     "prepare": "npm run download:artifacts",
-    "compile": "npm run check-types && npm run lint && node esbuild.mjs",
+    "compile": "node esbuild.mjs",
     "compile:prod": "npm run check-types && npm run lint && node esbuild.mjs --production",
     "compile:tests": "tsc -p .",
     "watch": "npm-run-all -p watch:esbuild watch:tsc",
@@ -945,7 +945,7 @@
     "download:artifacts": "node ./build/downloader.mjs",
     "vscode:prepublish": "npm run compile:prod",
     "package": "vsce package",
-    "pretest": "npm run compile:tests && npm run compile && npm run lint",
+    "pretest": "npm run compile:tests && npm run compile",
     "test": "vscode-test --coverage",
     "test:ui": "npm run compile:tests && node .vscode-uitest.mjs",
     "lint": "eslint",

--- a/package.json
+++ b/package.json
@@ -946,7 +946,7 @@
     "vscode:prepublish": "npm run compile:prod",
     "package": "vsce package",
     "pretest": "npm run compile:tests && npm run compile && npm run lint",
-    "test": "vscode-test",
+    "test": "vscode-test --coverage",
     "test:ui": "npm run compile:tests && node .vscode-uitest.mjs",
     "lint": "eslint",
     "format": "prettier --write .",


### PR DESCRIPTION
This enables code coverage reporting for the integration test suites. It uses the `vscode-test` extension's built-in code coverage reporting feature to generate coverage reports for the test suites.

Previously if you were to run `npm run compile` or `npm test`, you would be executing `npm run check-types`, then `npm run lint`, and finally `node esbuild.mjs` or `vscode-test`, respectively, every time you wanted to compile or test the code. This duplication added several seconds to the build or test time. This was unecessary when running interactively, and even more so in CI where these steps were repeated multiple times.

This also reduces the number of duplicate steps in CI by running type checking, linting, and formatting only once before compiling or running tests. It also results in a faster run time interactively because we aren't running the more intensive type checking every time.

This becomes more important as we added UI testing to the CI pipeline, which is a more intensive process than the other steps.