### PR TITLE
Fix flaky test by increasing sleep time

### DIFF
--- a/.changes/unreleased/INTERNAL-20241216-104206.yaml
+++ b/.changes/unreleased/INTERNAL-20241216-104206.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Fix flaky ui tests by increasing sleep time
+time: 2024-12-16T10:42:06.856418-05:00
+custom:
+    Issue: "1925"
+    Repository: vscode-terraform

--- a/src/test/e2e/specs/views/hcp.e2e.ts
+++ b/src/test/e2e/specs/views/hcp.e2e.ts
@@ -108,7 +108,7 @@ describe('HCP tree view tests', () => {
     expect(await runTree?.isDisplayed()).is.true;
 
     // wait for the run to load otherwise the test will fail
-    await VSBrowser.instance.driver.sleep(100);
+    await VSBrowser.instance.driver.sleep(500);
 
     const runItem = await runTree.findItem('Run 1');
     expect(runItem).not.undefined;


### PR DESCRIPTION
This test was failing on macOS because the sleep time was too short. Increasing it to 500ms should be enough to make the test pass.
