### PR TITLE
Add planned_and_saved run status for saved plan runs

### DIFF
--- a/.changes/unreleased/ENHANCEMENTS-20260630-110224.yaml
+++ b/.changes/unreleased/ENHANCEMENTS-20260630-110224.yaml
@@ -1,0 +1,6 @@
+kind: ENHANCEMENTS
+body: Add support for the planned_and_saved run status for saved plan runs in the HCP Terraform view
+time: 2026-06-30T11:02:24.492094+05:30
+custom:
+    Issue: "2286"
+    Repository: vscode-terraform

--- a/src/api/terraformCloud/run.ts
+++ b/src/api/terraformCloud/run.ts
@@ -29,6 +29,7 @@ const runStatus = z.enum([
   'post_plan_running',
   'post_plan_completed',
   'planned_and_finished',
+  'planned_and_saved',
   'apply_queued',
   'applying',
   'applied',

--- a/src/providers/tfc/helpers.ts
+++ b/src/providers/tfc/helpers.ts
@@ -72,6 +72,8 @@ export function GetRunStatusIcon(status?: string): vscode.ThemeIcon {
       return new vscode.ThemeIcon('pass', new vscode.ThemeColor('charts.green'));
     case 'planned_and_finished':
       return new vscode.ThemeIcon('pass-filled', new vscode.ThemeColor('charts.green'));
+    case 'planned_and_saved':
+      return new vscode.ThemeIcon('warning', new vscode.ThemeColor('charts.yellow'));
     case 'policy_soft_failed':
       return new vscode.ThemeIcon('warning', new vscode.ThemeColor('charts.yellow'));
     case 'applied':
@@ -132,6 +134,8 @@ export function GetRunStatusMessage(status?: string): string {
       return 'Tasks - post-plan (passed)';
     case 'planned_and_finished':
       return 'Planned and finished';
+    case 'planned_and_saved':
+      return 'Planned and saved';
     case 'policy_soft_failed':
       return 'Policy Soft Failure';
     case 'applied':


### PR DESCRIPTION
## Description

Adds the missing `planned_and_saved` run state to the HCP Terraform run status handling. This state is used for saved plan runs and was missing from our enum and status helpers.

Reference: [HCP Terraform Runs API – Run States](https://developer.hashicorp.com/terraform/cloud-docs/api-docs/run#run-states)

## Changes

- Added `planned_and_saved` to the `runStatus` enum in `src/api/terraformCloud/run.ts`
- Added `planned_and_saved` case to `GetRunStatusIcon` (warning / yellow, consistent with `planned`)
- Added `planned_and_saved` case to `GetRunStatusMessage` ("Planned and saved")
