### PR TITLE
Configure dependabot to update package.json and group dependency updates

### DIFF
--- a/.changes/unreleased/INTERNAL-20241209-100936.yaml
+++ b/.changes/unreleased/INTERNAL-20241209-100936.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Configure dependabot to update package.json and group dependency updates
+time: 2024-12-09T10:09:36.876848-05:00
+custom:
+    Issue: "1908"
+    Repository: vscode-terraform

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
   - package-ecosystem: 'npm'
-    versioning-strategy: lockfile-only
+    versioning-strategy: increase-if-necessary
     directory: '/'
     schedule:
       interval: 'daily'

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
     schedule:
       interval: 'daily'
     labels: ['dependencies']
+    groups:
+      development-dependencies:
+        dependency-type: "development"
     ignore:
       - dependency-name: '@types/*'
         update-types: ['version-update:semver-minor', 'version-update:semver-patch']

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
     labels: ['dependencies']
     groups:
       development-dependencies:
-        dependency-type: "development"
+        dependency-type: 'development'
     ignore:
       - dependency-name: '@types/*'
         update-types: ['version-update:semver-minor', 'version-update:semver-patch']


### PR DESCRIPTION
This bumps the versioning strategy to increase-if-necessary to allow for minor and patch updates to be automatically applied by Dependabot inside the package.json file. Our semantic version constraints are still respected with increase-if-necessary, but allows us to keep pace with libraries. See https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#versioning-strategy for more information.

This does introduce the possibility of breaking changes, as increase-if-necessary will update a major version. However since all PRs require a review, we can catch these breaking changes before they become a problem. We can monitor this and adjust the strategy if necessary.

Previously the versioning strategy was set to lockfile-only which only allowed for the exact version specified in the package-lock.json file to be updated. This was introduced in #721 with the intention of monitoring what was updated and then deciding if we would change the strategy.

This also adds groups to the dependabot configuration file for development dependencies.

There are many reasons to group dependencies, but the reason focused on here is optimizing for PR review. Instead of a single PR per dependency, a single PR with all the updates for a group is created. This is especially useful for development dependencies, which are often updated frequently and in small increments. This can lead to a large number of PRs being created. By grouping these dependencies, the rebase-review-merge-repeat cycle is reduced.

This commit introduces only groups for development dependancies in order to keep things simple. Likely we won't group production, but we can further refine the groups as needed.