### PR TITLE
fix: linting errors related to nullish coalescing

### DIFF
--- a/.changes/unreleased/BUG FIXES-20250519-122303.yaml
+++ b/.changes/unreleased/BUG FIXES-20250519-122303.yaml
@@ -1,0 +1,6 @@
+kind: BUG FIXES
+body: Fix for es lint error - nullish coalescing operator
+time: 2025-05-19T12:23:03.527053+05:30
+custom:
+    Issue: "2011"
+    Repository: vscode-terraform

--- a/src/commands/generateBugReport.ts
+++ b/src/commands/generateBugReport.ts
@@ -43,8 +43,7 @@ export class GenerateBugReportCommand implements vscode.Disposable {
   }
 
   generateBody(extensions: VSCodeExtension[], problemText?: string): string {
-    if (!problemText) {
-      problemText = `Steps To Reproduce
+    problemText ??= `Steps To Reproduce
 =====
 
 Steps to reproduce the behavior:
@@ -85,7 +84,7 @@ Note whether you use any tools for managing Terraform version/execution (e.g. 't
 any credentials helpers, or whether you have any other Terraform extensions installed.
 -->
 `;
-    }
+
     const body = `Issue Description
 =====
 
@@ -163,11 +162,7 @@ Outdated:\t${info.outdated}
         return 0;
       })
       .map((ext) => {
-        return {
-          name: ext.packageJSON.name,
-          publisher: ext.packageJSON.publisher,
-          version: ext.packageJSON.version,
-        };
+        return { name: ext.packageJSON.name, publisher: ext.packageJSON.publisher, version: ext.packageJSON.version };
       });
     return extensions;
   }
@@ -183,11 +178,7 @@ Outdated:\t${info.outdated}
         const response = resultJson.stdout.toString();
         const j = JSON.parse(response);
 
-        return {
-          version: j.terraform_version,
-          platform: j.platform,
-          outdated: j.terraform_outdated,
-        };
+        return { version: j.terraform_version, platform: j.platform, outdated: j.terraform_outdated };
       } catch {
         // fall through
       }
@@ -204,20 +195,12 @@ Outdated:\t${info.outdated}
         const version = matches && matches.length > 1 ? matches[1] : 'Not found';
         const platform = response.split('\n')[1].replace('on ', '');
 
-        return {
-          version: version,
-          platform: platform,
-          outdated: true,
-        };
+        return { version: version, platform: platform, outdated: true };
       } catch {
         // fall through
       }
     }
 
-    return {
-      version: 'Not found',
-      platform: 'Not found',
-      outdated: false,
-    };
+    return { version: 'Not found', platform: 'Not found', outdated: false };
   }
 }

--- a/src/features/languageStatus.ts
+++ b/src/features/languageStatus.ts
@@ -21,15 +21,11 @@ export class LanguageStatusFeature implements StaticFeature {
   clear(): void {}
 
   getState(): FeatureState {
-    return {
-      kind: 'static',
-    };
+    return { kind: 'static' };
   }
 
   public fillClientCapabilities(capabilities: ClientCapabilities & ExperimentalClientCapabilities): void {
-    if (!capabilities.experimental) {
-      capabilities.experimental = {};
-    }
+    capabilities.experimental ??= {};
   }
 
   public initialize(): void {

--- a/src/features/moduleCalls.ts
+++ b/src/features/moduleCalls.ts
@@ -27,15 +27,11 @@ export class ModuleCallsFeature implements StaticFeature {
   clear(): void {}
 
   getState(): FeatureState {
-    return {
-      kind: 'static',
-    };
+    return { kind: 'static' };
   }
 
   public fillClientCapabilities(capabilities: ClientCapabilities & ExperimentalClientCapabilities): void {
-    if (!capabilities.experimental) {
-      capabilities.experimental = {};
-    }
+    capabilities.experimental ??= {};
     capabilities.experimental.refreshModuleCallsCommandId = CLIENT_MODULE_CALLS_CMD_ID;
   }
 

--- a/src/features/moduleProviders.ts
+++ b/src/features/moduleProviders.ts
@@ -27,15 +27,11 @@ export class ModuleProvidersFeature implements StaticFeature {
   clear(): void {}
 
   getState(): FeatureState {
-    return {
-      kind: 'static',
-    };
+    return { kind: 'static' };
   }
 
   public fillClientCapabilities(capabilities: ClientCapabilities & ExperimentalClientCapabilities): void {
-    if (!capabilities.experimental) {
-      capabilities.experimental = {};
-    }
+    capabilities.experimental ??= {};
     capabilities.experimental.refreshModuleProvidersCommandId = CLIENT_MODULE_PROVIDERS_CMD_ID;
   }
 

--- a/src/features/showReferences.ts
+++ b/src/features/showReferences.ts
@@ -39,18 +39,15 @@ export class ShowReferencesFeature implements StaticFeature {
   clear(): void {}
 
   getState(): FeatureState {
-    return {
-      kind: 'static',
-    };
+    return { kind: 'static' };
   }
 
   public fillClientCapabilities(capabilities: ClientCapabilities & ExperimentalClientCapabilities): void {
     if (!this.isEnabled) {
       return;
     }
-    if (!capabilities.experimental) {
-      capabilities.experimental = {};
-    }
+
+    capabilities.experimental ??= {};
     capabilities.experimental.showReferencesCommandId = CLIENT_CMD_ID;
   }
 

--- a/src/features/telemetry.ts
+++ b/src/features/telemetry.ts
@@ -3,8 +3,8 @@
  * SPDX-License-Identifier: MPL-2.0
  */
 
-import * as vscode from 'vscode';
 import TelemetryReporter from '@vscode/extension-telemetry';
+import * as vscode from 'vscode';
 import { BaseLanguageClient, ClientCapabilities, FeatureState, StaticFeature } from 'vscode-languageclient';
 
 import { ExperimentalClientCapabilities } from './types';
@@ -28,15 +28,11 @@ export class TelemetryFeature implements StaticFeature {
   clear(): void {}
 
   getState(): FeatureState {
-    return {
-      kind: 'static',
-    };
+    return { kind: 'static' };
   }
 
   public fillClientCapabilities(capabilities: ClientCapabilities & ExperimentalClientCapabilities): void {
-    if (!capabilities.experimental) {
-      capabilities.experimental = {};
-    }
+    capabilities.experimental ??= {};
     capabilities.experimental.telemetryVersion = TELEMETRY_VERSION;
   }
 

--- a/src/features/terraformVersion.ts
+++ b/src/features/terraformVersion.ts
@@ -29,13 +29,11 @@ export class TerraformVersionFeature implements StaticFeature {
   clear(): void {}
 
   getState(): FeatureState {
-    return {
-      kind: 'static',
-    };
+    return { kind: 'static' };
   }
 
   public fillClientCapabilities(capabilities: ClientCapabilities & ExperimentalClientCapabilities): void {
-    capabilities.experimental = capabilities.experimental || {};
+    capabilities.experimental ??= {};
     capabilities.experimental.refreshTerraformVersionCommandId = this.clientTerraformVersionCommandId;
   }
 

--- a/src/providers/terraform/moduleCalls.ts
+++ b/src/providers/terraform/moduleCalls.ts
@@ -26,7 +26,7 @@ class ModuleCallItem extends vscode.TreeItem {
       children.length >= 1 ? vscode.TreeItemCollapsibleState.Collapsed : vscode.TreeItemCollapsibleState.None,
     );
 
-    this.description = this.version ? this.version : '';
+    this.description = this.version ?? '';
 
     if (this.version === undefined) {
       this.tooltip = this.sourceAddr;
@@ -42,10 +42,7 @@ class ModuleCallItem extends vscode.TreeItem {
   getIcon(type: string | undefined) {
     switch (type) {
       case 'tfregistry':
-        return {
-          light: this.terraformIcon,
-          dark: this.terraformIcon,
-        };
+        return { light: this.terraformIcon, dark: this.terraformIcon };
       case 'local':
         return new vscode.ThemeIcon('symbol-folder');
       case 'github':

--- a/src/providers/tfc/applyProvider.ts
+++ b/src/providers/tfc/applyProvider.ts
@@ -88,14 +88,8 @@ export class ApplyTreeDataProvider implements vscode.TreeDataProvider<vscode.Tre
     }
 
     try {
-      const result = await axios.get(apply.logReadUrl, {
-        headers: { Accept: 'text/plain' },
-        responseType: 'stream',
-      });
-      const lineStream = readline.createInterface({
-        input: result.data,
-        output: new Writable(),
-      });
+      const result = await axios.get(apply.logReadUrl, { headers: { Accept: 'text/plain' }, responseType: 'stream' });
+      const lineStream = readline.createInterface({ input: result.data, output: new Writable() });
 
       const applyLog: ApplyLog = {};
 
@@ -104,9 +98,7 @@ export class ApplyTreeDataProvider implements vscode.TreeDataProvider<vscode.Tre
           const logLine: LogLine = JSON.parse(line);
 
           if (logLine.type === 'apply_complete' && logLine.hook) {
-            if (!applyLog.appliedChanges) {
-              applyLog.appliedChanges = [];
-            }
+            applyLog.appliedChanges ??= [];
             applyLog.appliedChanges.push(logLine.hook);
             continue;
           }
@@ -119,15 +111,9 @@ export class ApplyTreeDataProvider implements vscode.TreeDataProvider<vscode.Tre
             continue;
           }
           if (logLine.type === 'diagnostic' && logLine.diagnostic) {
-            if (!applyLog.diagnostics) {
-              applyLog.diagnostics = [];
-            }
-            if (!applyLog.diagnosticSummary) {
-              applyLog.diagnosticSummary = {
-                errorCount: 0,
-                warningCount: 0,
-              };
-            }
+            applyLog.diagnostics ??= [];
+            applyLog.diagnosticSummary ??= { errorCount: 0, warningCount: 0 };
+
             applyLog.diagnostics.push(logLine.diagnostic);
             if (logLine.diagnostic.severity === 'warning') {
               applyLog.diagnosticSummary.warningCount += 1;
@@ -164,10 +150,7 @@ export class ApplyTreeDataProvider implements vscode.TreeDataProvider<vscode.Tre
       if (error instanceof Error) {
         message += error.message;
         vscode.window.showErrorMessage(message);
-        this.reporter.sendTelemetryErrorEvent('applyLogError', {
-          message: message,
-          stack: error.stack,
-        });
+        this.reporter.sendTelemetryErrorEvent('applyLogError', { message: message, stack: error.stack });
         return;
       }
 

--- a/src/providers/tfc/planProvider.ts
+++ b/src/providers/tfc/planProvider.ts
@@ -91,14 +91,8 @@ export class PlanTreeDataProvider implements vscode.TreeDataProvider<vscode.Tree
     }
 
     try {
-      const result = await axios.get(plan.logReadUrl, {
-        headers: { Accept: 'text/plain' },
-        responseType: 'stream',
-      });
-      const lineStream = readline.createInterface({
-        input: result.data,
-        output: new Writable(),
-      });
+      const result = await axios.get(plan.logReadUrl, { headers: { Accept: 'text/plain' }, responseType: 'stream' });
+      const lineStream = readline.createInterface({ input: result.data, output: new Writable() });
 
       const planLog: PlanLog = {};
 
@@ -107,22 +101,14 @@ export class PlanTreeDataProvider implements vscode.TreeDataProvider<vscode.Tree
           const logLine: LogLine = JSON.parse(line);
 
           if (logLine.type === 'planned_change' && logLine.change) {
-            if (!planLog.plannedChanges) {
-              planLog.plannedChanges = [];
-            }
+            planLog.plannedChanges ??= [];
             planLog.plannedChanges.push(logLine.change);
             continue;
           }
           if (logLine.type === 'resource_drift' && logLine.change) {
-            if (!planLog.driftChanges) {
-              planLog.driftChanges = [];
-            }
-            if (!planLog.driftSummary) {
-              planLog.driftSummary = {
-                changed: 0,
-                deleted: 0,
-              };
-            }
+            planLog.driftChanges ??= [];
+            planLog.driftSummary ??= { changed: 0, deleted: 0 };
+
             planLog.driftChanges.push(logLine.change);
             if (logLine.change.action === 'update') {
               planLog.driftSummary.changed += 1;
@@ -141,15 +127,8 @@ export class PlanTreeDataProvider implements vscode.TreeDataProvider<vscode.Tree
             continue;
           }
           if (logLine.type === 'diagnostic' && logLine.diagnostic) {
-            if (!planLog.diagnostics) {
-              planLog.diagnostics = [];
-            }
-            if (!planLog.diagnosticSummary) {
-              planLog.diagnosticSummary = {
-                errorCount: 0,
-                warningCount: 0,
-              };
-            }
+            planLog.diagnostics ??= [];
+            planLog.diagnosticSummary ??= { errorCount: 0, warningCount: 0 };
             planLog.diagnostics.push(logLine.diagnostic);
             if (logLine.diagnostic.severity === 'warning') {
               planLog.diagnosticSummary.warningCount += 1;
@@ -186,10 +165,7 @@ export class PlanTreeDataProvider implements vscode.TreeDataProvider<vscode.Tree
       if (error instanceof Error) {
         message += error.message;
         vscode.window.showErrorMessage(message);
-        this.reporter.sendTelemetryErrorEvent('planLogError', {
-          message: message,
-          stack: error.stack,
-        });
+        this.reporter.sendTelemetryErrorEvent('planLogError', { message: message, stack: error.stack });
         return;
       }
 


### PR DESCRIPTION
1.  Fixing below linting error which:
Prefer using nullish coalescing operator (`??=`) instead of an assignment expression, as it is simpler to read  @typescript-eslint/prefer-nullish-coalescing
Documentation - https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/Nullish_coalescing_assignment
2. Some code snippets were automatically formatted on file save (using prettier extension)