### PR TITLE
test: fix flaky HCP workspace tooltip assertion

### DIFF
--- a/.changes/unreleased/INTERNAL-20260630-094303.yaml
+++ b/.changes/unreleased/INTERNAL-20260630-094303.yaml
@@ -1,0 +1,6 @@
+kind: INTERNAL
+body: Fix flaky HCP workspace tooltip e2e assertion broken in newer VS Code Insiders
+time: 2026-06-30T09:43:03.180579+05:30
+custom:
+    Issue: "2285"
+    Repository: vscode-terraform

--- a/src/test/e2e/specs/views/hcp.e2e.ts
+++ b/src/test/e2e/specs/views/hcp.e2e.ts
@@ -105,7 +105,7 @@ describe('HCP tree view tests', () => {
 
     expect(await item?.getLabel()).equals('Workspace 1');
     expect(await item?.getDescription()).equals('[Project 1]');
-    expect(await item?.getTooltip()).equals('Workspace 1 [Project 1]');
+    expect(await item?.getTooltip()).contains('Workspace 1 [Project 1]');
   });
 
   it('should show a run when a workspace is clicked', async () => {


### PR DESCRIPTION
## Description

The `should have workspaces` e2e test in `hcp.e2e.ts` fails on newer VS Code Insiders builds:

```
AssertionError: expected 'Workspace 1 [Project 1], has actions' to equal 'Workspace 1 [Project 1]'
```
## Change

Switch the assertion from `equals` to `contains` so it tolerates the appended actions text.