### PR TITLE
Fix tests on ubuntu

### DIFF
--- a/.changes/unreleased/INTERNAL-20241209-123718.yaml
+++ b/.changes/unreleased/INTERNAL-20241209-123718.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Adapt CI config for Ubuntu 24.04.1
+time: 2024-12-09T12:37:18.241839+01:00
+custom:
+    Issue: "1907"
+    Repository: vscode-terraform

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -68,6 +68,9 @@ jobs:
         run: terraform version
       - name: Clean Install Dependencies
         run: npm ci
+      - name: Allow unprivileged user namespace (ubuntu)
+        if: runner.os == 'Linux'
+        run: sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
       - name: Run Tests
         run: xvfb-run -a npm test
         if: runner.os == 'Linux'


### PR DESCRIPTION
This PR updates the CI configuration for Ubuntu 24.04.1. GitHub has recently updated the latest ubuntu runners from 22.04.5 to 24.04.1.

This new command is required to successfully run our extension UI tests.