### PR TITLE
Stage 2.34.2025012311

### DIFF
--- a/.changes/v2.34.3.md
+++ b/.changes/v2.34.3.md
@@ -1,6 +1,13 @@
+## 2.34.2025012311 (2025-01-23)
+
+NOTES:
+
+This is a release to bring the prerelease channel to parity with stable.
+
 ## 2.34.3 (2025-01-22)
 
 ENHANCEMENTS:
 
 * Report usage of write-only attributes for public providers ([terraform-ls#1926](https://github.com/hashicorp/terraform-ls/issues/1926))
+* Support ephemeral write only attributes ([hcl-lang#440](https://github.com/hashicorp/hcl-lang/pull/440))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,17 @@
 # Changelog
 
+## 2.34.2025012311 (2025-01-23)
+
+NOTES:
+
+This is a release to bring the prerelease channel to parity with stable.
+
 ## 2.34.3 (2025-01-22)
 
 ENHANCEMENTS:
 
 * Report usage of write-only attributes for public providers ([terraform-ls#1926](https://github.com/hashicorp/terraform-ls/issues/1926))
+* Support ephemeral write only attributes ([hcl-lang#440](https://github.com/hashicorp/hcl-lang/pull/440))
 
 ## 2.34.2 (2024-12-19)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "terraform",
-  "version": "2.34.3",
+  "version": "2.34.2025012311",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "terraform",
-      "version": "2.34.3",
+      "version": "2.34.2025012311",
       "license": "MPL-2.0",
       "dependencies": {
         "@vscode/extension-telemetry": "^0.9.8",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "name": "terraform",
   "displayName": "HashiCorp Terraform",
   "description": "Syntax highlighting and autocompletion for Terraform",
-  "version": "2.34.3",
+  "version": "2.34.2025012311",
   "publisher": "hashicorp",
   "appInsightsKey": "InstrumentationKey=885372d2-6f3c-499f-9d25-b8b219983a52;IngestionEndpoint=https://westus2-1.in.applicationinsights.azure.com/;LiveEndpoint=https://westus2.livediagnostics.monitor.azure.com/;ApplicationId=6734158a-8ab9-4aec-9b5a-af151d14a754",
   "license": "MPL-2.0",


### PR DESCRIPTION
This brings the prerelease channel to parity with stable.

It also updates the changelog with a missing entry for 2.34.3.
