### PR TITLE
chore: remove dependabot dev group and set open PR limit to 10

### DIFF
--- a/.changes/unreleased/INTERNAL-20260325-145655.yaml
+++ b/.changes/unreleased/INTERNAL-20260325-145655.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: 'chore: remove dependabot dev group and set open PR limit to 10'
+time: 2026-03-25T14:56:55.443251+05:30
+custom:
+    Issue: "2216"
+    Repository: vscode-terraform

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,12 +3,10 @@ updates:
   - package-ecosystem: 'npm'
     versioning-strategy: increase-if-necessary
     directory: '/'
+    open-pull-requests-limit: 10
     schedule:
       interval: 'daily'
     labels: ['dependencies']
-    groups:
-      development-dependencies:
-        dependency-type: 'development'
     ignore:
       - dependency-name: '@types/*'
         update-types: ['version-update:semver-minor', 'version-update:semver-patch']


### PR DESCRIPTION
This PR updates Dependabot configuration to make failing dependency updates easier to isolate and to increase update throughput.

https://github.com/hashicorp/vscode-terraform/pull/2181 is currently failing builds.
Because development dependencies were grouped together, it is not possible to confidently identify which specific package update is causing the failure.

- Removed the npm development dependency grouping block: groups -> development-dependencies -> dependency-type: development
- Increased Dependabot open PR limit from the default 5 to 10 for npm updates.


## PCI review checklist
<!-- heimdall_github_prtemplate:grc-pci_dss-2024-01-05 -->
- [ ] I have documented a clear reason for, and description of, the change I am making.
- [ ] If applicable, I've documented a plan to revert these changes if they require more than reverting the pull request.
- [ ] If applicable, I've documented the impact of any changes to security controls.
  Examples of changes to security controls include using new access control methods, adding or removing logging pipelines, etc.
