### PR TITLE
ci: declare permissions on check-changelog and test

### DIFF
--- a/.github/workflows/check-changelog.yml
+++ b/.github/workflows/check-changelog.yml
@@ -10,6 +10,11 @@ on:
 
 name: Check if changelog entry exists
 
+# dorny/paths-filter only reads PR file metadata via the GitHub API.
+permissions:
+  contents: read
+  pull-requests: read
+
 jobs:
   changelog_existence:
     name: Check if changelog entry exists

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,6 +18,9 @@ on:
       - 'tests/**'
       - '**.md'
 
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Declares an explicit `permissions:` block on the two CI workflows still relying on the default `GITHUB_TOKEN` scope:

- **check-changelog.yml** — `contents: read` + `pull-requests: read`. Uses `dorny/paths-filter` (reads PR file list) and `actions/github-script` to fail the run if no changelog entry was added. No writes.
- **test.yml** — `contents: read`. Read-only lint/format/types/tests on PR + push to main/pre-release.

YAML validated locally.